### PR TITLE
Update appium-support minimum version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^3.0.0",
-    "appium-support": "^2.4.0",
+    "appium-support": "^2.26.0",
     "bluebird": "^3.4.7",
     "bplist-creator": "0.0.7",
     "bplist-parser": "^0.1.0",


### PR DESCRIPTION
This [commit](https://github.com/appium/appium-remote-debugger/commit/ce95e92cb5e0cc4c6c11799d79cf1b7a1cbb3bbc) added the use of appium-support.util.compareVersions which is only available in appium-support version [2.26.0](https://github.com/appium/appium-support/commit/d03c1973bca7b42eec4830c99e710c93d44990f3) and above.