### PR TITLE
Remove requirement of having a non-blank url

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -220,7 +220,7 @@ class RemoteDebugger extends events.EventEmitter {
           dictLoop: for (let appDict of _.values(this.appDict)) {
             if (found) break;
             for (let dict of (appDict.pageDict || [])) {
-              if (dict.url && (!ignoreAboutBlankUrl || dict.url !== 'about:blank') && (!currentUrl || dict.url === currentUrl)) {
+              if ((!ignoreAboutBlankUrl || dict.url !== 'about:blank') && (!currentUrl || dict.url === currentUrl)) {
                 // save where we found the right page
                 appIdKey = appDict.id;
                 pageDict = dict;


### PR DESCRIPTION
Otherwise we cannot get webviews that do not have any content yet. Appium's webview tests fail with this check.