### PR TITLE
Ensuring Appium times out gracefully if webkit does not return a response

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -19,6 +19,9 @@ const DEBUGGER_TYPES = {
 const SELECT_APP_RETRIES = 20;
 const REMOTE_DEBUGGER_PORT = 27753;
 
+/* How many milliseconds to wait for webkit to return a response before timing out */
+const RPC_RESPONSE_TIMEOUT_MS = 5000;
+
 
 class RemoteDebugger extends events.EventEmitter {
   /*
@@ -546,4 +549,4 @@ for (let [name, handler] of _.toPairs(messageHandlers)) {
   RemoteDebugger.prototype[name] = handler;
 }
 
-export { RemoteDebugger, DEBUGGER_TYPES, REMOTE_DEBUGGER_PORT };
+export { RemoteDebugger, DEBUGGER_TYPES, REMOTE_DEBUGGER_PORT, RPC_RESPONSE_TIMEOUT_MS };

--- a/lib/webkit-rpc-client.js
+++ b/lib/webkit-rpc-client.js
@@ -1,5 +1,5 @@
 import log from './logger';
-import { REMOTE_DEBUGGER_PORT } from './remote-debugger';
+import { REMOTE_DEBUGGER_PORT, RPC_RESPONSE_TIMEOUT_MS } from './remote-debugger';
 import getRemoteCommand from './remote-messages';
 import WebSocket from 'ws';
 import Promise from 'bluebird';
@@ -91,7 +91,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
           reject(new Error(error));
         }
       });
-    }).then((res) => {
+    }).finally((res) => {
       // no need to hold onto anything
       delete this.dataHandlers[id];
       delete this.dataMethods[id];
@@ -99,7 +99,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
 
       // and pass along the result
       return res;
-    });
+    }).timeout(RPC_RESPONSE_TIMEOUT_MS);
   }
 
 


### PR DESCRIPTION
Addressing #42.

I went with a simple 5 sec timeout. Let me know if it needs to be configured through a capability.