### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/remote-debugger-rpc-client.js
+++ b/lib/remote-debugger-rpc-client.js
@@ -6,7 +6,7 @@ import bplistParse from 'bplist-parser';
 import bufferpack from 'bufferpack';
 import Promise from 'bluebird';
 import { REMOTE_DEBUGGER_PORT } from './remote-debugger';
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import net from 'net';
 import RpcMessageHandler from './remote-debugger-message-handler';
 import getRemoteCommand from './remote-messages';

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "bplist-parser": "^0.1.0",
     "bufferpack": "0.0.6",
     "lodash": "^4.2.1",
-    "node-uuid": "^1.4.3",
     "request-promise": "^1.0.2",
     "source-map-support": "^0.4.0",
+    "uuid": "^3.0.0",
     "ws": "^1.0.1"
   },
   "scripts": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.