### PR TITLE
Clean up logging of objects

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -159,5 +159,17 @@ function getScriptForAtom (atom, args, frames, asyncCallBack = null) {
   return script;
 }
 
+function simpleStringify (value) {
+  if (!value) return JSON.stringify(value);
+
+  // we get back objects sometimes with string versions of functions
+  // which muddy the logs
+  let cleanValue = _.clone(value);
+  for (let property of ['ceil', 'clone', 'floor', 'round', 'scale', 'toString']) {
+    delete cleanValue[property];
+  }
+  return JSON.stringify(cleanValue);
+}
+
 export { appInfoFromDict, pageArrayFromDict, getDebuggerAppKey, getPossibleDebuggerAppKeys, checkParams,
-         wrapScriptForFrame, getScriptForAtom };
+         wrapScriptForFrame, getScriptForAtom, simpleStringify };

--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -1,6 +1,6 @@
 import log from './logger';
 import { RemoteDebugger } from './remote-debugger';
-import { pageArrayFromDict, getDebuggerAppKey } from './helpers';
+import { pageArrayFromDict, getDebuggerAppKey, simpleStringify } from './helpers';
 
 /*
  * Generic callbacks used throughout the lifecycle of the Remote Debugger.
@@ -10,7 +10,7 @@ import { pageArrayFromDict, getDebuggerAppKey } from './helpers';
 function onPageChange (appIdKey, pageDict) {
   // only act if this is the correct app
   if (this.appIdKey === appIdKey) {
-    log.debug(`Page changed: ${JSON.stringify(pageDict)}`);
+    log.debug(`Page changed: ${simpleStringify(pageDict)}`);
     this.emit(RemoteDebugger.EVENT_PAGE_CHANGE, pageArrayFromDict(pageDict));
   } else {
     log.debug(`Received page change notice for app ${appIdKey} ` +

--- a/lib/remote-debugger-rpc-client.js
+++ b/lib/remote-debugger-rpc-client.js
@@ -9,6 +9,7 @@ import uuid from 'node-uuid';
 import net from 'net';
 import RpcMessageHandler from './remote-debugger-message-handler';
 import getRemoteCommand from './remote-messages';
+import { simpleStringify } from './helpers';
 
 
 export default class RemoteDebuggerRpcClient {
@@ -164,7 +165,7 @@ export default class RemoteDebuggerRpcClient {
       if (this.messageHandler.hasSpecialMessageHandler(data.__selector)) {
         // special replies will return any number of arguments
         this.setSpecialMessageHandler(data.__selector, reject, function (...args) {
-          log.debug(`Received response from socket send: '${_.truncate(JSON.stringify(args), 50)}'`);
+          log.debug(`Received response from socket send: '${_.truncate(args, 50)}'`);
           this.socket.removeListener('error', onSocketError);
           resolve(args);
         }.bind(this));
@@ -173,7 +174,8 @@ export default class RemoteDebuggerRpcClient {
         // a simple sequential id
         this.curMsgId++;
         this.setDataMessageHandler(this.curMsgId.toString(), reject, (value) => {
-          log.debug(`Received data response from socket send: '${_.truncate(JSON.stringify(value), 50)}'`);
+          let msg = _.truncate(_.isString(value) ? value : JSON.stringify(value), 50);
+          log.debug(`Received data response from socket send: '${msg}'`);
           log.debug(`Original command: ${command}`);
           this.socket.removeListener('error', onSocketError);
           resolve(value);
@@ -276,7 +278,7 @@ export default class RemoteDebuggerRpcClient {
       if (plist.__selector === "_rpc_applicationSentData:") {
         log.debug('Received applicationSentData response');
       } else {
-        log.debug(`Receiving data from remote debugger: '${JSON.stringify(plist)}'`);
+        log.debug(`Receiving data from remote debugger: '${simpleStringify(plist)}'`);
       }
 
       // Jump forward the length of the plist

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -6,7 +6,7 @@ import { errors } from 'mobile-json-wire-protocol';
 import RemoteDebuggerRpcClient from './remote-debugger-rpc-client';
 import messageHandlers from './message-handlers';
 import { appInfoFromDict, pageArrayFromDict, getDebuggerAppKey, getPossibleDebuggerAppKeys, checkParams,
-         getScriptForAtom } from './helpers';
+         getScriptForAtom, simpleStringify } from './helpers';
 import { util } from 'appium-support';
 import _ from 'lodash';
 import Promise from 'bluebird';
@@ -219,7 +219,7 @@ class RemoteDebugger extends events.EventEmitter {
 
     // translate the dictionary into a useful form, and return to sender
     let pageArray = pageArrayFromDict(pageDict);
-    log.debug(`Selecting app ${this.appIdKey}: ${JSON.stringify(pageArray)}`);
+    log.debug(`Selecting app ${this.appIdKey}: ${simpleStringify(pageArray)}`);
     return pageArray;
   }
 
@@ -257,7 +257,7 @@ class RemoteDebugger extends events.EventEmitter {
     let script = getScriptForAtom(atom, args, frames);
 
     let value = await this.execute(script, true);
-    log.debug(`Received result for atom '${atom}' execution: ${JSON.stringify(value)}`);
+    log.debug(`Received result for atom '${atom}' execution: ${simpleStringify(value)}`);
     return value;
   }
 
@@ -323,7 +323,7 @@ class RemoteDebugger extends events.EventEmitter {
     log.debug('Checking document readyState');
     let readyCmd = '(function (){ return document.readyState; })()';
     let readyState = await this.execute(readyCmd, true);
-    log.debug(`readyState was ${JSON.stringify(readyState)}`);
+    log.debug(`readyState was ${simpleStringify(readyState)}`);
 
     return readyState === 'complete';
   }
@@ -450,7 +450,7 @@ class RemoteDebugger extends events.EventEmitter {
 
   convertResult (res) {
     if (_.isUndefined(res)) {
-      throw new Error(`Did not get OK result from remote debugger. Result was: ${JSON.stringify(res)}`);
+      throw new Error(`Did not get OK result from remote debugger. Result was: ${simpleStringify(res)}`);
     } else if (_.isString(res)) {
       try {
         res = JSON.parse(res);

--- a/lib/webkit-remote-debugger.js
+++ b/lib/webkit-remote-debugger.js
@@ -7,6 +7,7 @@ import WebKitRpcClient from './webkit-rpc-client';
 import _ from 'lodash';
 import url from 'url';
 import request from 'request-promise';
+import { simpleStringify } from './helpers';
 
 
 export default class WebKitRemoteDebugger extends RemoteDebugger {
@@ -35,7 +36,7 @@ export default class WebKitRemoteDebugger extends RemoteDebugger {
   async pageArrayFromJson () {
     log.debug(`Getting WebKitRemoteDebugger pageArray: ${this.host}, ${this.port}`);
     let pageElementJSON = await this.getJsonFromUrl(this.host, this.port, '/json');
-    log.debug(`Page element JSON: ${JSON.stringify(pageElementJSON)}`);
+    log.debug(`Page element JSON: ${simpleStringify(pageElementJSON)}`);
     // Add elements to an array
     let newPageArray = pageElementJSON.map((pageObject) => {
       let urlArray = pageObject.webSocketDebuggerUrl.split('/').reverse();

--- a/lib/webkit-rpc-client.js
+++ b/lib/webkit-rpc-client.js
@@ -5,6 +5,7 @@ import WebSocket from 'ws';
 import Promise from 'bluebird';
 import _ from 'lodash';
 import events from 'events';
+import { simpleStringify } from './helpers';
 
 
 export default class WebKitRpcClient extends events.EventEmitter {
@@ -155,7 +156,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
         this.dataHandlers[msgId](data.result);
       },
       'Page.navigate': (data) => {
-        log.debug(`Received page navigated message: ${JSON.stringify(data)}`);
+        log.debug(`Received page navigated message: ${simpleStringify(data)}`);
         let msgId = data.id;
         if (data.error) {
           this.errorHandlers[msgId](data.error);


### PR DESCRIPTION
Some objects that we log have stringified functions on them, which makes the logs less useful by cluttering with non-information. For logging, remove those properties.