### PR TITLE
Better mapping of pages, to allow multiple wkwebviews on sims

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,6 +2,8 @@ import log from './logger';
 import { get as getAtom } from 'appium-atoms';
 import _ from 'lodash';
 import assert from 'assert';
+import Promise from 'bluebird';
+
 
 /*
  * Takes a dictionary from the remote debugger and makes a more manageable
@@ -172,5 +174,20 @@ function simpleStringify (value) {
   return JSON.stringify(cleanValue);
 }
 
+function deferredPromise () {
+  // http://bluebirdjs.com/docs/api/deferred-migration.html
+  let resolve;
+  let reject;
+  let promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return {
+    promise,
+    resolve,
+    reject
+  };
+}
+
 export { appInfoFromDict, pageArrayFromDict, getDebuggerAppKey, getPossibleDebuggerAppKeys, checkParams,
-         wrapScriptForFrame, getScriptForAtom, simpleStringify };
+         wrapScriptForFrame, getScriptForAtom, simpleStringify, deferredPromise };

--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -8,10 +8,23 @@ import { pageArrayFromDict, getDebuggerAppKey, simpleStringify } from './helpers
  */
 
 function onPageChange (appIdKey, pageDict) {
+  // save the page dict for this app
+  if (this.appDict[appIdKey]) {
+    if (this.appDict[appIdKey].pageDict && this.appDict[appIdKey].pageDict.resolve) {
+      // pageDict is a promise, so resolve
+      this.appDict[appIdKey].pageDict.resolve();
+    }
+    // keep track of the page dictionary
+    this.appDict[appIdKey].pageDict = pageArrayFromDict(pageDict);
+  }
+
   // only act if this is the correct app
   if (this.appIdKey === appIdKey) {
     log.debug(`Page changed: ${simpleStringify(pageDict)}`);
-    this.emit(RemoteDebugger.EVENT_PAGE_CHANGE, pageArrayFromDict(pageDict));
+    this.emit(RemoteDebugger.EVENT_PAGE_CHANGE, {
+      appIdKey: appIdKey.replace('PID:', ''),
+      pageArray: pageArrayFromDict(pageDict)
+    });
   } else {
     log.debug(`Received page change notice for app ${appIdKey} ` +
               `but listening for ${this.appIdKey}. Ignoring.`);

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -6,7 +6,7 @@ import { errors } from 'mobile-json-wire-protocol';
 import RemoteDebuggerRpcClient from './remote-debugger-rpc-client';
 import messageHandlers from './message-handlers';
 import { appInfoFromDict, pageArrayFromDict, getDebuggerAppKey, getPossibleDebuggerAppKeys, checkParams,
-         getScriptForAtom, simpleStringify } from './helpers';
+         getScriptForAtom, simpleStringify, deferredPromise } from './helpers';
 import { util } from 'appium-support';
 import _ from 'lodash';
 import Promise from 'bluebird';
@@ -54,7 +54,7 @@ class RemoteDebugger extends events.EventEmitter {
     // set up the special callbacks for handling rd events
     this.specialCbs = {
       '_rpc_reportIdentifier:': _.noop,
-      '_rpc_forwardGetListing:': _.noop,
+      '_rpc_forwardGetListing:': this.onPageChange.bind(this),
       '_rpc_reportConnectedApplicationList:': _.noop,
       '_rpc_applicationConnected:': this.onAppConnect.bind(this),
       '_rpc_applicationDisconnected:': this.onAppDisconnect.bind(this),
@@ -94,7 +94,8 @@ class RemoteDebugger extends events.EventEmitter {
     for (let [app, info] of _.toPairs(apps)) {
       log.debug(`Application: '${app}'`);
       for (let [key, value] of _.toPairs(info)) {
-        log.debug(`    ${key}: '${value}'`);
+        let valueString = _.isFunction(value) ? '[Function]' : JSON.stringify(value);
+        log.debug(`    ${key}: '${valueString}'`);
       }
     }
   }
@@ -138,6 +139,11 @@ class RemoteDebugger extends events.EventEmitter {
     this.appDict = this.appDict || {};
     let [id, entry] = appInfoFromDict(dict);
     this.appDict[id] = entry;
+
+    // add a promise to get the page dictionary
+    if (_.isUndefined(entry.pageDict)) {
+      entry.pageDict = deferredPromise();
+    }
 
     log.debug('Current applications available:');
     this.logApplicationDictionary(this.appDict);
@@ -194,6 +200,9 @@ class RemoteDebugger extends events.EventEmitter {
             }
           }
 
+          // save the page array for this app
+          this.appDict[appIdKey].pageDict = pageArrayFromDict(pageDict);
+
           // we have gotten the correct application by this point, so short circuit everything
           done = true;
         } catch (err) {
@@ -216,19 +225,32 @@ class RemoteDebugger extends events.EventEmitter {
     this.rpcClient.setSpecialMessageHandler('_rpc_forwardGetListing:', null,
            this.onPageChange.bind(this));
 
+    // wait for all the promises are back, or 30s passes
+    let pagePromises = _.map(this.appDict, (app) => app.pageDict && app.pageDict.promise);
+    await Promise.any([Promise.delay(30000), Promise.all(pagePromises)]);
+
     // translate the dictionary into a useful form, and return to sender
     let pageArray = pageArrayFromDict(pageDict);
     log.debug(`Selecting app ${this.appIdKey}: ${simpleStringify(pageArray)}`);
-    return pageArray;
+
+    let fullPageArray = [];
+    for (let [app, info] of _.toPairs(this.appDict)) {
+      let id = app.replace('PID:', '');
+      if (_.isUndefined(info.pageDict)) continue;
+      for (let page of info.pageDict) {
+        let pageDict = _.clone(page);
+        pageDict.id = `${id}.${pageDict.id}`;
+        fullPageArray.push(pageDict);
+      }
+    }
+    return fullPageArray;
   }
 
-  async selectPage (pageIdKey, skipReadyCheck = false) {
-    let errors = checkParams({appIdKey: this.appIdKey});
-    if (errors) throw new Error(errors);
-
+  async selectPage (appIdKey, pageIdKey, skipReadyCheck = false) {
+    this.appIdKey = `PID:${appIdKey}`;
     this.pageIdKey = pageIdKey;
 
-    log.debug(`Selecting page ${pageIdKey} and forwarding socket setup`);
+    log.debug(`Selecting page '${pageIdKey}' on app '${this.appIdKey}' and forwarding socket setup`);
 
     await this.rpcClient.send('setSenderKey', {
       appIdKey: this.appIdKey,

--- a/test/helpers/remote-debugger-server.js
+++ b/test/helpers/remote-debugger-server.js
@@ -226,6 +226,24 @@ class RemoteDebuggerServer {
     }
   }
 
+  sendPageInfoMessage (appIdKey) {
+    let data = {
+      __selector: '_rpc_applicationSentListing:',
+      __argument: {
+        WIRApplicationIdentifierKey: appIdKey,
+        WIRListingKey: {
+          '1': {
+            WIRTypeKey: 'WIRTypeWeb',
+            WIRPageIdentifierKey: 1,
+            WIRTitleKey: '',
+            WIRURLKey: ''
+          }
+        }
+      }
+    };
+    this.send(data);
+  }
+
   sendFrameNavigationMessage () {
     let dataKey = {
       method: 'Page.frameNavigated',

--- a/test/unit/remote-debugger-specs.js
+++ b/test/unit/remote-debugger-specs.js
@@ -113,7 +113,13 @@ describe('RemoteDebugger', () => {
       }
 
       let spy = sinon.spy(rd.rpcClient, 'selectApp');
-      await rd.selectApp();
+      let selectPromise = rd.selectApp();
+
+      server.sendPageInfoMessage('PID:42');
+      server.sendPageInfoMessage('PID:44');
+
+      await selectPromise;
+
       rd.appIdKey.should.equal('PID:42');
       spy.calledOnce.should.be.true;
     });
@@ -122,16 +128,23 @@ describe('RemoteDebugger', () => {
       server.changeApp(1, false);
 
       let spy = sinon.spy(rd.rpcClient, 'selectApp');
-      await rd.selectApp();
+      let selectPromise = rd.selectApp();
+
+      await Promise.delay(1000);
+      server.sendPageInfoMessage('PID:44');
+      server.sendPageInfoMessage('PID:42');
+      server.sendPageInfoMessage('PID:46');
+
+      await selectPromise;
+
       spy.calledTwice.should.be.true;
     });
   }));
 
   describe('#selectPage', withConnectedServer(rds, (server) => {
-    requireAppIdKey('selectPage', []);
-    confirmRpcSend('selectPage', [1, true], 3);
-    confirmRpcSend('selectPage', [1, false], 4);
-    confirmRemoteDebuggerErrorHandling(server, 'selectPage', [1]);
+    confirmRpcSend('selectPage', [1, 2, true], 3);
+    confirmRpcSend('selectPage', [1, 2, false], 4);
+    confirmRemoteDebuggerErrorHandling(server, 'selectPage', [1, 2]);
   }));
 
   describe('#execute', withConnectedServer(rds, () => {


### PR DESCRIPTION
Traditional webviews return an app with multiple pages associated with it. We would find the one we wanted. In wkwebviews each page is mapped to its own app. So rather than looking at a single app, we need to look at all of them.

This changes the webview ids from simple integers (which were app ids) to composites of the app and the page. For UIWebviews the webviews will be, for app `PID:1234` with four pages, something like `1234.1`, `1234.2`, `1234.3`, and `1234.4`. For WkWebviews we will get ids like `1234.0`, `1235.0`, `1236.0`, and `1237.0`.

Since there is no _a priori_ way to tell what the id would be for a particular webview in the previous scheme, this should not be a breaking change.

See discussion https://github.com/appium/appium/issues/5839