### PR TITLE
Add support for iOS 10

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -19,7 +19,8 @@ function appInfoFromDict (dict) {
     bundleId: dict.WIRApplicationBundleIdentifierKey,
     isProxy: isProxy,
     hostId: dict.WIRHostApplicationIdentifierKey,
-    isActive: dict.WIRIsApplicationActiveKey
+    isActive: dict.WIRIsApplicationActiveKey,
+    isAutomationEnabled: !!dict.WIRRemoteAutomationEnabledKey,
   };
 
   return [id, entry];

--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -12,7 +12,7 @@ function onPageChange (appIdKey, pageDict) {
   if (this.appDict[appIdKey]) {
     if (this.appDict[appIdKey].pageDict && this.appDict[appIdKey].pageDict.resolve) {
       // pageDict is a promise, so resolve
-      this.appDict[appIdKey].pageDict.resolve();
+      this.appDict[appIdKey].pageDict.resolve(pageDict);
     }
     // keep track of the page dictionary
     this.appDict[appIdKey].pageDict = pageArrayFromDict(pageDict);
@@ -33,14 +33,14 @@ function onPageChange (appIdKey, pageDict) {
 
 function onAppConnect (dict) {
   let appIdKey = dict.WIRApplicationIdentifierKey;
-  log.debug(`Notified that a new application ${appIdKey} has connected`);
+  log.debug(`Notified that new application '${appIdKey}' has connected`);
 
   this.updateAppsWithDict(dict);
 }
 
-function onAppDisconnect (dict) {
+async function onAppDisconnect (dict) {
   let appIdKey = dict.WIRApplicationIdentifierKey;
-  log.debug(`Application ${appIdKey} disconnected. Removing from app dictionary.`);
+  log.debug(`Application '${appIdKey}' disconnected. Removing from app dictionary.`);
 
   // get rid of the entry in our app dictionary,
   // since it is no longer available
@@ -54,16 +54,29 @@ function onAppDisconnect (dict) {
 
   if (!this.appDict) {
     // this means we no longer have any apps. what the what?
-    log.debug('Main app disconnected.');
+    log.debug('Main app disconnected. Disconnecting altogether.');
     this.connected = false;
     this.emit(RemoteDebugger.EVENT_DISCONNECT, true);
   }
 }
 
+function onAppUpdate (dict) {
+  let appIdKey = dict.WIRApplicationIdentifierKey;
+  log.debug(`Notified that application '${appIdKey}' has been updated.`);
+
+  this.updateAppsWithDict(dict);
+}
+
+function onReportDriverList (dict) {
+  log.debug(`Notified of connected drivers: ${dict.WIRDriverDictionaryKey}.`);
+}
+
 const messageHandlers = {
   onPageChange,
   onAppConnect,
-  onAppDisconnect
+  onAppDisconnect,
+  onAppUpdate,
+  onReportDriverList,
 };
 
 export default messageHandlers;

--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -64,7 +64,9 @@ export default class RpcMessageHandler {
       // page change and app connect/disconnect
       if (handler !== '_rpc_forwardGetListing:' &&
           handler !== '_rpc_applicationDisconnected:' &&
-          handler !== '_rpc_applicationConnected:') {
+          handler !== '_rpc_applicationConnected:' &&
+          handler !== '_rpc_applicationUpdated:' &&
+          handler !== '_rpc_reportConnectedDriverList:') {
         this.specialHandlers[handler] = null;
       }
       fn(...args);
@@ -166,6 +168,14 @@ export default class RpcMessageHandler {
       },
       '_rpc_applicationDisconnected:': (plist) => {
         this.handleSpecialMessage('_rpc_applicationDisconnected:',
+            plist.__argument);
+      },
+      '_rpc_applicationUpdated:': (plist) => {
+        this.handleSpecialMessage('_rpc_applicationUpdated:',
+            plist.__argument);
+      },
+      '_rpc_reportConnectedDriverList:': (plist) => {
+        this.handleSpecialMessage('_rpc_reportConnectedDriverList:',
             plist.__argument);
       },
       '_rpc_applicationSentData:': this.handleDataMessage.bind(this),

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -11,6 +11,7 @@ import { util } from 'appium-support';
 import _ from 'lodash';
 import Promise from 'bluebird';
 
+
 const DEBUGGER_TYPES = {
   webkit: 1,
   webinspector: 2
@@ -58,6 +59,8 @@ class RemoteDebugger extends events.EventEmitter {
       '_rpc_reportConnectedApplicationList:': _.noop,
       '_rpc_applicationConnected:': this.onAppConnect.bind(this),
       '_rpc_applicationDisconnected:': this.onAppDisconnect.bind(this),
+      '_rpc_applicationUpdated:': this.onAppUpdate.bind(this),
+      '_rpc_reportConnectedDriverList:': this.onReportDriverList.bind(this),
     };
 
     this.host = host || 'localhost';
@@ -147,6 +150,10 @@ class RemoteDebugger extends events.EventEmitter {
     // application dictionary
     this.appDict = this.appDict || {};
     let [id, entry] = appInfoFromDict(dict);
+    if (this.appDict[id]) {
+      // preserve the page dictionary for this entry
+      entry.pageDict = this.appDict[id].pageDict;
+    }
     this.appDict[id] = entry;
 
     // add a promise to get the page dictionary
@@ -183,7 +190,6 @@ class RemoteDebugger extends events.EventEmitter {
           // which leads to the remote debugger getting disconnected, and into a loop
           if (_.isEmpty(pageDict)) {
             log.debug('Empty page dictionary received. Trying again.');
-            // this.appIdKey = appIdKey;
             continue;
           }
 
@@ -232,9 +238,13 @@ class RemoteDebugger extends events.EventEmitter {
            this.onPageChange.bind(this));
 
     // wait for all the promises are back, or 30s passes
-    let pagePromises = _.map(this.appDict, (app) => app.pageDict && app.pageDict.promise);
-    log.debug(`Waiting for ${pagePromises.length} pages to be fulfilled`);
-    await Promise.any([Promise.delay(30000), Promise.all(pagePromises)]);
+    let pagePromises = Object.values(this.appDict)
+      .filter((app) => !!app.pageDict && !!app.pageDict.promise)
+      .map((app) => app.pageDict.promise);
+    if (pagePromises.length) {
+      log.debug(`Waiting for ${pagePromises.length} pages to be fulfilled`);
+      await Promise.any([Promise.delay(30000), Promise.all(pagePromises)]);
+    }
 
     // translate the dictionary into a useful form, and return to sender
     let pageArray = pageArrayFromDict(pageDict);

--- a/lib/remote-messages.js
+++ b/lib/remote-messages.js
@@ -32,12 +32,12 @@ function setSenderKey (connId, senderId, appIdKey, pageIdKey) {
       WIRApplicationIdentifierKey: appIdKey,
       WIRConnectionIdentifierKey: connId,
       WIRSenderKey: senderId,
-      WIRPageIdentifierKey: pageIdKey
+      WIRPageIdentifierKey: pageIdKey,
+      WIRAutomaticallyPause: false
     },
     __selector: '_rpc_forwardSocketSetup:'
   };
 }
-
 
 /*
  * Action functions

--- a/test/helpers/remote-debugger-server.js
+++ b/test/helpers/remote-debugger-server.js
@@ -22,7 +22,8 @@ const APP_INFO = {
     bundleId: 'io.appium.bundle',
     isProxy: false,
     hostId: '',
-    isActive: '1'
+    isActive: '1',
+    isAutomationEnabled: false
   }
 };
 


### PR DESCRIPTION
Mostly this is cosmetic. The crux of the matter is adding `WIRAutomaticallyPause: false` to the arguments sent on the `_rpc_forwardSocketSetup:` call (setting the sending id before choosing the page). Without this the connection to the app succeeds, but almost immediately the remote debugger disconnects the app and we are left with no way to automate it.

This appears to be fully backward compatible.