### PR TITLE
Allow basic i-w-d-p functioning

### DIFF
--- a/lib/webkit-remote-debugger.js
+++ b/lib/webkit-remote-debugger.js
@@ -36,7 +36,21 @@ export default class WebKitRemoteDebugger extends RemoteDebugger {
   async pageArrayFromJson () {
     log.debug(`Getting WebKitRemoteDebugger pageArray: ${this.host}, ${this.port}`);
     let pageElementJSON = await this.getJsonFromUrl(this.host, this.port, '/json');
+    if (pageElementJSON[0].deviceId) {
+      log.debug(`Device JSON: ${simpleStringify(pageElementJSON)}`);
+
+      let devices = pageElementJSON.filter((device) => device.deviceId !== 'SIMULATOR');
+      if (devices.length > 1) {
+        log.debug(`Connected to ${devices.length} devices. ` +
+                  `Choosing the first, with udid '${devices[0].deviceId}'.`);
+      }
+      this.port = devices[0].url.split(':')[1];
+      log.debug(`Received notification that ios-webkit-debug-proxy is listening on port '${this.port}'`);
+
+      pageElementJSON = await this.getJsonFromUrl(this.host, this.port, '/json');
+    }
     log.debug(`Page element JSON: ${simpleStringify(pageElementJSON)}`);
+
     // Add elements to an array
     let newPageArray = pageElementJSON.map((pageObject) => {
       let urlArray = pageObject.webSocketDebuggerUrl.split('/').reverse();


### PR DESCRIPTION
If [ios-webkit-debug-proxy](https://github.com/google/ios-webkit-debug-proxy) is started as Google [recommends](https://github.com/google/ios-webkit-debug-proxy#start-the-proxy) it listens generically on the default port (9221) and chooses another port (sequentially through open ports) for each connected device and simulator.

The call, then, to `localhost:9221/json` produces a list of the devices connected.

Starting:
```
$ /usr/local/Cellar/ios-webkit-debug-proxy/1.7/bin/ios_webkit_debug_proxy
Listing devices on :9221
Connected :9223 to i(am)Phone (xxxxx)
Connected :9222 to SIMULATOR (SIMULATOR)
```
Hitting `localhost:9221/json`:
```
[{
   "deviceId": "SIMULATOR",
   "deviceName": "SIMULATOR",
   "url": "localhost:9222"
},{
   "deviceId": "xxxxx",
   "deviceName": "i(am)Phone",
   "url": "localhost:9223"
}]
```

While we recommend that a particular device and port are chosen when starting the proxy (using the `-c` flag), the basic functionality should at least be supported.

This PR assumes that there is only a single real device (sims are ignored) connected, otherwise whatever one is first in the list is used. If we wanted to make this better we could make the device udid get passed in at some point, so we could choose.

Addresses https://github.com/appium/appium/issues/6970