### PR TITLE
Make sure we keep track of the page we have chosen

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -203,6 +203,9 @@ class RemoteDebugger extends events.EventEmitter {
               if (found) break;
               for (let dict of (appDict.pageDict || [])) {
                 if (dict.url === currentUrl) {
+                  // save where we found the right page
+                  appIdKey = appDict.id;
+                  pageDict = dict;
                   found = true;
                   break dictLoop;
                 }


### PR DESCRIPTION
When we check the apps we are breaking out of the selection when we have the right app, but not keeping track of what that app is. This means we end up getting _an_ app but not necessarily the _right_ app.

So keep track of the id and the page dictionary where the page is.