### PR TITLE
Add JS garbage collection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import { RemoteDebugger, DEBUGGER_TYPES, REMOTE_DEBUGGER_PORT } from './lib/remote-debugger';
 import WebKitRemoteDebugger from './lib/webkit-remote-debugger';
 
-export { RemoteDebugger, DEBUGGER_TYPES, REMOTE_DEBUGGER_PORT, WebKitRemoteDebugger };
 
+export { RemoteDebugger, DEBUGGER_TYPES, REMOTE_DEBUGGER_PORT, WebKitRemoteDebugger };

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -51,6 +51,7 @@ class RemoteDebugger extends events.EventEmitter {
       socketPath,
       pageReadyTimeout = PAGE_READY_TIMEOUT,
       remoteDebugProxy,
+      garbageCollectOnExecute = true,
     } = opts;
 
     this.bundleId = bundleId;
@@ -61,6 +62,7 @@ class RemoteDebugger extends events.EventEmitter {
       this.pageLoadMs = pageLoadMs;
       log.debug(`useNewSafari --> ${this.useNewSafari}`);
     }
+    this.garbageCollectOnExecute = garbageCollectOnExecute;
 
     this.host = host;
     this.port = port;
@@ -592,7 +594,9 @@ class RemoteDebugger extends events.EventEmitter {
       if (errors) throw new Error(errors); // eslint-disable-line curly
     }
 
