### PR TITLE
Fix handling of page change

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@ Issues for this repo are disabled. Log any issues at the [main Appium repo's iss
 
 ## Safari's version of the WebKit API
 
-Safari implements a wonky version of the WebKit API. It is not documented. But there
-is good documentation for the closely related API from Chrome DevTools, to be
-[found here](https://chromedevtools.github.io/devtools-protocol/);
+Safari implements a wonky version of the WebKit API. It is not documented. The
+JSON version of the protocol is documented in the WebKit source code, in
+[Source/JavaScriptCore/inspector/protocol/](https://github.com/WebKit/webkit/tree/master/Source/JavaScriptCore/inspector/protocol).
+
+There is good documentation for the closely related API from Chrome DevTools, to
+be [found here](https://chromedevtools.github.io/devtools-protocol/).
 
 ## API
 

--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -10,14 +10,6 @@ import _ from 'lodash';
  */
 
 
-/**
- * Remove the `isKey` property from the page array, since it does not affect
- * equality
- */
-function cleanPageArray (arr) {
-  return _.map(arr, (el) => _.pick(el, 'id', 'title', 'url'));
-}
-
 function onPageChange (appIdKey, pageDict) {
   if (_.isEmpty(pageDict)) {
     return;
@@ -33,7 +25,7 @@ function onPageChange (appIdKey, pageDict) {
         this.appDict[appIdKey].pageArray.resolve();
       } else {
         // we have a pre-existing pageDict
-        if (_.isEqual(cleanPageArray(this.appDict[appIdKey].pageArray), cleanPageArray(pageArray))) {
+        if (_.isEqual(this.appDict[appIdKey].pageArray, pageArray)) {
           log.debug(`Received page change notice for app '${appIdKey}' ` +
                     `but the listing has not changed. Ignoring.`);
           return;


### PR DESCRIPTION
Remove the stripping of `isKey` from equality check on page change.