### PR TITLE
Make sure empty target events are handled correctly

### DIFF
--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -57,14 +57,22 @@ export default class RpcClient {
     throw new Error(`Sub-classes need to implement a 'sendMessage' function`);
   }
 
-  addTarget (targetInfo = {}) {
+  addTarget (targetInfo) {
+    if (_.isUndefined(targetInfo) || _.isUndefined(targetInfo.targetId)) {
+      log.debug(`Received 'targetCreated' event with no target. Skipping`);
+      return;
+    }
     log.debug(`Target created: ${JSON.stringify(targetInfo)}`);
     if (!this.targets.includes(targetInfo.targetId)) {
       this.targets.push(targetInfo.targetId);
     }
   }
 
-  removeTarget (targetInfo = {}) {
+  removeTarget (targetInfo) {
+    if (_.isUndefined(targetInfo) || _.isUndefined(targetInfo.targetId)) {
+      log.debug(`Received 'taretDestroyed' event with no target. Skipping`);
+      return;
+    }
     log.debug(`Target destroyed: ${JSON.stringify(targetInfo)}`);
     _.pull(this.targets, targetInfo.targetId);
   }

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -57,14 +57,14 @@ export default class RpcClient {
     throw new Error(`Sub-classes need to implement a 'sendMessage' function`);
   }
 
-  addTarget (targetInfo) {
+  addTarget (targetInfo = {}) {
     log.debug(`Target created: ${JSON.stringify(targetInfo)}`);
     if (!this.targets.includes(targetInfo.targetId)) {
       this.targets.push(targetInfo.targetId);
     }
   }
 
-  removeTarget (targetInfo) {
+  removeTarget (targetInfo = {}) {
     log.debug(`Target destroyed: ${JSON.stringify(targetInfo)}`);
     _.pull(this.targets, targetInfo.targetId);
   }


### PR DESCRIPTION
It seems that sometimes the Web Inspector sends empty `targetDestroyed` events, which leads to errors since we're trying to get a property on the information, which would be `undefined`.

See line 10207 of https://dev.azure.com/srinivasansekar/java-client/_build/results?buildId=164