### PR TITLE
don't connect to app if url is `about:blank` or empty url

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -189,7 +189,7 @@ class RemoteDebugger extends events.EventEmitter {
     }
   }
 
-  async selectApp (currentUrl = null, maxTries = SELECT_APP_RETRIES) {
+  async selectApp (currentUrl = null, maxTries = SELECT_APP_RETRIES, ignoreAboutBlankUrl = false) {
     log.debug('Selecting application');
     if (!this.appDict || _.keys(this.appDict).length === 0) {
       log.debug('No applications currently connected.');
@@ -215,26 +215,24 @@ class RemoteDebugger extends events.EventEmitter {
           // save the page array for this app
           this.appDict[appIdKey].pageDict = pageArrayFromDict(pageDict);
 
-          // if we are looking for a particular url, make sure we have the right page
-          if (currentUrl) {
-            let found = false;
-            dictLoop: for (let appDict of _.values(this.appDict)) {
-              if (found) break;
-              for (let dict of (appDict.pageDict || [])) {
-                if (dict.url === currentUrl) {
-                  // save where we found the right page
-                  appIdKey = appDict.id;
-                  pageDict = dict;
-                  found = true;
-                  break dictLoop;
-                }
+          // if we are looking for a particular url, make sure we have the right page. Ignore empty or undefined urls. Ignore about:blank if requested.
+          let found = false;
+          dictLoop: for (let appDict of _.values(this.appDict)) {
+            if (found) break;
+            for (let dict of (appDict.pageDict || [])) {
+              if (dict.url && (!ignoreAboutBlankUrl || dict.url !== 'about:blank') && (!currentUrl || dict.url === currentUrl)) {
+                // save where we found the right page
+                appIdKey = appDict.id;
+                pageDict = dict;
+                found = true;
+                break dictLoop;
               }
             }
-            if (!found) {
-              log.debug(`Received app, but expected url ('${currentUrl}') was not found. Trying again.`);
-              pageDict = null;
-              continue;
-            }
+          }
+          if (!found) {
+            log.debug(`Received app, but expected url ('${currentUrl}') was not found. Trying again.`);
+            pageDict = null;
+            continue;
           }
 
           // we have gotten the correct application by this point, so short circuit everything

--- a/test/helpers/remote-debugger-server.js
+++ b/test/helpers/remote-debugger-server.js
@@ -152,7 +152,7 @@ class RemoteDebuggerServer {
             WIRTypeKey: 'WIRTypeWeb',
             WIRPageIdentifierKey: 1,
             WIRTitleKey: '',
-            WIRURLKey: ''
+            WIRURLKey: 'about:blank'
           }
         }
       }
@@ -237,7 +237,7 @@ class RemoteDebuggerServer {
             WIRTypeKey: 'WIRTypeWeb',
             WIRPageIdentifierKey: 1,
             WIRTitleKey: '',
-            WIRURLKey: ''
+            WIRURLKey: 'about:blank'
           }
         }
       }

--- a/test/unit/remote-debugger-specs.js
+++ b/test/unit/remote-debugger-specs.js
@@ -139,6 +139,16 @@ describe('RemoteDebugger', () => {
 
       spy.calledTwice.should.be.true;
     });
+     it('should not connect to app if url is about:blank and ignoreAboutBlankUrl is passed true to selectApp', async () => {
+
+      let selectPromise = rd.selectApp({ignoreAboutBlankUrl: true});
+
+      try {
+        await selectPromise;
+      } catch (err) {
+        err.message.should.include('Could not connect to a valid app');
+      }
+    });
   }));
 
   describe('#selectPage', withConnectedServer(rds, (server) => {


### PR DESCRIPTION
What I observed is remote debugger hangs sometimes if connected to webview with empty url or about:blank. May be because at that point it is still trying to load page. Here I totally neglect empty url and have option of ignoring `about:blank` so that it doesn't hang anymore.