### PR TITLE
Change the way errors are handled in catch

### DIFF
--- a/lib/webkit-rpc-client.js
+++ b/lib/webkit-rpc-client.js
@@ -94,9 +94,11 @@ export default class WebKitRpcClient extends events.EventEmitter {
           reject(new Error(error));
         }
       });
-    }).catch(WebKitRPCWarning, (e) => {
-      log.info(e.message);
-      log.info('Doing nothing');
+    }).catch((e) => {
+      if (e.constructor.name !== WebKitRPCWarning.name) {
+        throw e;
+      }
+      log.warn(e.message);
       return Promise.resolve(null);
     }).finally((res) => {
       // no need to hold onto anything


### PR DESCRIPTION
Perhaps bluebird cannot properly do its job, so we try to distinguish the actual error class it on our own