### PR TITLE
Patch to try to recoonect appium-remote-client to ios_webkit_debug_proxy

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -341,7 +341,16 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   async executeAtom (atom, args, frames) {
-    if (!this.rpcClient.connected) throw new Error('Remote debugger is not connected'); // eslint-disable-line curly
+    if (!this.rpcClient.connected) {
+      log.debug('The remote debugger is not connected. Trying to connect again');
+
+      // This method is called on the subclass WebKitRemoteDebugger
+      await this.connect(this.pageIdKey);
+
+      if (!this.rpcClient.connected) {
+        throw new Error('Remote debugger is not connected'); // eslint-disable-line curly
+      }
+    }
 
     let script = await getScriptForAtom(atom, args, frames);
 


### PR DESCRIPTION
- pageId is retrieved when first context/window is set
Check - https://github.com/appium/appium-ios-driver/blob/0ccc26ed8d7eb96917e1755e430d07580104bad0/lib/commands/context.js#L83

- pageId is set for the remote connection via request `ws://${this.host}:${this.port}/devtools/page/${pageId}`
check - lib/webkit-rpc-client.js line: 35