### PR TITLE
Allow alert handler to be passed in to url nav function

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -341,7 +341,7 @@ class RemoteDebugger extends events.EventEmitter {
     await this.execute(script);
   }
 
-  async pageLoad (startPageLoadMs, handleAlert) {
+  async pageLoad (startPageLoadMs, pageLoadVerifyHook) {
     let timeoutMs = 500;
     let start = startPageLoadMs || Date.now();
     log.debug('Page loaded, verifying whether ready');
@@ -364,8 +364,8 @@ class RemoteDebugger extends events.EventEmitter {
         return;
       }
 
-      if (_.isFunction(handleAlert)) {
-        await handleAlert();
+      if (_.isFunction(pageLoadVerifyHook)) {
+        await pageLoadVerifyHook();
       }
 
       let ready = await this.checkPageIsReady();
@@ -396,9 +396,9 @@ class RemoteDebugger extends events.EventEmitter {
     await this.waitForDom();
   }
 
-  async waitForDom (startPageLoadMs, handleAlert) {
+  async waitForDom (startPageLoadMs, pageLoadVerifyHook) {
     log.debug('Waiting for dom...');
-    await this.pageLoad(startPageLoadMs, handleAlert);
+    await this.pageLoad(startPageLoadMs, pageLoadVerifyHook);
   }
 
   async checkPageIsReady () {
@@ -422,7 +422,7 @@ class RemoteDebugger extends events.EventEmitter {
     return readyState === 'complete';
   }
 
-  async navToUrl (url, handleAlert) {
+  async navToUrl (url, pageLoadVerifyHook) {
     // no need to do this check when using webkit
     if (this.debuggerType === DEBUGGER_TYPES.webinspector) {
       let errors = checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
@@ -445,7 +445,7 @@ class RemoteDebugger extends events.EventEmitter {
     if (this.debuggerType === DEBUGGER_TYPES.webinspector) {
       await this.waitForFrameNavigated();
     }
-    await this.waitForDom(Date.now(), handleAlert);
+    await this.waitForDom(Date.now(), pageLoadVerifyHook);
   }
 
   async waitForFrameNavigated () {

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -22,6 +22,8 @@ const REMOTE_DEBUGGER_PORT = 27753;
 /* How many milliseconds to wait for webkit to return a response before timing out */
 const RPC_RESPONSE_TIMEOUT_MS = 5000;
 
+const PAGE_READY_TIMEOUT = 5000;
+
 
 class RemoteDebugger extends events.EventEmitter {
   /*
@@ -38,7 +40,7 @@ class RemoteDebugger extends events.EventEmitter {
     super();
 
     let {bundleId, platformVersion, debuggerType, useNewSafari, pageLoadMs,
-         host, port} = opts;
+         host, port, pageReadyTimeout} = opts;
 
     this.bundleId = bundleId;
     this.platformVersion = platformVersion;
@@ -51,6 +53,8 @@ class RemoteDebugger extends events.EventEmitter {
 
     this.host = host || 'localhost';
     this.port = port || REMOTE_DEBUGGER_PORT;
+
+    this.pageReadyTimeout = pageReadyTimeout || PAGE_READY_TIMEOUT;
   }
 
   setup () {
@@ -337,7 +341,7 @@ class RemoteDebugger extends events.EventEmitter {
     await this.execute(script);
   }
 
-  async pageLoad (startPageLoadMs) {
+  async pageLoad (startPageLoadMs, handleAlert) {
     let timeoutMs = 500;
     let start = startPageLoadMs || Date.now();
     log.debug('Page loaded, verifying whether ready');
@@ -358,6 +362,10 @@ class RemoteDebugger extends events.EventEmitter {
       if (!this.appIdKey) {
         log.debug('Not connected to an application. Ignoring page load');
         return;
+      }
+
+      if (_.isFunction(handleAlert)) {
+        await handleAlert();
       }
 
       let ready = await this.checkPageIsReady();
@@ -388,9 +396,9 @@ class RemoteDebugger extends events.EventEmitter {
     await this.waitForDom();
   }
 
-  async waitForDom (startPageLoadMs) {
+  async waitForDom (startPageLoadMs, handleAlert) {
     log.debug('Waiting for dom...');
-    await this.pageLoad(startPageLoadMs);
+    await this.pageLoad(startPageLoadMs, handleAlert);
   }
 
   async checkPageIsReady () {
@@ -399,13 +407,22 @@ class RemoteDebugger extends events.EventEmitter {
 
     log.debug('Checking document readyState');
     let readyCmd = '(function (){ return document.readyState; })()';
-    let readyState = await this.execute(readyCmd, true);
+    let readyState = 'loading';
+    try {
+      readyState = await Promise.resolve(this.execute(readyCmd, true)).timeout(this.pageReadyTimeout);
+    } catch (err) {
+      if (!(err instanceof Promise.TimeoutError)) {
+        throw err;
+      }
+      log.debug(`Page readiness check timed out after ${this.pageReadyTimeout}ms`);
+      return false;
+    }
     log.debug(`readyState was ${simpleStringify(readyState)}`);
 
     return readyState === 'complete';
   }
 
-  async navToUrl (url) {
+  async navToUrl (url, handleAlert) {
     // no need to do this check when using webkit
     if (this.debuggerType === DEBUGGER_TYPES.webinspector) {
       let errors = checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
@@ -428,7 +445,7 @@ class RemoteDebugger extends events.EventEmitter {
     if (this.debuggerType === DEBUGGER_TYPES.webinspector) {
       await this.waitForFrameNavigated();
     }
-    await this.waitForDom(Date.now());
+    await this.waitForDom(Date.now(), handleAlert);
   }
 
   async waitForFrameNavigated () {


### PR DESCRIPTION
1. Add timeout for page readiness check (and option to pass in the timeout, as `pageReadyTimeout` (in ms)).
2. Add optional async function parameter to `navToUrl` to handle any possible popup during url navigation. What this does is up to the calling code.