### PR TITLE
Add try of generic app when none found

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,6 +5,8 @@ import assert from 'assert';
 import Promise from 'bluebird';
 
 
+const WEB_CONTENT_BUNDLE_ID = 'com.apple.WebKit.WebContent';
+
 /*
  * Takes a dictionary from the remote debugger and makes a more manageable
  * dictionary whose keys are understandable
@@ -89,16 +91,28 @@ function getDebuggerAppKey (bundleId, platformVersion, appDict) {
   return appId;
 }
 
+function appIdForBundle (bundleId, appDict) {
+  let appId;
+  for (let [key, data] of _.toPairs(appDict)) {
+    if (data.bundleId === bundleId) {
+      appId = key;
+      break;
+    }
+  }
+
+  // if nothing is found, try to get the generic app
+  if (!appId && bundleId !== WEB_CONTENT_BUNDLE_ID) {
+    return appIdForBundle(WEB_CONTENT_BUNDLE_ID, appDict);
+  }
+
+  return appId;
+}
+
 function getPossibleDebuggerAppKeys (bundleId, platformVersion, appDict) {
   let proxiedAppIds = [];
   if (parseFloat(platformVersion) >= 8) {
-    let appId;
-    for (let [key, data] of _.toPairs(appDict)) {
-      if (data.bundleId === bundleId) {
-        appId = key;
-        break;
-      }
-    }
+    let appId = appIdForBundle(bundleId, appDict);
+
     // now we need to determine if we should pick a proxy for this instead
     if (appId) {
       log.debug(`Found app id key '${appId}' for bundle '${bundleId}'`);


### PR DESCRIPTION
Currently if there is not yet any app connected to a bundleId we zip through the retries (since there is nothing to retry. Use the default app instead.

Hoping this has some affect on https://github.com/appium/appium/issues/7587