### PR TITLE
Make sure that allowNavigationWithoutReload exists before calling

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -661,7 +661,9 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   allowNavigationWithoutReload (allow = true) {
-    this.rpcClient.allowNavigationWithoutReload(allow);
+    if (_.isFunction(this.rpcClient.allowNavigationWithoutReload)) {
+      this.rpcClient.allowNavigationWithoutReload(allow);
+    }
   }
 
   async getCookies (urls) {


### PR DESCRIPTION
See https://github.com/appium/appium/issues/11683.

With WebKit we do not do the same logic for frame navigation, so this is not necessary.