### PR TITLE
Better logging for promise

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -91,11 +91,20 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   logApplicationDictionary (apps) {
+    function getValueString (key, value) {
+      if (_.isFunction(value)) {
+        return '[Function]';
+      }
+      if (key === 'pageDict' && !_.isArray(value)) {
+        return '"Waiting for data"';
+      }
+      return JSON.stringify(value);
+    }
     for (let [app, info] of _.toPairs(apps)) {
       log.debug(`Application: '${app}'`);
       for (let [key, value] of _.toPairs(info)) {
-        let valueString = _.isFunction(value) ? '[Function]' : JSON.stringify(value);
-        log.debug(`    ${key}: '${valueString}'`);
+        let valueString = getValueString(key, value);
+        log.debug(`    ${key}: ${valueString}`);
       }
     }
   }


### PR DESCRIPTION
Instead of logging application list as

```
dbug RemoteDebugger Notified that a new application PID:96989 has connected
dbug RemoteDebugger Current applications available:
dbug RemoteDebugger Application: 'PID:96987'
dbug RemoteDebugger     id: '"PID:96987"'
dbug RemoteDebugger     name: '"Safari"'
dbug RemoteDebugger     bundleId: '"com.apple.mobilesafari"'
dbug RemoteDebugger     isProxy: 'false'
dbug RemoteDebugger     hostId: 'undefined'
dbug RemoteDebugger     isActive: '1'
dbug RemoteDebugger Application: 'PID:96989'
dbug RemoteDebugger     id: '"PID:96989"'
dbug RemoteDebugger     name: '""'
dbug RemoteDebugger     bundleId: '"com.apple.WebKit.WebContent"'
dbug RemoteDebugger     isProxy: 'true'
dbug RemoteDebugger     hostId: '"PID:96987"'
dbug RemoteDebugger     isActive: '1'
dbug RemoteDebugger     pageDict: '{"promise":{"isFulfilled":false,"isRejected":false}}'
```

We will get 

```
dbug RemoteDebugger Notified that a new application PID:97917 has connected
dbug RemoteDebugger Current applications available:
dbug RemoteDebugger Application: 'PID:97915'
dbug RemoteDebugger     id: "PID:97915"
dbug RemoteDebugger     name: "Safari"
dbug RemoteDebugger     bundleId: "com.apple.mobilesafari"
dbug RemoteDebugger     isProxy: false
dbug RemoteDebugger     hostId: undefined
dbug RemoteDebugger     isActive: 1
dbug RemoteDebugger Application: 'PID:97917'
dbug RemoteDebugger     id: "PID:97917"
dbug RemoteDebugger     name: ""
dbug RemoteDebugger     bundleId: "com.apple.WebKit.WebContent"
dbug RemoteDebugger     isProxy: true
dbug RemoteDebugger     hostId: "PID:97915"
dbug RemoteDebugger     isActive: 1
dbug RemoteDebugger     pageDict: "Waiting for data"
```