### PR TITLE
Make webkit response timeout configurable

### DIFF
--- a/lib/webkit-remote-debugger.js
+++ b/lib/webkit-remote-debugger.js
@@ -2,7 +2,7 @@
 
 import log from './logger';
 import { errors } from 'appium-base-driver';
-import { RemoteDebugger, DEBUGGER_TYPES } from './remote-debugger';
+import { RemoteDebugger, DEBUGGER_TYPES, RPC_RESPONSE_TIMEOUT_MS } from './remote-debugger';
 import WebKitRpcClient from './webkit-rpc-client';
 import _ from 'lodash';
 import url from 'url';
@@ -14,12 +14,14 @@ export default class WebKitRemoteDebugger extends RemoteDebugger {
   constructor (opts = {}) {
     super(_.defaults({debuggerType: DEBUGGER_TYPES.webkit}, opts));
 
+    this.webkitResponseTimeout = opts.webkitResponseTimeout || RPC_RESPONSE_TIMEOUT_MS;
+
     // used to store callback types when sending requests
     this.dataMethods = {};
   }
 
   async connect (pageId) {
-    this.rpcClient = new WebKitRpcClient(this.host, this.port);
+    this.rpcClient = new WebKitRpcClient(this.host, this.port, this.webkitResponseTimeout);
     await this.rpcClient.connect(pageId);
   }
 

--- a/lib/webkit-rpc-client.js
+++ b/lib/webkit-rpc-client.js
@@ -9,11 +9,13 @@ import { simpleStringify } from './helpers';
 
 
 export default class WebKitRpcClient extends events.EventEmitter {
-  constructor (host, port = REMOTE_DEBUGGER_PORT) {
+  constructor (host, port = REMOTE_DEBUGGER_PORT, responseTimeout = RPC_RESPONSE_TIMEOUT_MS) {
     super();
 
     this.host = host;
     this.port = port;
+
+    this.responseTimeout = responseTimeout;
 
     this.curMsgId = 0;
 
@@ -71,6 +73,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
     let data = getRemoteCommand(command, _.defaults({connId: this.connId, senderId: this.senderId}, opts));
 
     log.debug(`Sending WebKit data: ${_.truncate(JSON.stringify(data), 50)}`);
+    log.debug(`Webkit response timeout: ${this.responseTimeout}`);
 
     this.curMsgId++;
     data.id = this.curMsgId;
@@ -99,7 +102,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
 
       // and pass along the result
       return res;
-    }).timeout(RPC_RESPONSE_TIMEOUT_MS);
+    }).timeout(this.responseTimeout);
   }
 
 


### PR DESCRIPTION
We timeout webkit requests after 5s currently, because sometimes they hang (see #43). But some systems might need more time (or less, I suppose), so make it configurable through a `webkitResponseTimeout` option, which will be an iOS capability.

Addresses: https://github.com/appium/appium/issues/7977