### PR TITLE
Remove redundant async modifier

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -622,7 +622,7 @@ class RemoteDebugger extends events.EventEmitter {
     return res.hasOwnProperty('value') ? res.value : res;
   }
 
-  async allowNavigationWithoutReload (allow = true) {
+  allowNavigationWithoutReload (allow = true) {
     this.rpcClient.allowNavigationWithoutReload(allow);
   }
 }


### PR DESCRIPTION
This method is not asynchronous and also the client code (for example inside ios driver) does not add `await` while invoking it.