### PR TITLE
Add handler for starting/stopping JS console capture

### DIFF
--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -128,9 +128,9 @@ export default class RpcMessageHandler {
       }
     } else if (dataKey.method === 'Page.loadEventFired') {
       await this.specialHandlers.pageLoad();
-    } else if (dataKey.method === 'Timeline.eventRecorded') {
+    } else if (dataKey.method === 'Timeline.eventRecorded' && _.isFunction(this.timelineEventHandler)) {
       this.timelineEventHandler(dataKey.params.record);
-    } else if (dataKey.method === 'Console.messageAdded') {
+    } else if (dataKey.method === 'Console.messageAdded' && _.isFunction(this.consoleLogEventHandler)) {
       this.consoleLogEventHandler(dataKey.params.message);
     } else if (_.isFunction(this.dataHandlers[msgId])) {
       log.debug('Found data handler for response');

--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -29,6 +29,10 @@ export default class RpcMessageHandler {
     this.timelineEventHandler = timelineEventHandler;
   }
 
+  setConsoleLogEventHandler (consoleLogEventHandler) {
+    this.consoleLogEventHandler = consoleLogEventHandler;
+  }
+
   hasErrorHandler (key) {
     return _.has(this.errorHandlers, key);
   }
@@ -126,6 +130,8 @@ export default class RpcMessageHandler {
       await this.specialHandlers.pageLoad();
     } else if (dataKey.method === 'Timeline.eventRecorded') {
       this.timelineEventHandler(dataKey.params.record);
+    } else if (dataKey.method === 'Console.messageAdded') {
+      this.consoleLogEventHandler(dataKey.params.message);
     } else if (_.isFunction(this.dataHandlers[msgId])) {
       log.debug('Found data handler for response');
       // we will either get back a result object that has a result.value

--- a/lib/remote-debugger-rpc-client.js
+++ b/lib/remote-debugger-rpc-client.js
@@ -229,7 +229,11 @@ export default class RemoteDebuggerRpcClient {
         log.error(msg);
         reject(new Error(msg));
       }
-    }).finally(() => {
+    })
+    .catch((err) => {
+      log.error(`Error sending RPC message to remote debugger: ${err.message}`);
+    })
+    .finally(() => {
       // remove this listener, so we don't exhaust the system
       this.socket.removeListener('error', onSocketError);
     });
@@ -327,5 +331,10 @@ export default class RemoteDebuggerRpcClient {
   setTimelineEventHandler (timelineEventHandler) {
     this.timelineEventHandler = timelineEventHandler;
     this.messageHandler.setTimelineEventHandler(timelineEventHandler);
+  }
+
+  setConsoleLogEventHandler (consoleEventHandler) {
+    this.consoleEventHandler = consoleEventHandler;
+    this.messageHandler.setConsoleLogEventHandler(consoleEventHandler);
   }
 }

--- a/lib/remote-debugger-rpc-client.js
+++ b/lib/remote-debugger-rpc-client.js
@@ -230,9 +230,6 @@ export default class RemoteDebuggerRpcClient {
         reject(new Error(msg));
       }
     })
-    .catch((err) => {
-      log.error(`Error sending RPC message to remote debugger: ${err.message}`);
-    })
     .finally(() => {
       // remove this listener, so we don't exhaust the system
       this.socket.removeListener('error', onSocketError);

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -501,6 +501,25 @@ class RemoteDebugger extends events.EventEmitter {
     });
   }
 
