### PR TITLE
Do not select an app if its pageDict is invalid

### DIFF
--- a/lib/remote-debugger-rpc-client.js
+++ b/lib/remote-debugger-rpc-client.js
@@ -126,6 +126,11 @@ export default class RemoteDebuggerRpcClient {
         appIdKey
       });
 
+      // Reject the page dict if it is not valid
+      if (!this.isValidPageDict(pageDict)) {
+        pageDict = null;
+      }
+
       // sometimes the connect logic happens, but with an empty dictionary
       // which leads to the remote debugger getting disconnected, and into a loop
       if (_.isEmpty(pageDict)) {
@@ -139,6 +144,19 @@ export default class RemoteDebuggerRpcClient {
       // no matter what, we want to restore the handler that was changed.
       this.setSpecialMessageHandler('_rpc_applicationConnected:', null, applicationConnectedHandler);
     });
+  }
+
+  isValidPageDict(pageDict) {
+    if (!pageDict) {
+      return false;
+    }
+    let minimumInvalidPageIdentifierKey = 5; // see https://github.com/appium/appium-remote-debugger/issues/45
+    for (let pageDictValue of _.values(pageDict)) {
+      if (pageDictValue.WIRPageIdentifierKey >= minimumInvalidPageIdentifierKey) {
+        return false;
+      }
+    }
+    return true;
   }
 
   async send (command, opts = {}) {


### PR DESCRIPTION
This adresses issue #45: It seems that Safari on iOS >= 10 simulator returns appIds for https://www.google.com, https://www.yahoo.com, ... (depends on which search engines are configured) even though only 1 tab is open in Safari for my own local page. This might have been also the case in earlier iOS versions but the order or returned appIds is different on every call. If Appium connects to such an appId, the connection may break down or may not even respond to a call. To detect invalid appIds, it seems to be sufficient to check if the pageId >= 5 of a page dict. Only invalid tabs seems to have such an id >= 5 which was the only indicator of an invalid/hidden appId/tab I could find.