### PR TITLE
Check for the right app better

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -149,7 +149,9 @@ class RemoteDebugger extends events.EventEmitter {
     this.logApplicationDictionary(this.appDict);
 
     // try to get the app id from our connected apps
-    this.appIdKey = getDebuggerAppKey(this.bundleId, this.platformVersion, this.appDict);
+    if (this.appIdKey) {
+      this.appIdKey = getDebuggerAppKey(this.bundleId, this.platformVersion, this.appDict);
+    }
   }
 
   async selectApp (currentUrl = null, maxTries = SELECT_APP_RETRIES) {
@@ -164,7 +166,6 @@ class RemoteDebugger extends events.EventEmitter {
     let done = false;
     for (let i = 0; i < maxTries; i++) {
       if (done) break;
-
       let possibleAppIds = getPossibleDebuggerAppKeys(this.bundleId, this.platformVersion, this.appDict);
       log.debug(`Trying out the possible app ids: ${possibleAppIds.join(', ')}`);
       for (let attemptedAppIdKey of possibleAppIds) {
@@ -173,7 +174,6 @@ class RemoteDebugger extends events.EventEmitter {
         try {
           log.debug(`Selecting app ${attemptedAppIdKey} (try #${i+1} of ${maxTries})`);
           [appIdKey, pageDict] = await this.rpcClient.selectApp(attemptedAppIdKey, this.onAppConnect.bind(this));
-
           // in iOS 8.2 the connect logic happens, but with an empty dictionary
           // which leads to the remote debugger getting disconnected, and into a loop
           if (_.isEmpty(pageDict)) {
@@ -182,31 +182,32 @@ class RemoteDebugger extends events.EventEmitter {
             continue;
           }
 
-          // if we are looking for a particular url, make sure this is the right page
-          if (currentUrl) {
-            let found;
-            _.each(pageDict, (record) => {
-              if (record.WIRURLKey === currentUrl) {
-                // this is the page we want
-                found = true;
-              }
-            });
+          // save the page array for this app
+          this.appDict[appIdKey].pageDict = pageArrayFromDict(pageDict);
 
+          // if we are looking for a particular url, make sure we have the right page
+          if (currentUrl) {
+            let found = false;
+            for (let appDict of _.values(this.appDict)) {
+              if (found) break;
+              for (let dict of (appDict.pageDict || [])) {
+                if (dict.url === currentUrl) {
+                  found = true;
+                  break;
+                }
+              }
+            }
             if (!found) {
               log.debug(`Received app, but expected url ('${currentUrl}') was not found. Trying again.`);
-              // this.appIdKey = appIdKey;
               pageDict = null;
               continue;
             }
           }
 
-          // save the page array for this app
-          this.appDict[appIdKey].pageDict = pageArrayFromDict(pageDict);
-
           // we have gotten the correct application by this point, so short circuit everything
           done = true;
         } catch (err) {
-          log.debug(`Retrying connection`);
+          log.debug(`Error checking application: '${err}'. Retrying connection`);
         }
       }
     }
@@ -227,11 +228,12 @@ class RemoteDebugger extends events.EventEmitter {
 
     // wait for all the promises are back, or 30s passes
     let pagePromises = _.map(this.appDict, (app) => app.pageDict && app.pageDict.promise);
+    log.debug(`Waiting for ${pagePromises.length} pages to be fulfilled`);
     await Promise.any([Promise.delay(30000), Promise.all(pagePromises)]);
 
     // translate the dictionary into a useful form, and return to sender
     let pageArray = pageArrayFromDict(pageDict);
-    log.debug(`Selecting app ${this.appIdKey}: ${simpleStringify(pageArray)}`);
+    log.debug(`Finally selecting app ${this.appIdKey}: ${simpleStringify(pageArray)}`);
 
     let fullPageArray = [];
     for (let [app, info] of _.toPairs(this.appDict)) {


### PR DESCRIPTION
Rather than simply looking through the current record, look through all the records we have already to see if the page has been found in the background. This should (a) speed things up and (b) make things more reliable, as we don't need to interact with the remote debugger so much.