+  async startConsole (fn) {
+    log.debug('Starting to listen for JavaScript console');
+    this.rpcClient.setConsoleLogEventHandler(fn);
+    return await this.rpcClient.send('startConsole', {
+      appIdKey: this.appIdKey,
+      pageIdKey: this.pageIdKey,
+      debuggerType: this.debuggerType
+    });
+  }
+
+  async stopConsole () {
+    log.debug('Stopping to listen for JavaScript console');
+    await this.rpcClient.send('stopConsole', {
+      appIdKey: this.appIdKey,
+      pageIdKey: this.pageIdKey,
+      debuggerType: this.debuggerType
+    });
+  }
+
   async execute (command, override) {
     // if the page is not loaded yet, wait for it
     if (this.pageLoading && !override) {

--- a/lib/remote-messages.js
+++ b/lib/remote-messages.js
@@ -86,6 +86,16 @@ function stopTimeline (connId, senderId, appIdKey, pageIdKey, debuggerType) {
                          pageIdKey, debuggerType);
 }
 
+function startConsole (connId, senderId, appIdKey, pageIdKey, debuggerType) {
+  return command('Console.enable', {}, appIdKey, connId, senderId,
+                         pageIdKey, debuggerType);
+}
+
+function stopConsole (connId, senderId, appIdKey, pageIdKey, debuggerType) {
+  return command('Console.disable', {}, appIdKey, connId, senderId,
+                         pageIdKey, debuggerType);
+}
+
 
 /*
  * Internal functions
@@ -182,6 +192,14 @@ export default function getRemoteCommand (command, opts) {
       break;
     case 'stopTimeline':
       cmd = stopTimeline(opts.connId, opts.senderId, opts.appIdKey,
+              opts.pageIdKey, opts.debuggerType);
+      break;
+    case 'startConsole':
+      cmd = startConsole(opts.connId, opts.senderId, opts.appIdKey,
+              opts.pageIdKey, opts.debuggerType);
+      break;
+    case 'stopConsole':
+      cmd = stopConsole(opts.connId, opts.senderId, opts.appIdKey,
               opts.pageIdKey, opts.debuggerType);
       break;
     default:

--- a/lib/webkit-rpc-client.js
+++ b/lib/webkit-rpc-client.js
@@ -109,9 +109,14 @@ export default class WebKitRpcClient extends events.EventEmitter {
 
 
   receive (data) {
-    log.debug(`Receiving WebKit data: ${_.truncate(data, DATA_LOG_LENGTH)}`);
+    log.debug(`Receiving WebKit data: '${_.truncate(data, DATA_LOG_LENGTH)}'`);
 
     data = JSON.parse(data);
+
+    if (!data) {
+      log.warn(`No parseable data found`);
+      return;
+    }
 
     // we can get an error, or we can get a response that is an error
     if (data.wasThrown || data.result.wasThrown) {
@@ -188,10 +193,5 @@ export default class WebKitRpcClient extends events.EventEmitter {
   setTimelineEventHandler (timelineEventHandler) {
     this.timelineEventHandler = timelineEventHandler;
     this.messageHandler.setTimelineEventHandler(timelineEventHandler);
-  }
-
-  setConsoleLogEventHandler (consoleEventHandler) {
-    this.consoleEventHandler = consoleEventHandler;
-    this.messageHandler.setConsoleLogEventHandler(consoleEventHandler);
   }
 }

--- a/lib/webkit-rpc-client.js
+++ b/lib/webkit-rpc-client.js
@@ -189,4 +189,9 @@ export default class WebKitRpcClient extends events.EventEmitter {
     this.timelineEventHandler = timelineEventHandler;
     this.messageHandler.setTimelineEventHandler(timelineEventHandler);
   }
+
+  setConsoleLogEventHandler (consoleEventHandler) {
+    this.consoleEventHandler = consoleEventHandler;
+    this.messageHandler.setConsoleLogEventHandler(consoleEventHandler);
+  }
 }


### PR DESCRIPTION
Add methods `startConsole` and `stopConsole` to begin and end capture of the JS console from the connected app.

The callback sent to `startConsole` is passed an entry whenever a log line is generated on the device. The entry for something like `console.log('HI ALL');` on the device would be:
```
{ source: 'console-api',
  level: 'log',
  text: 'HI ALL',
  type: 'log',
  line: 8,
  column: 16,
  url: 'http://localhost:4994/test/guinea-pig',
  repeatCount: 1,
  parameters: [ { type: 'string', value: 'HI ALL' } ],
  stackTrace:
   [ { functionName: 'global code',
       url: 'http://localhost:4994/test/guinea-pig',
       scriptId: '1',
       lineNumber: 8,
       columnNumber: 16 } ] }
```