-    await this.garbageCollect();
+    if (this.garbageCollectOnExecute) {
+      await this.garbageCollect();
+    }
 
     log.debug(`Sending javascript command ${_.truncate(command, {length: 50})}`);
     let res = await this.rpcClient.send('sendJSCommand', {
@@ -609,7 +613,9 @@ class RemoteDebugger extends events.EventEmitter {
     let errors = checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
     if (errors) throw new Error(errors); // eslint-disable-line curly
 
-    await this.garbageCollect();
+    if (this.garbageCollectOnExecute) {
+      await this.garbageCollect();
+    }
 
     log.debug('Calling javascript function');
     let res = await this.rpcClient.send('callJSFunction', {

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -23,6 +23,8 @@ const RPC_RESPONSE_TIMEOUT_MS = 5000;
 
 const PAGE_READY_TIMEOUT = 5000;
 
+const RESPONSE_LOG_LENGTH = 100;
+
 
 class RemoteDebugger extends events.EventEmitter {
   /*
@@ -362,7 +364,7 @@ class RemoteDebugger extends events.EventEmitter {
     let script = await getScriptForAtom(atom, args, frames);
 
     let value = await this.execute(script, true);
-    log.debug(`Received result for atom '${atom}' execution: ${simpleStringify(value)}`);
+    log.debug(`Received result for atom '${atom}' execution: ${_.truncate(simpleStringify(value), {length: RESPONSE_LOG_LENGTH})}`);
     return value;
   }
 
@@ -444,7 +446,7 @@ class RemoteDebugger extends events.EventEmitter {
     if (errors) throw new Error(errors); // eslint-disable-line curly
 
     log.debug('Checking document readyState');
-    let readyCmd = '(function (){ return document.readyState; })()';
+    const readyCmd = '(function (){ return document.readyState; })()';
     let readyState = 'loading';
     try {
       readyState = await Promise.resolve(this.execute(readyCmd, true)).timeout(this.pageReadyTimeout);
@@ -590,6 +592,8 @@ class RemoteDebugger extends events.EventEmitter {
       if (errors) throw new Error(errors); // eslint-disable-line curly
     }
 
+    await this.garbageCollect();
+
     log.debug(`Sending javascript command ${_.truncate(command, {length: 50})}`);
     let res = await this.rpcClient.send('sendJSCommand', {
       command,
@@ -604,6 +608,8 @@ class RemoteDebugger extends events.EventEmitter {
   async callFunction (objId, fn, args) {
     let errors = checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
     if (errors) throw new Error(errors); // eslint-disable-line curly
+
+    await this.garbageCollect();
 
     log.debug('Calling javascript function');
     let res = await this.rpcClient.send('callJSFunction', {
@@ -620,7 +626,7 @@ class RemoteDebugger extends events.EventEmitter {
 
   convertResult (res) {
     if (_.isUndefined(res)) {
-      throw new Error(`Did not get OK result from remote debugger. Result was: ${simpleStringify(res)}`);
+      throw new Error(`Did not get OK result from remote debugger. Result was: ${_.truncate(simpleStringify(res), {length: RESPONSE_LOG_LENGTH})}`);
     } else if (_.isString(res)) {
       try {
         res = JSON.parse(res);
@@ -664,6 +670,24 @@ class RemoteDebugger extends events.EventEmitter {
       debuggerType: this.debuggerType,
       cookieName,
       url,
+    });
+  }
+
+  async garbageCollect () {
+    log.debug(`Garbage collecting`);
+    const errors = checkParams({
+      appIdKey: this.appIdKey,
+      pageIdKey: this.pageIdKey,
+    });
+    if (errors) {
+      log.debug(`Unable to collect garbage at this time`);
+    }
+    await this.rpcClient.send('garbageCollect', {
+      appIdKey: this.appIdKey,
+      pageIdKey: this.pageIdKey,
+      debuggerType: this.debuggerType
+    }).catch(function (err) {
+      log.debug(`Unable to collect garbage: ${err.message}`);
     });
   }
 }

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -688,11 +688,14 @@ class RemoteDebugger extends events.EventEmitter {
     if (errors) {
       log.debug(`Unable to collect garbage at this time`);
     }
+
     await this.rpcClient.send('garbageCollect', {
       appIdKey: this.appIdKey,
       pageIdKey: this.pageIdKey,
       debuggerType: this.debuggerType
-    }).catch(function (err) {
+    }).then(function () { // eslint-disable-line promise/prefer-await-to-then
+      log.debug(`Garbage collection successful`);
+    }).catch(function (err) { // eslint-disable-line promise/prefer-await-to-callbacks
       log.debug(`Unable to collect garbage: ${err.message}`);
     });
   }

--- a/lib/remote-messages.js
+++ b/lib/remote-messages.js
@@ -116,6 +116,11 @@ function deleteCookie (connId, senderId, appIdKey, pageIdKey, debuggerType, cook
                          pageIdKey, debuggerType);
 }
 
+function garbageCollect (connId, senderId, appIdKey, pageIdKey, debuggerType) {
+  return command('Heap.gc', {}, appIdKey, connId, senderId,
+                         pageIdKey, debuggerType);
+}
+
 
 /*
  * Internal functions
@@ -237,6 +242,10 @@ export default function getRemoteCommand (command, opts) {
     case 'deleteCookie':
       cmd = deleteCookie(opts.connId, opts.senderId, opts.appIdKey,
               opts.pageIdKey, opts.debuggerType, opts.cookieName, opts.url);
+      break;
+    case 'garbageCollect':
+      cmd = garbageCollect(opts.connId, opts.senderId, opts.appIdKey,
+              opts.pageIdKey, opts.debuggerType);
       break;
     default:
       throw new Error(`Unknown command: ${command}`);

--- a/test/helpers/remote-debugger-server.js
+++ b/test/helpers/remote-debugger-server.js
@@ -164,16 +164,7 @@ class RemoteDebuggerServer {
     let plistData = JSON.parse(plist.__argument.WIRSocketDataKey.toString('utf8'));
 
     let result = {};
-    if (this.dataResponseError) {
-      result = {
-        result: {
-          type: 'string',
-          value: this.dataResponseError
-        },
-        wasThrown: true
-      };
-      this.dataResponseError = null;
-    } else if (this.dataResponseValue.length > 0) {
+    if (this.dataResponseValue.length > 0) {
       // add the response value
       result = {
         result: {
@@ -182,6 +173,15 @@ class RemoteDebuggerServer {
         },
         wasThrown: false
       };
+    } else if (this.dataResponseError) {
+      result = {
+        result: {
+          type: 'string',
+          value: this.dataResponseError
+        },
+        wasThrown: true
+      };
+      this.dataResponseError = null;
     }
 
     let dataKey = {

--- a/test/unit/remote-debugger-specs.js
+++ b/test/unit/remote-debugger-specs.js
@@ -54,8 +54,11 @@ describe('RemoteDebugger', function () {
       spy.callCount.should.equal(num);
     });
   }
-  function confirmRemoteDebuggerErrorHandling (server, fn, args, errText = 'remote debugger error') {
+  function confirmRemoteDebuggerErrorHandling (server, fn, args, gc = false, errText = 'remote debugger error') {
     it('should handle error from remote debugger', async function () {
+      if (gc) {
+        server.setDataResponseValue('');
+      }
       server.setDataResponseError(errText);
       await rd[fn](...args).should.be.rejectedWith(errText);
     });
@@ -101,7 +104,7 @@ describe('RemoteDebugger', function () {
   }));
 
   describe('#selectApp', withConnectedServer(rds, (server) => {
-    confirmRpcSend('selectApp', []);
+    confirmRpcSend('selectApp', [], 1);
     it('should be able to handle an app change event before selection', async function () {
       this.timeout(10000);
 
@@ -160,42 +163,45 @@ describe('RemoteDebugger', function () {
   }));
 
   describe('#selectPage', withConnectedServer(rds, (server) => {
-    confirmRpcSend('selectPage', [1, 2, true], 3);
-    confirmRpcSend('selectPage', [1, 2, false], 4);
+    confirmRpcSend('selectPage', [1, 2, true], 4);
+    confirmRpcSend('selectPage', [1, 2, false], 6);
     confirmRemoteDebuggerErrorHandling(server, 'selectPage', [1, 2]);
   }));
 
   describe('#execute', withConnectedServer(rds, () => {
     requireAppIdKey('execute', []);
     requirePageIdKey('execute', []);
-    confirmRpcSend('execute', ['document.getElementsByTagName("html")[0].outerHTML']);
+    confirmRpcSend('execute', ['document.getElementsByTagName("html")[0].outerHTML'], 2);
   }));
 
   describe('#checkPageIsReady', withConnectedServer(rds, (server) => {
     requireAppIdKey('checkPageIsReady', []);
-    confirmRpcSend('checkPageIsReady', []);
+    confirmRpcSend('checkPageIsReady', [], 2);
     it('should return true when server responds with complete', async function () {
+      server.setDataResponseValue('');
       server.setDataResponseValue('complete');
       let ready = await rd.checkPageIsReady();
       ready.should.be.true;
     });
     it('should return false when server responds with loading', async function () {
+      server.setDataResponseValue('');
       server.setDataResponseValue('loading');
       let ready = await rd.checkPageIsReady();
       ready.should.be.false;
     });
-    confirmRemoteDebuggerErrorHandling(server, 'checkPageIsReady', []);
+    confirmRemoteDebuggerErrorHandling(server, 'checkPageIsReady', [], true);
   }));
 
   describe('#executeAtom', withConnectedServer(rds, (server) => {
-    confirmRpcSend('executeAtom', ['find_element', [], []]);
+    confirmRpcSend('executeAtom', ['find_element', [], []], 2);
     it('should execute the atom', async function () {
       let sentElement = {ELEMENT: ':wdc:1435784377545'};
+      server.setDataResponseValue('');
       server.setDataResponseValue(sentElement);
       let element = await rd.executeAtom('find_element', [], []);
       element.should.eql(sentElement);
     });
-    confirmRemoteDebuggerErrorHandling(server, 'executeAtom', ['find_element', [], []]);
+    confirmRemoteDebuggerErrorHandling(server, 'executeAtom', ['find_element', [], []], true);
   }));
 
   describe('timeline', withConnectedServer(rds, () => {
@@ -232,13 +238,13 @@ describe('RemoteDebugger', function () {
 
     requireAppIdKey('navToUrl', [url]);
     requirePageIdKey('navToUrl', [url]);
-    confirmRpcSend('navToUrl', [url], 2);
+    confirmRpcSend('navToUrl', [url], 3);
   }));
 
   describe('#callFunction', withConnectedServer(rds, () => {
     requireAppIdKey('callFunction', []);
     requirePageIdKey('callFunction', []);
-    confirmRpcSend('callFunction', []);
+    confirmRpcSend('callFunction', [], 2);
   }));
 
   describe('#pageLoad', withConnectedServer(rds, (server) => {
@@ -259,7 +265,9 @@ describe('RemoteDebugger', function () {
       rd.pageLoadMs = 10000;
 
       // make the server respond first with random status, then with complete
+      server.setDataResponseValue('');
       server.setDataResponseValue('loading');
+      server.setDataResponseValue('');
       server.setDataResponseValue('complete');
 
       let spy = sinon.spy(rd, 'checkPageIsReady');

--- a/test/unit/remote-debugger-specs.js
+++ b/test/unit/remote-debugger-specs.js
@@ -20,13 +20,14 @@ describe('RemoteDebugger', function () {
   let rd;
   let rds = [];
   beforeEach(function () {
-    let opts = {
+    const opts = {
       bundleId: APP_INFO['PID:42'].bundleId,
       platformVersion: '8.3',
       useNewSafari: true,
       pageLoadMs: 5000,
       port: 27754,
-      debuggerType: DEBUGGER_TYPES.webinspector};
+      debuggerType: DEBUGGER_TYPES.webinspector,
+    };
     rd = new RemoteDebugger(opts);
     rds[0] = rd;
   });


### PR DESCRIPTION
Modeled after #93, which was closed for some reason. Add an option, `garbageCollectOnExecute`, to turn off.