### PR TITLE
Add methods for getting the cookies and delete a particular cookie

### DIFF
--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -85,8 +85,8 @@ export default class RpcMessageHandler {
   }
 
   async handleDataMessage (plist) {
-    let dataKey = JSON.parse(plist.__argument.WIRMessageDataKey.toString('utf8'));
-    let msgId = dataKey.id;
+    const dataKey = JSON.parse(plist.__argument.WIRMessageDataKey.toString('utf8'));
+    const msgId = (dataKey.id || '').toString();
     let result = dataKey.result;
     let error = dataKey.error || null;
 
@@ -98,9 +98,6 @@ export default class RpcMessageHandler {
       error = new Error(message);
     }
 
-    if (!_.isNull(msgId) && !_.isUndefined(msgId)) {
-      msgId = msgId.toString();
-    }
     if (error) {
       if (this.hasErrorHandler(msgId)) {
         this.errorHandlers[msgId](error);

--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -84,8 +84,17 @@ export default class RpcMessageHandler {
     }
   }
 
+  parseDataKey (plist) {
+    try {
+      return JSON.parse(plist.__argument.WIRMessageDataKey.toString('utf8'));
+    } catch (err) {
+      log.error(`Unparseable message data: ${plist.__argument.WIRMessageDataKey.toString('utf8')}`);
+      throw new Error(`Unable to parse message data: ${err.message}`);
+    }
+  }
+
   async handleDataMessage (plist) {
-    const dataKey = JSON.parse(plist.__argument.WIRMessageDataKey.toString('utf8'));
+    const dataKey = this.parseDataKey(plist);
     const msgId = (dataKey.id || '').toString();
     let result = dataKey.result;
     let error = dataKey.error || null;
@@ -134,7 +143,7 @@ export default class RpcMessageHandler {
     } else if (dataKey.method === 'Console.messageAdded' && _.isFunction(this.consoleLogEventHandler)) {
       this.consoleLogEventHandler(dataKey.params.message);
     } else if (dataKey.method && dataKey.method.startsWith('Network.') && _.isFunction(this.networkLogEventHandler)) {
-      this.networkLogEventHandler(dataKey.params);
+      this.networkLogEventHandler(dataKey.method, dataKey.params);
     } else if (_.isFunction(this.dataHandlers[msgId])) {
       log.debug('Found data handler for response');
       // we will either get back a result object that has a result.value

--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -88,7 +88,7 @@ export default class RpcMessageHandler {
     try {
       return JSON.parse(plist.__argument.WIRMessageDataKey.toString('utf8'));
     } catch (err) {
-      log.error(`Unparseable message data: ${plist.__argument.WIRMessageDataKey.toString('utf8')}`);
+      log.error(`Unparseable message data: ${_.truncate(JSON.stringify(plist), {length: 100})}`);
       throw new Error(`Unable to parse message data: ${err.message}`);
     }
   }

--- a/lib/remote-debugger-rpc-client.js
+++ b/lib/remote-debugger-rpc-client.js
@@ -228,8 +228,14 @@ export default class RemoteDebuggerRpcClient {
         // keep track of the messages coming and going using
         // a simple sequential id
         this.curMsgId++;
-        this.setDataMessageHandler(this.curMsgId.toString(), reject, (value) => {
-          let msg = _.truncate(_.isString(value) ? value : JSON.stringify(value), {length: 50});
+
+        const errorHandler = function (err) {
+          const msg = `Remote debugger error with code '${err.code}': ${err.message}`;
+          reject(new Error(msg));
+        };
+
+        this.setDataMessageHandler(this.curMsgId.toString(), errorHandler, (value) => {
+          const msg = _.truncate(_.isString(value) ? value : JSON.stringify(value), {length: 50});
           log.debug(`Received data response from socket send: '${msg}'`);
           log.debug(`Original command: ${command}`);
           resolve(value);

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -630,6 +630,27 @@ class RemoteDebugger extends events.EventEmitter {
   allowNavigationWithoutReload (allow = true) {
     this.rpcClient.allowNavigationWithoutReload(allow);
   }
+
+  async getCookies (urls) {
+    log.debug('Getting network cookies');
+    return await this.rpcClient.send('getCookies', {
+      appIdKey: this.appIdKey,
+      pageIdKey: this.pageIdKey,
+      debuggerType: this.debuggerType,
+      urls,
+    });
+  }
+
+  async deleteCookie (cookieName, url) {
+    log.debug(`Deleting cookie '${cookieName}' on '${url}'`);
+    return await this.rpcClient.send('deleteCookie', {
+      appIdKey: this.appIdKey,
+      pageIdKey: this.pageIdKey,
+      debuggerType: this.debuggerType,
+      cookieName,
+      url,
+    });
+  }
 }
 
 // event emitted publically

--- a/lib/remote-messages.js
+++ b/lib/remote-messages.js
@@ -106,6 +106,16 @@ function stopNetwork (connId, senderId, appIdKey, pageIdKey, debuggerType) {
                          pageIdKey, debuggerType);
 }
 
+function getCookies (connId, senderId, appIdKey, pageIdKey, debuggerType, urls) {
+  return command('Page.getCookies', {urls}, appIdKey, connId, senderId,
+                         pageIdKey, debuggerType);
+}
+
+function deleteCookie (connId, senderId, appIdKey, pageIdKey, debuggerType, cookieName, url) {
+  return command('Page.deleteCookie', {cookieName, url}, appIdKey, connId, senderId,
+                         pageIdKey, debuggerType);
+}
+
 
 /*
  * Internal functions
@@ -219,6 +229,14 @@ export default function getRemoteCommand (command, opts) {
     case 'stopNetwork':
       cmd = stopNetwork(opts.connId, opts.senderId, opts.appIdKey,
               opts.pageIdKey, opts.debuggerType);
+      break;
+    case 'getCookies':
+      cmd = getCookies(opts.connId, opts.senderId, opts.appIdKey,
+              opts.pageIdKey, opts.debuggerType, opts.urls);
+      break;
+    case 'deleteCookie':
+      cmd = deleteCookie(opts.connId, opts.senderId, opts.appIdKey,
+              opts.pageIdKey, opts.debuggerType, opts.cookieName, opts.url);
       break;
     default:
       throw new Error(`Unknown command: ${command}`);

--- a/test/unit/remote-debugger-specs.js
+++ b/test/unit/remote-debugger-specs.js
@@ -62,6 +62,8 @@ describe('RemoteDebugger', function () {
   }
 
   describe('#connect', function () {
+    this.retries(3);
+
     let server = new RemoteDebuggerServer();
 
     beforeEach(async function () {
@@ -72,7 +74,9 @@ describe('RemoteDebugger', function () {
     });
 
     it('should return application information', async function () {
+      let spy = sinon.spy(rd, 'setConnectionKey');
       (await rd.connect()).should.eql(APP_INFO);
+      spy.calledOnce.should.be.true;
     });
     it('should set the connection key', async function () {
       let spy = sinon.spy(rd, 'setConnectionKey');


### PR DESCRIPTION
Safari uses the deprecated [Page.getCookies](https://chromedevtools.github.io/devtools-protocol/tot/Page#method-getCookies) and [Page.deleteCookie](https://chromedevtools.github.io/devtools-protocol/tot/Page#method-deleteCookie) methods, rather than those from the [Network domain](https://chromedevtools.github.io/devtools-protocol/tot/Network). This means that it also does not have access to setting cookies.