### PR TITLE
Handle iOS 12.2 for real devices

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,10 +3,11 @@ import getAtom from './atoms';
 import _ from 'lodash';
 import assert from 'assert';
 import B from 'bluebird';
+import { util } from 'appium-support';
 
 
 const WEB_CONTENT_BUNDLE_ID = 'com.apple.WebKit.WebContent';
-const MIN_PLATFORM_FOR_TARGET_BASED = 12.2;
+const MIN_PLATFORM_FOR_TARGET_BASED = '12.2';
 
 /*
  * Takes a dictionary from the remote debugger and makes a more manageable
@@ -210,16 +211,13 @@ function deferredPromise () {
   };
 }
 
-function checkIsTargetBased (isSafari, platformVersion) {
+function isTargetBased (isSafari, platformVersion) {
   // on iOS 12.2 the messages get sent through the Target domain
-  if (_.isString(platformVersion)) {
-    platformVersion = parseFloat(platformVersion);
-  }
-  return isSafari && platformVersion >= MIN_PLATFORM_FOR_TARGET_BASED;
+  return isSafari && util.compareVersions(platformVersion, '>=', MIN_PLATFORM_FOR_TARGET_BASED);
 }
 
 export {
   appInfoFromDict, pageArrayFromDict, getDebuggerAppKey,
   getPossibleDebuggerAppKeys, checkParams, wrapScriptForFrame, getScriptForAtom,
-  simpleStringify, deferredPromise, checkIsTargetBased,
+  simpleStringify, deferredPromise, isTargetBased,
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,6 +6,7 @@ import B from 'bluebird';
 
 
 const WEB_CONTENT_BUNDLE_ID = 'com.apple.WebKit.WebContent';
+const MIN_PLATFORM_FOR_TARGET_BASED = 12.2;
 
 /*
  * Takes a dictionary from the remote debugger and makes a more manageable
@@ -209,8 +210,16 @@ function deferredPromise () {
   };
 }
 
+function checkIsTargetBased (isSafari, platformVersion) {
+  // on iOS 12.2 the messages get sent through the Target domain
+  if (_.isString(platformVersion)) {
+    platformVersion = parseFloat(platformVersion);
+  }
+  return isSafari && platformVersion >= MIN_PLATFORM_FOR_TARGET_BASED;
+}
+
 export {
   appInfoFromDict, pageArrayFromDict, getDebuggerAppKey,
   getPossibleDebuggerAppKeys, checkParams, wrapScriptForFrame, getScriptForAtom,
-  simpleStringify, deferredPromise,
+  simpleStringify, deferredPromise, checkIsTargetBased,
 };

--- a/lib/remote-debugger-rpc-client.js
+++ b/lib/remote-debugger-rpc-client.js
@@ -9,9 +9,8 @@ import UUID from 'uuid-js';
 import net from 'net';
 import RpcMessageHandler from './remote-debugger-message-handler';
 import RemoteMessages from './remote-messages';
+import { checkIsTargetBased } from './helpers';
 
-
-const MIN_PLATFORM_FOR_TARGET_BASED = 12.2;
 
 export default class RemoteDebuggerRpcClient {
   constructor (opts = {}) {
@@ -42,11 +41,7 @@ export default class RemoteDebuggerRpcClient {
     // message handlers
     this.specialMessageHandlers = specialMessageHandlers;
 
-    // on iOS 12.2 the messages get sent through the Target domain
-    if (_.isString(platformVersion)) {
-      platformVersion = parseFloat(platformVersion);
-    }
-    const isTargetBased = isSafari && platformVersion >= MIN_PLATFORM_FOR_TARGET_BASED;
+    const isTargetBased = checkIsTargetBased(isSafari, platformVersion);
     this.remoteMessages = new RemoteMessages(isTargetBased);
     this.messageHandler = new RpcMessageHandler(this.specialMessageHandlers, isTargetBased);
     log.debug(`Using ${isTargetBased ? 'Target-based' : 'full Web Inspector protocol'} communication`);

--- a/lib/remote-debugger-rpc-client.js
+++ b/lib/remote-debugger-rpc-client.js
@@ -9,7 +9,7 @@ import UUID from 'uuid-js';
 import net from 'net';
 import RpcMessageHandler from './remote-debugger-message-handler';
 import RemoteMessages from './remote-messages';
-import { checkIsTargetBased } from './helpers';
+import { isTargetBased } from './helpers';
 
 
 export default class RemoteDebuggerRpcClient {
@@ -41,10 +41,10 @@ export default class RemoteDebuggerRpcClient {
     // message handlers
     this.specialMessageHandlers = specialMessageHandlers;
 
-    const isTargetBased = checkIsTargetBased(isSafari, platformVersion);
-    this.remoteMessages = new RemoteMessages(isTargetBased);
-    this.messageHandler = new RpcMessageHandler(this.specialMessageHandlers, isTargetBased);
-    log.debug(`Using ${isTargetBased ? 'Target-based' : 'full Web Inspector protocol'} communication`);
+    const targetBased = isTargetBased(isSafari, platformVersion);
+    this.remoteMessages = new RemoteMessages(targetBased);
+    this.messageHandler = new RpcMessageHandler(this.specialMessageHandlers, targetBased);
+    log.debug(`Using ${targetBased ? 'Target-based' : 'full Web Inspector protocol'} communication`);
   }
 
   async connect () {

--- a/lib/webkit-remote-debugger.js
+++ b/lib/webkit-remote-debugger.js
@@ -20,12 +20,21 @@ export default class WebKitRemoteDebugger extends RemoteDebugger {
 
     this.webkitResponseTimeout = opts.webkitResponseTimeout || RPC_RESPONSE_TIMEOUT_MS;
 
+    this.platformVersion = opts.platformVersion;
+    this.isSafari = opts.isSafari;
+
     // used to store callback types when sending requests
     this.dataMethods = {};
   }
 
   async connect (pageId) {
-    this.rpcClient = new WebKitRpcClient(this.host, this.port, this.webkitResponseTimeout);
+    this.rpcClient = new WebKitRpcClient({
+      host: this.host,
+      port: this.port,
+      responseTimeout: this.webkitResponseTimeout,
+      platformVersion: this.platformVersion,
+      isSafari: this.isSafari,
+    });
     await this.rpcClient.connect(pageId);
   }
 
@@ -40,12 +49,12 @@ export default class WebKitRemoteDebugger extends RemoteDebugger {
   }
 
   async pageArrayFromJson (ignoreAboutBlankUrl = false) {
-    log.debug(`Getting WebKitRemoteDebugger pageArray: ${this.host}, ${this.port}`);
+    log.debug(`Getting WebKitRemoteDebugger pageArray. Host: '${this.host}', port: '${this.port}'`);
     let pageElementJSON = await this.getJsonFromUrl(this.host, this.port, '/json');
     if (pageElementJSON[0] && pageElementJSON[0].deviceId) {
       log.debug(`Device JSON: ${simpleStringify(pageElementJSON)}`);
 
-      let devices = pageElementJSON.filter((device) => device.deviceId !== 'SIMULATOR');
+      const devices = pageElementJSON.filter((device) => device.deviceId !== 'SIMULATOR');
       if (devices.length > 1) {
         log.debug(`Connected to ${devices.length} devices. ` +
                   `Choosing the first, with udid '${devices[0].deviceId}'.`);
@@ -58,11 +67,11 @@ export default class WebKitRemoteDebugger extends RemoteDebugger {
     log.debug(`Page element JSON: ${simpleStringify(pageElementJSON)}`);
 
     // Add elements to an array
-    let newPageArray = pageElementJSON.filter((pageObject) => {
+    const newPageArray = pageElementJSON.filter((pageObject) => {
       return pageObject.url && (!ignoreAboutBlankUrl || pageObject.url !== 'about:blank');
     }).map((pageObject) => {
-      let urlArray = pageObject.webSocketDebuggerUrl.split('/').reverse();
-      let id = urlArray[0];
+      const urlArray = pageObject.webSocketDebuggerUrl.split('/').reverse();
+      const id = urlArray[0];
       return {
         id,
         title: pageObject.title,
@@ -75,11 +84,12 @@ export default class WebKitRemoteDebugger extends RemoteDebugger {
   }
 
   async getJsonFromUrl (hostname, port, pathname) {
-    let uri = url.format({
+    const uri = url.format({
       protocol: 'http',
       hostname,
       port,
-      pathname
+      pathname,
+      json: true,
     });
     log.debug(`Sending request to: ${uri}`);
     return JSON.parse(await request({uri, method: 'GET'}));

--- a/lib/webkit-rpc-client.js
+++ b/lib/webkit-rpc-client.js
@@ -5,7 +5,7 @@ import WebSocket from 'ws';
 import B from 'bluebird';
 import _ from 'lodash';
 import events from 'events';
-import { simpleStringify } from './helpers';
+import { simpleStringify, checkIsTargetBased } from './helpers';
 import ES6Error from 'es6-error';
 import { util } from 'appium-support';
 
@@ -13,13 +13,24 @@ import { util } from 'appium-support';
 const DATA_LOG_LENGTH = {length: 200};
 
 export default class WebKitRpcClient extends events.EventEmitter {
-  constructor (host, port = REMOTE_DEBUGGER_PORT, responseTimeout = RPC_RESPONSE_TIMEOUT_MS) {
+  constructor (opts = {}) {
     super();
+
+    const {
+      host,
+      port = REMOTE_DEBUGGER_PORT,
+      responseTimeout = RPC_RESPONSE_TIMEOUT_MS,
+      platformVersion,
+      isSafari,
+    } = opts;
 
     this.host = host || 'localhost';
     this.port = port;
 
     this.responseTimeout = responseTimeout;
+
+    this.platformVersion = platformVersion;
+    this.isSafari = isSafari;
 
     this.curMsgId = 0;
 
@@ -27,17 +38,20 @@ export default class WebKitRpcClient extends events.EventEmitter {
     this.dataMethods = {};
     this.errorHandlers = {};
 
-    this.remoteMessages = new RemoteMessages();
+    this.isTargetBased = checkIsTargetBased(isSafari, platformVersion);
+    this.remoteMessages = new RemoteMessages(this.isTargetBased);
+    log.debug(`Using ${this.isTargetBased ? 'Target-based' : 'full Web Inspector protocol'} communication`);
   }
 
   async connect (pageId) {
     return await new B((resolve, reject) => {
       // we will only resolve this call when the socket is open
       // WebKit url
-      let url = `ws://${this.host}:${this.port}/devtools/page/${pageId}`;
+      const url = `ws://${this.host}:${this.port}/devtools/page/${pageId}`;
       this.pageIdKey = pageId;
 
       // create and set up socket with appropriate event handlers
+      log.debug(`Connecting to WebKit socket: '${url}'`);
       this.socket = new WebSocket(url);
       this.socket.on('open', () => {
         log.debug(`WebKit debugger web socket connected to url: ${url}`);
@@ -78,15 +92,25 @@ export default class WebKitRpcClient extends events.EventEmitter {
     log.debug(`Sending WebKit data: ${_.truncate(JSON.stringify(data), DATA_LOG_LENGTH)}`);
     log.debug(`Webkit response timeout: ${this.responseTimeout}`);
 
-    this.curMsgId++;
-    data.id = this.curMsgId;
+    const msgId = this.curMsgId++;
+    data.id = msgId;
 
-    const id = this.curMsgId.toString();
+    let method = data.method;
+    if (this.isTargetBased) {
+      method = data.params.message.method;
+
+      data.params.id = msgId;
+      data.params.message.id = msgId;
+      data.params.message = JSON.stringify(data.params.message);
+      data.params.targetId = 'page-1';
+    }
+
+    const id = msgId.toString();
     return await new B((resolve, reject) => {
       // only resolve the send command when WebKit returns a response
       // store the handler and the data sent
       this.dataHandlers[id] = resolve;
-      this.dataMethods[id] = data.method;
+      this.dataMethods[id] = method;
       this.errorHandlers[id] = reject;
 
       // send the data
@@ -101,7 +125,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
         throw e;
       }
       log.warn(e.message);
-      return B.resolve(null);
+      return B.resolve();
     }).finally((res) => {
       // no need to hold onto anything
       delete this.dataHandlers[id];
@@ -141,16 +165,53 @@ export default class WebKitRpcClient extends events.EventEmitter {
       return rejectCall(new Error(message));
     }
 
-    const msgId = data.id;
+    let msgId = data.id;
+
+    let result = data.result;
+    let params = data.params;
+    let error = data.error;
+    let method = this.dataMethods[msgId] || data.method;
+    if (this.isTargetBased) {
+      if (!(data.method || '').startsWith('Target')) {
+        log.debug(`Received reciept for message '${msgId}'`);
+        return;
+      }
+      if (data.params.message) {
+        const message = JSON.parse(data.params.message);
+
+        // get nested params if necessary
+        if (message.params) {
+          params = message.params;
+        }
+
+        // the message is aggravatingly nested
+        if (message.result) {
+          result = message.result;
+          if (message.result.result) {
+            result = message.result.result;
+            if (message.result.result.value) {
+              result = message.result.result.value;
+              if (_.isString(result)) {
+                try {
+                  result = JSON.parse(result);
+                } catch (ign) {}
+              }
+            }
+          }
+        }
+        msgId = message.id;
+        method = message.method || method;
+      }
+    }
+
     // when sending we set a data method and associated callback.
     // get that, or the generic (automatically sent, not associated
     // with a particular request) method
-    const method = this.dataMethods[msgId] || data.method;
     if (!method) {
       return rejectCall(
-        new WebKitRPCWarning(`Did not find any handlers for ${msgId ? `'${msgId}'` : 'the recent'} message`));
+        new WebKitRPCWarning(`Did not find any handlers for ${msgId ? `'${msgId}'` : 'recent'} message`));
     }
-    log.debug(`Found method '${method}'${msgId ? ` for '${msgId}' message` : ''}`);
+    log.debug(`Found method '${method}' ${msgId ? `for message '${msgId}'` : ''}`);
     let isEventHandled = false;
     switch (method) {
       case 'Profiler.resetProfiles':
@@ -160,13 +221,17 @@ export default class WebKitRpcClient extends events.EventEmitter {
         break;
       case 'Timeline.eventRecorded':
         if (this.timelineEventHandler) {
-          this.timelineEventHandler(data.result);
+          this.timelineEventHandler(result);
           isEventHandled = true;
         }
         break;
+      case 'Console.messagesCleared':
+        // pass
+        isEventHandled = true;
+        break;
       case 'Console.messageAdded':
         if (this.consoleEventHandler) {
-          this.consoleEventHandler(data.params.message);
+          this.consoleEventHandler(params.message);
           isEventHandled = true;
         }
         break;
@@ -180,19 +245,25 @@ export default class WebKitRpcClient extends events.EventEmitter {
       case 'Network.loadingFinished':
       case 'Network.loadingFailed':
         if (_.isFunction(this.networkEventHandler)) {
-          this.networkEventHandler(method, data.params);
+          this.networkEventHandler(method, params);
           return;
         }
         break;
+      case 'Target.targetCreated':
+        log.debug(`Target created: ${JSON.stringify(params.targetInfo)}`);
+        isEventHandled = true;
+        break;
+      case 'Target.dispatchMessageFromTarget':
+        log.debug('HERE');
     }
     if (!data.error && _.has(this.dataHandlers, msgId)) {
-      return this.dataHandlers[msgId](data.result);
+      return this.dataHandlers[msgId](result);
     }
     if (data.error && _.has(this.errorHandlers, msgId)) {
-      return this.errorHandlers[msgId](data.error);
+      return this.errorHandlers[msgId](error);
     }
     if (!isEventHandled) {
-      log.debug(`There is no handler scheduled for method '${method}' in ${msgId ? `'${msgId}'` : 'the recent'} message`);
+      log.debug(`There is no handler scheduled for method '${method}' in ${msgId ? `message '${msgId}'` : 'recent messages'}`);
     }
   }
 

--- a/lib/webkit-rpc-client.js
+++ b/lib/webkit-rpc-client.js
@@ -5,7 +5,7 @@ import WebSocket from 'ws';
 import B from 'bluebird';
 import _ from 'lodash';
 import events from 'events';
-import { simpleStringify, checkIsTargetBased } from './helpers';
+import { simpleStringify, isTargetBased } from './helpers';
 import ES6Error from 'es6-error';
 import { util } from 'appium-support';
 
@@ -38,7 +38,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
     this.dataMethods = {};
     this.errorHandlers = {};
 
-    this.isTargetBased = checkIsTargetBased(isSafari, platformVersion);
+    this.isTargetBased = isTargetBased(isSafari, platformVersion);
     this.remoteMessages = new RemoteMessages(this.isTargetBased);
     log.debug(`Using ${this.isTargetBased ? 'Target-based' : 'full Web Inspector protocol'} communication`);
   }
@@ -165,24 +165,34 @@ export default class WebKitRpcClient extends events.EventEmitter {
       return rejectCall(new Error(message));
     }
 
-    let msgId = data.id;
+    let {
+      id: msgId,
+      result,
+      params,
+      error,
+    } = data;
 
-    let result = data.result;
-    let params = data.params;
-    let error = data.error;
     let method = this.dataMethods[msgId] || data.method;
     if (this.isTargetBased) {
-      if (!(data.method || '').startsWith('Target')) {
-        log.debug(`Received reciept for message '${msgId}'`);
+      if (!_.startsWith(data.method, 'Target')) {
+        log.debug(`Received receipt for message '${msgId}'`);
         return;
       }
       if (data.params.message) {
-        const message = JSON.parse(data.params.message);
+        let message;
+        try {
+          message = JSON.parse(data.params.message);
+        } catch (err) {
+          // this should never happen, so log as much information as possible
+          // since we need to accomodate something we have not seen
+          log.error(`Unable to parse message: ${err.message}`);
+          log.error(`Data:`);
+          log.error(`${JSON.stringify(data, null, 2)}`);
+          // continue. maybe something can be salvaged?
+        }
 
         // get nested params if necessary
-        if (message.params) {
-          params = message.params;
-        }
+        params = message.params || params;
 
         // the message is aggravatingly nested
         if (message.result) {
@@ -191,6 +201,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
             result = message.result.result;
             if (message.result.result.value) {
               result = message.result.result.value;
+              // only at this level is parsing the result necessary
               if (_.isString(result)) {
                 try {
                   result = JSON.parse(result);
@@ -199,6 +210,7 @@ export default class WebKitRpcClient extends events.EventEmitter {
             }
           }
         }
+
         msgId = message.id;
         method = message.method || method;
       }
@@ -253,8 +265,6 @@ export default class WebKitRpcClient extends events.EventEmitter {
         log.debug(`Target created: ${JSON.stringify(params.targetInfo)}`);
         isEventHandled = true;
         break;
-      case 'Target.dispatchMessageFromTarget':
-        log.debug('HERE');
     }
     if (!data.error && _.has(this.dataHandlers, msgId)) {
       return this.dataHandlers[msgId](result);


### PR DESCRIPTION
Add support for iOS 12.2 on real devices. For this to work `ios-webkit-debug-proxy` needs to be the latest from HEAD.

This duplicates a bunch of logic, but as the package is structured now that is necessary. Once this is in I will allocate some time to refactor this to use the same message handler system, which should remove the duplication.