### PR TITLE
Do not send page change event when navigating

### DIFF
--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -40,6 +40,11 @@ function onPageChange (appIdKey, pageDict) {
     this.appDict[appIdKey].pageArray = pageArray;
   }
 
+  if (this._navigatingToPage) {
+    // in the middle of navigating, so reporting a page change will cause problems
+    return;
+  }
+
   // only act if this is the correct app
   if (this.appIdKey !== appIdKey) {
     log.debug(`Received page change notice for app '${appIdKey}' ` +

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -82,6 +82,7 @@ class RemoteDebugger extends events.EventEmitter {
     this.appIdKey = null;
     this.pageIdKey = null;
     this.pageLoading = false;
+    this._navigatingToPage = false;
 
     // set up the special callbacks for handling rd events
     this.specialCbs = {
@@ -495,27 +496,33 @@ class RemoteDebugger extends events.EventEmitter {
   async navToUrl (url, pageLoadVerifyHook) {
     // no need to do this check when using webkit
     if (this.debuggerType === DEBUGGER_TYPES.webinspector) {
-      let errors = checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
+      const errors = checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
       if (errors) throw new Error(errors); // eslint-disable-line curly
     }
 
-    log.debug(`Navigating to new URL: ${url}`);
-    await this.rpcClient.send('setUrl', {
-      url,
-      appIdKey: this.appIdKey,
-      pageIdKey: this.pageIdKey,
-      debuggerType: this.debuggerType
-    });
+    this._navigatingToPage = true;
 
-    if (!this.useNewSafari) {
-      // a small pause for the browser to catch up
-      await B.delay(1000);
-    }
+    try {
+      log.debug(`Navigating to new URL: '${url}'`);
+      await this.rpcClient.send('setUrl', {
+        url,
+        appIdKey: this.appIdKey,
+        pageIdKey: this.pageIdKey,
+        debuggerType: this.debuggerType
+      });
 
-    if (this.debuggerType === DEBUGGER_TYPES.webinspector) {
-      await this.waitForFrameNavigated();
+      if (!this.useNewSafari) {
+        // a small pause for the browser to catch up
+        await B.delay(1000);
+      }
+
+      if (this.debuggerType === DEBUGGER_TYPES.webinspector) {
+        await this.waitForFrameNavigated();
+      }
+      await this.waitForDom(Date.now(), pageLoadVerifyHook);
+    } finally {
+      this._navigatingToPage = false;
     }
-    await this.waitForDom(Date.now(), pageLoadVerifyHook);
   }
 
   async waitForFrameNavigated () {


### PR DESCRIPTION
If we are in the middle of navigating to a page, do not send page change notifications, which cause confusion.