### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-node_modules
-*.log
-tmp
-coverage
-atoms_build_dir
-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,17 @@ matrix:
       node_js: "8"
       env: COVERALLS=1
     - osx_image: xcode8.3
-      node_js: "6"
+      node_js: "10"
 
     - osx_image: xcode9.4
       node_js: "8"
     - osx_image: xcode9.4
-      node_js: "6"
+      node_js: "10"
+
+    - osx_image: xcode10
+      node_js: "8"
+    - osx_image: xcode10
+      node_js: "10"
 script:
   - npm test
 after_success:

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -13,8 +13,9 @@ const WEB_CONTENT_BUNDLE_ID = 'com.apple.WebKit.WebContent';
  */
 function appInfoFromDict (dict) {
   let id = dict.WIRApplicationIdentifierKey;
-  let isProxy = _.isString(dict.WIRIsApplicationProxyKey) ?
-                  dict.WIRIsApplicationProxyKey.toLowerCase() === 'true' : dict.WIRIsApplicationProxyKey;
+  let isProxy = _.isString(dict.WIRIsApplicationProxyKey)
+    ? dict.WIRIsApplicationProxyKey.toLowerCase() === 'true'
+    : dict.WIRIsApplicationProxyKey;
   let entry = {
     id,
     isProxy,
@@ -210,5 +211,8 @@ function deferredPromise () {
   };
 }
 
-export { appInfoFromDict, pageArrayFromDict, getDebuggerAppKey, getPossibleDebuggerAppKeys, checkParams,
-         wrapScriptForFrame, getScriptForAtom, simpleStringify, deferredPromise };
+export {
+  appInfoFromDict, pageArrayFromDict, getDebuggerAppKey,
+  getPossibleDebuggerAppKeys, checkParams, wrapScriptForFrame, getScriptForAtom,
+  simpleStringify, deferredPromise,
+};

--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -39,7 +39,7 @@ function onAppConnect (dict) {
   this.updateAppsWithDict(dict);
 }
 
-async function onAppDisconnect (dict) {
+function onAppDisconnect (dict) {
   let appIdKey = dict.WIRApplicationIdentifierKey;
   log.debug(`Application '${appIdKey}' disconnected. Removing from app dictionary.`);
   log.debug(`Current app is ${this.appIdKey}`);

--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -102,9 +102,9 @@ export default class RpcMessageHandler {
 
     // we can get an error, or we can get a response that is an error
     if (result && result.wasThrown) {
-      let message = (result.result && (result.result.value || result.result.description)) ?
-                    (result.result.value || result.result.description) :
-                    'Error occurred in handling data message';
+      let message = (result.result && (result.result.value || result.result.description))
+        ? (result.result.value || result.result.description)
+        : 'Error occurred in handling data message';
       error = new Error(message);
     }
 

--- a/lib/remote-debugger-rpc-client.js
+++ b/lib/remote-debugger-rpc-client.js
@@ -89,7 +89,7 @@ export default class RemoteDebuggerRpcClient {
     // connect the socket
     return await new Promise((resolve, reject) => {
       // only resolve this function when we are actually connected
-      this.socket.on('connect', async () => {
+      this.socket.on('connect', () => {
         log.debug(`Debugger socket connected`);
         this.connected = true;
 
@@ -107,7 +107,7 @@ export default class RemoteDebuggerRpcClient {
     });
   }
 
-  async disconnect () {
+  async disconnect () { // eslint-disable-line require-await
     if (this.isConnected()) {
       log.debug('Disconnecting from remote debugger');
       this.socket.destroy();
@@ -140,7 +140,7 @@ export default class RemoteDebuggerRpcClient {
       // local callback, temporarily added as callback to
       // `_rpc_applicationConnected:` remote debugger response
       // to handle the initial connection
-      let onAppChange = async (dict) => {
+      let onAppChange = (dict) => {
         // from the dictionary returned, get the ids
         let oldAppIdKey = dict.WIRHostApplicationIdentifierKey;
         let correctAppIdKey = dict.WIRApplicationIdentifierKey;
@@ -179,7 +179,7 @@ export default class RemoteDebuggerRpcClient {
     });
   }
 
-  async send (command, opts = {}) {
+  async send (command, opts = {}) { // eslint-disable-line require-await
     // error listener, which needs to be removed after the promise is resolved
     let onSocketError;
 

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -238,7 +238,7 @@ class RemoteDebugger extends events.EventEmitter {
       log.debug(`Trying out the possible app ids: ${possibleAppIds.join(', ')}`);
       for (let attemptedAppIdKey of possibleAppIds) {
         try {
-          log.debug(`Selecting app ${attemptedAppIdKey} (try #${i+1} of ${maxTries})`);
+          log.debug(`Selecting app ${attemptedAppIdKey} (try #${i + 1} of ${maxTries})`);
           [appIdKey, pageDict] = await this.rpcClient.selectApp(attemptedAppIdKey, this.onAppConnect.bind(this));
           // in iOS 8.2 the connect logic happens, but with an empty dictionary
           // which leads to the remote debugger getting disconnected, and into a loop
@@ -385,7 +385,7 @@ class RemoteDebugger extends events.EventEmitter {
     await this.execute(script);
   }
 
-  async frameDetached () {
+  frameDetached () {
     this.emit(RemoteDebugger.EVENT_FRAMES_DETACHED);
   }
 
@@ -430,7 +430,7 @@ class RemoteDebugger extends events.EventEmitter {
     await verify();
   }
 
-  async cancelPageLoad () {
+  cancelPageLoad () {
     log.debug('Unregistering from page readiness notifications');
     this.pageLoading = false;
     if (this.pageLoadDelay) {
@@ -497,14 +497,14 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   async waitForFrameNavigated () {
-    return new Promise(async (resolve, reject) => {
+    return await new Promise(async (resolve, reject) => {
       log.debug('Waiting for frame navigated message...');
       let startMs = Date.now();
 
       // add a handler for the `Page.frameNavigated` message
       // from the remote debugger
       let navEventListener = (value) => {
-        log.debug(`Frame navigated in ${((Date.now() - startMs)/1000)} sec from source: ${value}`);
+        log.debug(`Frame navigated in ${((Date.now() - startMs) / 1000)} sec from source: ${value}`);
         if (this.navigationDelay) {
           this.navigationDelay.cancel();
         }
@@ -723,4 +723,6 @@ for (let [name, handler] of _.toPairs(messageHandlers)) {
   RemoteDebugger.prototype[name] = handler;
 }
 
-export { RemoteDebugger, DEBUGGER_TYPES, REMOTE_DEBUGGER_PORT, RPC_RESPONSE_TIMEOUT_MS };
+export {
+  RemoteDebugger, DEBUGGER_TYPES, REMOTE_DEBUGGER_PORT, RPC_RESPONSE_TIMEOUT_MS,
+};

--- a/lib/remote-messages.js
+++ b/lib/remote-messages.js
@@ -12,7 +12,7 @@ function setConnectionKey (connId) {
     __argument: {
       WIRConnectionIdentifierKey: connId
     },
-    __selector : '_rpc_reportIdentifier:'
+    __selector: '_rpc_reportIdentifier:'
   };
 }
 
@@ -22,7 +22,7 @@ function connectToApp (connId, appIdKey) {
       WIRConnectionIdentifierKey: connId,
       WIRApplicationIdentifierKey: appIdKey
     },
-    __selector : '_rpc_forwardGetListing:'
+    __selector: '_rpc_forwardGetListing:'
   };
 }
 

--- a/lib/webkit-rpc-client.js
+++ b/lib/webkit-rpc-client.js
@@ -29,7 +29,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
   }
 
   async connect (pageId) {
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       // we will only resolve this call when the socket is open
       // WebKit url
       let url = `ws://${this.host}:${this.port}/devtools/page/${pageId}`;
@@ -80,7 +80,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
     data.id = this.curMsgId;
 
     const id = this.curMsgId.toString();
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       // only resolve the send command when WebKit returns a response
       // store the handler and the data sent
       this.dataHandlers[id] = resolve;

--- a/package.json
+++ b/package.json
@@ -22,10 +22,17 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "index.js",
+    "lib",
+    "build/index.js",
+    "build/lib",
+    "atoms"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^3.0.0",
     "appium-support": "^2.4.0",
-    "babel-runtime": "=5.8.24",
     "bluebird": "^3.4.7",
     "bplist-creator": "0.0.7",
     "bplist-parser": "^0.1.0",
@@ -39,7 +46,7 @@
     "ws": "^6.0.0"
   },
   "scripts": {
-    "prepublish": "gulp prepublish",
+    "prepare": "gulp prepublish",
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
     "test": "gulp once",
     "watch": "gulp watch",
@@ -58,32 +65,22 @@
     "precommit-test"
   ],
   "devDependencies": {
-    "appium-gulp-plugins": "^2.4.0",
-    "babel-eslint": "^7.1.1",
+    "ajv": "^6.5.3",
+    "appium-gulp-plugins": "^3.1.0",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.1.0",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.3.1",
-    "gulp": "^3.9.1",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "gulp": "^4.0.0",
     "mocha": "^5.1.1",
     "pre-commit": "^1.1.3",
     "sinon": "^6.0.0"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
-    ]
+    "ignore": []
   }
 }

--- a/test/helpers/remote-debugger-server.js
+++ b/test/helpers/remote-debugger-server.js
@@ -97,11 +97,11 @@ class RemoteDebuggerServer {
     };
 
     // add more
-    if (num > UPDATED_APP_INFO+1) {
+    if (num > UPDATED_APP_INFO + 1) {
       // we only have so many to give!
       num = UPDATED_APP_INFO + 1;
     }
-    for (let i = 0; i < num-1; i++) {
+    for (let i = 0; i < num - 1; i++) {
       let entry = UPDATED_APP_INFO[i];
       data.__argument.WIRApplicationDictionaryKey.push({[entry.id]: entry});
     }
@@ -202,7 +202,7 @@ class RemoteDebuggerServer {
 
   changeApp (num = 1, immediate = true) {
     if (immediate) {
-      if (num > UPDATED_APP_INFO.length-1) {
+      if (num > UPDATED_APP_INFO.length - 1) {
         // we only have a certain number of info to send
         num = UPDATED_APP_INFO.length - 1;
       }
@@ -210,12 +210,12 @@ class RemoteDebuggerServer {
         let data = {
           __selector: '_rpc_applicationConnected:',
           __argument: {
-            WIRApplicationIdentifierKey: UPDATED_APP_INFO[this.app-1].id,
-            WIRApplicationNameKey: UPDATED_APP_INFO[this.app-1].name,
-            WIRApplicationBundleIdentifierKey: UPDATED_APP_INFO[this.app-1].bundleId,
-            WIRIsApplicationProxyKey: UPDATED_APP_INFO[this.app-1].isProxy,
-            WIRHostApplicationIdentifierKey: UPDATED_APP_INFO[this.app-1].hostId,
-            WIRIsApplicationActiveKey: UPDATED_APP_INFO[this.app-1].isActive
+            WIRApplicationIdentifierKey: UPDATED_APP_INFO[this.app - 1].id,
+            WIRApplicationNameKey: UPDATED_APP_INFO[this.app - 1].name,
+            WIRApplicationBundleIdentifierKey: UPDATED_APP_INFO[this.app - 1].bundleId,
+            WIRIsApplicationProxyKey: UPDATED_APP_INFO[this.app - 1].isProxy,
+            WIRHostApplicationIdentifierKey: UPDATED_APP_INFO[this.app - 1].hostId,
+            WIRIsApplicationActiveKey: UPDATED_APP_INFO[this.app - 1].isActive
           }
         };
         this.send(data);
@@ -272,7 +272,7 @@ class RemoteDebuggerServer {
   }
 
   async start () {
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       this.server = net.createServer((c) => {
         this.client = c;
         c.on('end', () => {
@@ -317,7 +317,7 @@ class RemoteDebuggerServer {
   }
 
   async stop () {
-    return new Promise((resolve) => {
+    return await new Promise((resolve) => {
       if (this.server) {
         if (this.client) {
           this.client.end();

--- a/test/helpers/webkit-remote-debugger-server.js
+++ b/test/helpers/webkit-remote-debugger-server.js
@@ -24,7 +24,7 @@ class WebKitRemoteDebuggerServer {
   async start (ws = false) {
     if (!ws) {
       // just need a simple http server for non-websocket calls
-      return new Promise((resolve) => {
+      return await new Promise((resolve) => {
         this.server = http.createServer((req, res) => {
           res.writeHead(200, {'Content-Type': 'application/json'});
           if (this.nextResponse) {
@@ -50,7 +50,7 @@ class WebKitRemoteDebuggerServer {
   // stop one or both of the servers.
   async stop () {
     if (!this.ws) {
-      return new Promise((resolve) => {
+      return await new Promise((resolve) => {
         if (this.server) {
           this.server.close((err) => { // eslint-disable-line promise/prefer-await-to-callbacks
             resolve(`Stopped listening: ${err}`);

--- a/test/unit/remote-debugger-specs.js
+++ b/test/unit/remote-debugger-specs.js
@@ -277,7 +277,7 @@ describe('RemoteDebugger', function () {
     });
   }));
 
-  describe('socket errors', async function () {
+  describe('socket errors', function () {
     it('should handle socket connect error', async function () {
       await rd.connect().should.be.rejected;
     });

--- a/test/unit/remote-messages-specs.js
+++ b/test/unit/remote-messages-specs.js
@@ -10,9 +10,11 @@ chai.should();
 describe('getRemoteCommand', function () {
   this.timeout(MOCHA_TIMEOUT);
 
-  const commands = ['setConnectionKey', 'connectToApp', 'setSenderKey',
-                    'indicateWebView', 'sendJSCommand', 'callJSFunction',
-                    'setUrl', 'enablePage', 'startTimeline', 'stopTimeline'];
+  const commands = [
+    'setConnectionKey', 'connectToApp', 'setSenderKey', 'indicateWebView',
+    'sendJSCommand', 'callJSFunction', 'setUrl', 'enablePage', 'startTimeline',
+    'stopTimeline',
+  ];
   for (const command of commands) {
     it(`should be able to retrieve ${command} command`, function () {
       const remoteCommand = getRemoteCommand(command, {});

--- a/test/unit/webkit-remote-debugger-specs.js
+++ b/test/unit/webkit-remote-debugger-specs.js
@@ -65,7 +65,7 @@ describe('WebKitRemoteDebugger', function () {
           url: '/path/to/other_page.html'
         }
       ];
-      beforeEach(async function () {
+      beforeEach(function () {
         server.respondWith(data);
       });
 


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.