### PR TITLE
Update ws library

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "node-uuid": "^1.4.3",
     "request-promise": "^1.0.2",
     "source-map-support": "^0.3.2",
-    "ws": "^0.8.0"
+    "ws": "^1.0.1"
   },
   "scripts": {
     "prepublish": "./node_modules/.bin/gulp prepublish",


### PR DESCRIPTION
There is a memory leak in the `ws` version we use. Bumping to the fixed version (1.0.1).

https://nodesecurity.io/advisories/ws_buffer-leak