### PR TITLE
Do not disconnect when no apps are present

### DIFF
--- a/lib/remote-debugger-rpc-client.js
+++ b/lib/remote-debugger-rpc-client.js
@@ -70,9 +70,15 @@ export default class RemoteDebuggerRpcClient {
   }
 
   async disconnect () {
-    log.debug('Disconnecting from remote debugger');
+    if (this.isConnected()) {
+      log.debug('Disconnecting from remote debugger');
+      this.socket.destroy();
+    }
     this.connected = false;
-    this.socket.destroy();
+  }
+
+  isConnected () {
+    return this.connected;
   }
 
   setSpecialMessageHandler (key, errorHandler, handler) {

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -30,7 +30,7 @@ class RemoteDebugger extends events.EventEmitter {
    *   - host - the remote debugger's host address
    *   - port - the remote debugger port through which to communicate
    */
-  constructor (opts) {
+  constructor (opts = {}) {
     super();
 
     let {bundleId, platformVersion, debuggerType, useNewSafari, pageLoadMs,
@@ -86,6 +86,10 @@ class RemoteDebugger extends events.EventEmitter {
     this.emit(RemoteDebugger.EVENT_DISCONNECT, true);
   }
 
+  isConnected () {
+    return !!(this.rpcClient && this.rpcClient.isConnected());
+  }
+
   async setConnectionKey () {
     // only resolve when the connection response is received
     return await new Promise(async (resolve, reject) => {
@@ -96,7 +100,7 @@ class RemoteDebugger extends events.EventEmitter {
         if (_.isUndefined(apps) || _.keys(apps).length === 0) {
           let msg = 'Received no apps from remote debugger. Unable to connect.';
           log.debug(msg);
-          return reject(new Error(msg));
+          return resolve(this.appDict);
         }
         let newDict = {};
         log.debug(`Received application dictionary: ${JSON.stringify(apps)}`);
@@ -131,6 +135,11 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   async selectApp (maxTries = SELECT_APP_RETRIES) {
+    if (!this.appDict || _.keys(this.appDict).length === 0) {
+      log.debug('No applications currently connected.');
+      return [];
+    }
+
     // iterative solution, as recursion was swallowing the promise at some point
     this.appIdKey = getDebuggerAppKey(this.bundleId, this.platformVersion, this.appDict);
     let pageDict;

--- a/lib/webkit-remote-debugger.js
+++ b/lib/webkit-remote-debugger.js
@@ -10,7 +10,7 @@ import request from 'request-promise';
 
 
 export default class WebKitRemoteDebugger extends RemoteDebugger {
-  constructor (opts) {
+  constructor (opts = {}) {
     super(_.defaults({debuggerType: DEBUGGER_TYPES.webkit}, opts));
 
     // used to store callback types when sending requests


### PR DESCRIPTION
Rather than erroring when there are no apps present, just keep going. Otherwise reconnecting too soon causes the remote debugger on the device to freak out and stop responding. The client will disconnect when the client feels like it.

@scottdixon This, in addition to some changes once this lands, fixes the getting context multiple times issue.