### PR TITLE
Change direction of condition

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -184,7 +184,7 @@ class RemoteDebugger extends events.EventEmitter {
     this.logApplicationDictionary(this.appDict);
 
     // try to get the app id from our connected apps
-    if (this.appIdKey) {
+    if (!this.appIdKey) {
       this.appIdKey = getDebuggerAppKey(this.bundleId, this.platformVersion, this.appDict);
     }
   }


### PR DESCRIPTION
Condition was backwards, so sometimes we would end up, inexplicably, in the wrong app and timeout.