### PR TITLE
Fix error handling

### DIFF
--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -84,7 +84,7 @@ export default class RpcMessageHandler {
 
     // we can get an error, or we can get a response that is an error
     if (result && result.wasThrown) {
-      let message = (result.result && (result.result.value || result.result.description)) ? 
+      let message = (result.result && (result.result.value || result.result.description)) ?
                     (result.result.value || result.result.description) :
                     'Error occurred in handling data message';
       error = new Error(message);
@@ -111,15 +111,19 @@ export default class RpcMessageHandler {
     } else if (dataKey.method === 'Page.frameNavigated') {
       if (!this.willNavigateWithoutReload && !this.pageLoading) {
         log.debug('Frame navigated, unloading page');
-        this.specialHandlers['Page.frameNavigated']('remote-debugger');
-        this.specialHandlers['Page.frameNavigated'] = null;
+        if (_.isFunction(this.specialHandlers['Page.frameNavigated'])) {
+          this.specialHandlers['Page.frameNavigated']('remote-debugger');
+          this.specialHandlers['Page.frameNavigated'] = null;
+        } else {
+          log.debug('No frame navigation callback set.');
+        }
       } else {
         log.debug('Frame navigated but we were warned about it, not ' +
                   'considering page state unloaded');
         this.willNavigateWithoutReload = false;
       }
     } else if (dataKey.method === 'Page.loadEventFired') {
-      await this.pageLoad();
+      await this.specialHandlers.pageLoad();
     } else if (dataKey.method === 'Timeline.eventRecorded') {
       this.timelineEventHandler(dataKey.params.record);
     } else if (_.isFunction(this.dataHandlers[msgId])) {

--- a/lib/remote-debugger-rpc-client.js
+++ b/lib/remote-debugger-rpc-client.js
@@ -50,7 +50,7 @@ export default class RemoteDebuggerRpcClient {
     this.socket.on('data', this.receive.bind(this));
 
     // connect the socket
-    return await new Promise(async (resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       // only resolve this function when we are actually connected
       this.socket.connect(this.port, '::1');
       this.socket.on('connect', async () => {
@@ -100,7 +100,7 @@ export default class RemoteDebuggerRpcClient {
   }
 
   async selectApp (appIdKey, applicationConnectedHandler) {
-    return await new Promise(async (resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       // local callback, temporarily added as callback to
       // `_rpc_applicationConnected:` remote debugger response
       // to handle the initial connection
@@ -122,19 +122,21 @@ export default class RemoteDebuggerRpcClient {
       this.setSpecialMessageHandler('_rpc_applicationConnected:', reject, onAppChange);
 
       // do the actual connecting to the app
-      let [connectedAppIdKey, pageDict] = await this.send('connectToApp', {
-        appIdKey
-      });
+      return (async () => {
+        let [connectedAppIdKey, pageDict] = await this.send('connectToApp', {
+          appIdKey
+        });
 
-      // sometimes the connect logic happens, but with an empty dictionary
-      // which leads to the remote debugger getting disconnected, and into a loop
-      if (_.isEmpty(pageDict)) {
-        let msg = 'Empty page dictionary received';
-        log.debug(msg);
-        reject(new Error(msg));
-      } else {
-        resolve([connectedAppIdKey, pageDict]);
-      }
+        // sometimes the connect logic happens, but with an empty dictionary
+        // which leads to the remote debugger getting disconnected, and into a loop
+        if (_.isEmpty(pageDict)) {
+          let msg = 'Empty page dictionary received';
+          log.debug(msg);
+          reject(new Error(msg));
+        } else {
+          resolve([connectedAppIdKey, pageDict]);
+        }
+      })();
     }).finally(() => {
       // no matter what, we want to restore the handler that was changed.
       this.setSpecialMessageHandler('_rpc_applicationConnected:', null, applicationConnectedHandler);
@@ -145,7 +147,7 @@ export default class RemoteDebuggerRpcClient {
     // error listener, which needs to be removed after the promise is resolved
     let onSocketError;
 
-    return await new Promise(async (resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       // promise to be resolved whenever remote debugger
       // replies to our request
 

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -69,6 +69,7 @@ class RemoteDebugger extends events.EventEmitter {
       '_rpc_applicationDisconnected:': this.onAppDisconnect.bind(this),
       '_rpc_applicationUpdated:': this.onAppUpdate.bind(this),
       '_rpc_reportConnectedDriverList:': this.onReportDriverList.bind(this),
+      'pageLoad': this.pageLoad.bind(this),
     };
 
     this.rpcClient = null;
@@ -136,7 +137,7 @@ class RemoteDebugger extends events.EventEmitter {
 
   async setConnectionKey () {
     // only resolve when the connection response is received
-    return await new Promise(async (resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       // local callback, called when the remote debugger has established
       // a connection to the app under test
       // `app` will be an array of dictionaries of app information
@@ -160,10 +161,12 @@ class RemoteDebugger extends events.EventEmitter {
       this.rpcClient.setSpecialMessageHandler('_rpc_reportConnectedApplicationList:', reject, connectCb);
 
       log.debug('Sending connection key request');
-      let [simNameKey, simBuildKey, simPlatformVersion] = await this.rpcClient.send('setConnectionKey');
-      log.debug(`Sim name: ${simNameKey}`);
-      log.debug(`Sim build: ${simBuildKey}`);
-      log.debug(`Sim platform version: ${simPlatformVersion}`);
+      return (async () => {
+        let [simNameKey, simBuildKey, simPlatformVersion] = await this.rpcClient.send('setConnectionKey');
+        log.debug(`Sim name: ${simNameKey}`);
+        log.debug(`Sim build: ${simBuildKey}`);
+        log.debug(`Sim platform version: ${simPlatformVersion}`);
+      })();
     });
   }
 
@@ -349,7 +352,14 @@ class RemoteDebugger extends events.EventEmitter {
         }
       }
 
+      // we can get this called in the middle of trying to find a new app
+      if (!this.appIdKey) {
+        log.debug('Not connected to an application. Ignoring page load');
+        return;
+      }
+
       let ready = await this.checkPageIsReady();
+
       // if we are ready, or we've spend too much time on this
       if (ready || (this.pageLoadMs > 0 && (start + this.pageLoadMs) < Date.now())) {
         log.debug('Page is ready');
@@ -382,6 +392,9 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   async checkPageIsReady () {
+    let errors = checkParams({appIdKey: this.appIdKey});
+    if (errors) throw new Error(errors);
+
     log.debug('Checking document readyState');
     let readyCmd = '(function (){ return document.readyState; })()';
     let readyState = await this.execute(readyCmd, true);

--- a/lib/webkit-rpc-client.js
+++ b/lib/webkit-rpc-client.js
@@ -25,7 +25,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
   }
 
   async connect (pageId) {
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       // we will only resolve this call when the socket is open
       // WebKit url
       let url = `ws://${this.host}:${this.port}/devtools/page/${pageId}`;
@@ -76,7 +76,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
     data.id = this.curMsgId;
 
     let id = this.curMsgId.toString();
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       // only resolve the send command when WebKit returns a response
       // store the handler and the data sent
       this.dataHandlers[id] = resolve;

--- a/test/unit/remote-debugger-specs.js
+++ b/test/unit/remote-debugger-specs.js
@@ -164,7 +164,6 @@ describe('RemoteDebugger', () => {
 
   describe('#checkPageIsReady', withConnectedServer(rds, (server) => {
     requireAppIdKey('checkPageIsReady', []);
-    requirePageIdKey('checkPageIsReady', []);
     confirmRpcSend('checkPageIsReady', []);
     it('should return true when server responds with complete', async () => {
       server.setDataResponseValue('complete');


### PR DESCRIPTION
Fix a number of cases in which we are mishandling errors, or we don't have the requisite information to process incoming messages.

This, in conjunction with a couple of driver issues, cleans up the unhandled rejection errors.