### PR TITLE
Reset page dictionary if url is wrong

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -169,6 +169,7 @@ class RemoteDebugger extends events.EventEmitter {
           if (!found) {
             log.debug(`Received app, but expected url ('${currentUrl}') was not found. Trying again.`);
             this.appIdKey = appIdKey;
+            pageDict = null;
             continue;
           }
         }
@@ -259,7 +260,7 @@ class RemoteDebugger extends events.EventEmitter {
       this.pageLoadDelay = util.cancellableDelay(timeoutMs);
       try {
         await this.pageLoadDelay;
-      } catch(err) {
+      } catch (err) {
         if (err instanceof Promise.CancellationError) {
           // if the promise has been cancelled
           // we want to skip checking the readiness


### PR DESCRIPTION
Rather than letting it fall through and act like a page was actually selected if all the retries are used up. This way we throw the proper error.