### PR TITLE
Fix handling of application disconnects

### DIFF
--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -27,13 +27,17 @@ function onAppConnect (dict) {
 
 function onAppDisconnect (dict) {
   let appIdKey = dict.WIRApplicationIdentifierKey;
-  log.debug(`Application ${appIdKey} disconnected. Removing from app dictionary and attempting to find app key.`);
+  log.debug(`Application ${appIdKey} disconnected. Removing from app dictionary.`);
 
   // get rid of the entry in our app dictionary,
   // since it is no longer available
   delete this.appDict[appIdKey];
 
-  this.appIdKey = getDebuggerAppKey(this.bundleId, this.platformVersion, this.appDict);
+  // if the disconnected app is the one we are connected to, try to find another
+  if (this.appIdKey === appIdKey) {
+    log.debug(`No longer have app id. Attempting to find new one.`);
+    this.appIdKey = getDebuggerAppKey(this.bundleId, this.platformVersion, this.appDict);
+  }
 
   if (!this.appDict) {
     // this means we no longer have any apps. what the what?


### PR DESCRIPTION
Rather than always finding a new app id, only do it if we've actually lost the one we are connected to.