### PR TITLE
fix the truncate usage

### DIFF
--- a/lib/remote-debugger-rpc-client.js
+++ b/lib/remote-debugger-rpc-client.js
@@ -171,7 +171,7 @@ export default class RemoteDebuggerRpcClient {
         // temporarily wrap with promise handling
         let specialMessageHandler = this.getSpecialMessageHandler(data.__selector);
         this.setSpecialMessageHandler(data.__selector, reject, function (...args) {
-          log.debug(`Received response from socket send: '${_.truncate(JSON.stringify(args), 50)}'`);
+          log.debug(`Received response from socket send: '${_.truncate(JSON.stringify(args), {length: 50})}'`);
 
           // call the original listener, and put it back, if necessary
           specialMessageHandler(...args);
@@ -187,7 +187,7 @@ export default class RemoteDebuggerRpcClient {
         // a simple sequential id
         this.curMsgId++;
         this.setDataMessageHandler(this.curMsgId.toString(), reject, (value) => {
-          let msg = _.truncate(_.isString(value) ? value : JSON.stringify(value), 50);
+          let msg = _.truncate(_.isString(value) ? value : JSON.stringify(value), {length: 50});
           log.debug(`Received data response from socket send: '${msg}'`);
           log.debug(`Original command: ${command}`);
           resolve(value);

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -481,7 +481,7 @@ class RemoteDebugger extends events.EventEmitter {
       if (errors) throw new Error(errors);
     }
 
-    log.debug(`Sending javascript command ${_.truncate(command, 50)}`);
+    log.debug(`Sending javascript command ${_.truncate(command, {length: 50})}`);
     let res = await this.rpcClient.send('sendJSCommand', {
       command: command,
       appIdKey: this.appIdKey,

--- a/lib/webkit-rpc-client.js
+++ b/lib/webkit-rpc-client.js
@@ -70,7 +70,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
   async send (command, opts = {}) {
     let data = getRemoteCommand(command, _.defaults({connId: this.connId, senderId: this.senderId}, opts));
 
-    log.debug(`Sending WebKit data: ${_.truncate(JSON.stringify(data), 50)}`);
+    log.debug(`Sending WebKit data: ${_.truncate(JSON.stringify(data), {length: 50})}`);
 
     this.curMsgId++;
     data.id = this.curMsgId;
@@ -104,7 +104,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
 
 
   receive (data) {
-    log.debug(`Receiving WebKit data: ${_.truncate(data, 50)}`);
+    log.debug(`Receiving WebKit data: ${_.truncate(data, {length: 50})}`);
 
     data = JSON.parse(data);
 


### PR DESCRIPTION
According to the [doc](https://lodash.com/docs/4.15.0#truncate), length should be in Object notation. 
