### PR TITLE
Keep track of updated remote debugger app

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -142,9 +142,8 @@ class RemoteDebugger extends events.EventEmitter {
 
     // iterative solution, as recursion was swallowing the promise at some point
     this.appIdKey = getDebuggerAppKey(this.bundleId, this.platformVersion, this.appDict);
-    let pageDict;
+    let pageDict, appIdKey;
     for (let i = 0; i < maxTries; i++) {
-      let appIdKey;
       try {
         log.debug(`Selecting app ${this.appIdKey} (try #${i+1} of ${maxTries})`);
         [appIdKey, pageDict] = await this.rpcClient.selectApp(this.appIdKey, this.onAppConnect.bind(this));
@@ -161,6 +160,11 @@ class RemoteDebugger extends events.EventEmitter {
       let msg = `Could not connect to a valid app after ${maxTries} tries.`;
       log.error(msg);
       throw new Error(msg);
+    }
+
+    if (this.appIdKey !== appIdKey) {
+      log.debug(`Received altered app id, updating from '${this.appIdKey}' to '${appIdKey}'`);
+      this.appIdKey = appIdKey;
     }
 
     // set the callback for getting a listing to the page change callback

--- a/test/unit/remote-debugger-specs.js
+++ b/test/unit/remote-debugger-specs.js
@@ -114,7 +114,7 @@ describe('RemoteDebugger', () => {
 
       let spy = sinon.spy(rd.rpcClient, 'selectApp');
       await rd.selectApp();
-      rd.appIdKey.should.equal('PID:44');
+      rd.appIdKey.should.equal('PID:42');
       spy.calledOnce.should.be.true;
     });
     it('should be able to handle an app change event during selection', async () => {


### PR DESCRIPTION
We have had some issues with iOS 9+ and webviews connecting then hanging. Fix this by remembering the actually connected app.

Original PR: appium/appium#5800