### PR TITLE
Avoid "Cannot read property 'promise' of undefined" error while checking for app

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -253,6 +253,10 @@ class RemoteDebugger extends events.EventEmitter {
           dictLoop: for (const appDict of _.values(this.appDict)) {
             if (found) break; // eslint-disable-line curly
 
+            if (!appDict || !appDict.pageDict) {
+              continue;
+            }
+
             // if the page dictionary has not been loaded yet from the web
             // inspector, wait for it or time out after 10s
             if (appDict.pageDict.promise) {


### PR DESCRIPTION
https://gist.github.com/Joskony/12233f06431430fdb6be6bcf3650139f#file-appium-log-L612