### PR TITLE
Move to logger from appium-support

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,5 @@
-import { getLogger } from 'appium-logger';
+import { logger } from 'appium-support';
 
-const log = getLogger('RemoteDebugger');
+const log = logger.getLogger('RemoteDebugger');
 
 export default log;

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   },
   "dependencies": {
     "appium-base-driver": "^2.0.0",
-    "appium-logger": "^2.1.0",
-    "appium-support": "^2.0.10",
+    "appium-support": "^2.4.0",
     "babel-runtime": "=5.8.24",
     "bluebird": "^3.4.7",
     "bplist-creator": "0.0.6",

--- a/test/helpers/remote-debugger-server.js
+++ b/test/helpers/remote-debugger-server.js
@@ -5,9 +5,9 @@ import bplistCreate from 'bplist-creator';
 import bplistParse from 'bplist-parser';
 import bufferpack from 'bufferpack';
 import Promise from 'bluebird';
-import { getLogger } from 'appium-logger';
+import { logger } from 'appium-support';
 
-const log = getLogger('RemoteDebugger');
+const log = logger.getLogger('RemoteDebugger');
 
 
 const DEVICE_INFO = {

--- a/test/helpers/webkit-remote-debugger-server.js
+++ b/test/helpers/webkit-remote-debugger-server.js
@@ -3,9 +3,9 @@
 import http from 'http';
 import Promise from 'bluebird';
 import ws from 'ws';
-import { getLogger } from 'appium-logger';
+import { logger } from 'appium-support';
 
-const log = getLogger('RemoteDebugger');
+const log = logger.getLogger('RemoteDebugger');
 let WebSocketServer = ws.Server;
 
 


### PR DESCRIPTION
Stop using the deprecated `appium-logger`.