### PR TITLE
Switch from uuid to uuid-js

### DIFF
--- a/lib/remote-debugger-rpc-client.js
+++ b/lib/remote-debugger-rpc-client.js
@@ -5,7 +5,7 @@ import bplistParse from 'bplist-parser';
 import bufferpack from 'bufferpack';
 import Promise from 'bluebird';
 import { REMOTE_DEBUGGER_PORT } from './remote-debugger';
-import uuid from 'uuid';
+import UUID from 'uuid-js';
 import net from 'net';
 import RpcMessageHandler from './remote-debugger-message-handler';
 import getRemoteCommand from './remote-messages';
@@ -31,8 +31,8 @@ export default class RemoteDebuggerRpcClient {
 
     this.socket = null;
     this.connected = false;
-    this.connId = uuid.v4();
-    this.senderId = uuid.v4();
+    this.connId = UUID.create().toString();
+    this.senderId = UUID.create().toString();
     this.curMsgId = 0;
     this.received = Buffer.alloc(0);
     this.readPos = 0;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
     "source-map-support": "^0.5.5",
-    "uuid": "^3.0.1",
+    "uuid-js": "^0.7.5",
     "ws": "^6.0.0"
   },
   "scripts": {


### PR DESCRIPTION
In Appium's packages, we use [uuid-js](https://www.npmjs.com/package/uuid-js) everywhere but here, so change here so we're only supporting a single package
```
$ npm ls uuid
appium@1.8.0-beta /Users/isaacmurchie/code/appium
├─┬ appium-ios-driver@2.5.1
│ └─┬ appium-remote-debugger@3.18.0
│   └── uuid@3.3.2  deduped
├─┬ request@2.87.0
│ └── uuid@3.3.2
└─┬ wd@1.10.1
  └─┬ request@2.85.0
    └── uuid@3.3.2  deduped

$npm ls uuid-js
appium@1.8.0-beta /Users/isaacmurchie/code/appium
├─┬ appium-base-driver@3.1.0
│ └── uuid-js@0.7.5
├─┬ appium-espresso-driver@1.0.0-beta.11
│ └─┬ appium-base-driver@2.33.0
│   └── uuid-js@0.7.5  deduped
├─┬ appium-ios-driver@2.5.1
│ └── uuid-js@0.7.5  deduped
├─┬ appium-mac-driver@1.2.0
│ └─┬ appium-base-driver@2.33.0
│   └── uuid-js@0.7.5  deduped
├─┬ appium-tizen-driver@1.0.0-beta
│ └─┬ appium-base-driver@2.33.0
│   └── uuid-js@0.7.5  deduped
├─┬ appium-windows-driver@1.2.0
│ └─┬ appium-base-driver@2.33.0
│   └── uuid-js@0.7.5  deduped
├─┬ appium-xcuitest-driver@2.87.0
│ └── uuid-js@0.7.5  deduped
└─┬ appium-youiengine-driver@1.0.18
  └─┬ appium-base-driver@2.33.0
    └── uuid-js@0.7.5  deduped
```