### PR TITLE
fix: Properly save reported targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   include:
     - stage: tests
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env:
         - TEST=test
         - COVERALLS=1
@@ -20,7 +20,7 @@ jobs:
         - TEST=e2e-test
 
     - stage:
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env:
         - PLATFORM_VERSION=12.1
         - TEST=e2e-test
@@ -29,6 +29,13 @@ jobs:
       osx_image: xcode10.2
       env:
         - PLATFORM_VERSION=12.2
+        - TEST=e2e-test
+
+    - stage:
+      osx_image: xcode11
+      env:
+        - PLATFORM_VERSION=13.0
+        - DEVICE_NAME="iPhone X"
         - TEST=e2e-test
 
 script:

--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 // we will receive events that we do not listen to.
 // if we start to listen to one of these, remove it from the list
 const IGNORED_EVENTS = [
+  'Page.defaultAppearanceDidChange',
   'Page.domContentEventFired',
   'Page.frameStartedLoading',
   'Page.frameStoppedLoading',
@@ -40,6 +41,10 @@ export default class RpcMessageHandler {
 
   getSpecialMessageHandler (key) {
     return this.specialHandlers[key];
+  }
+
+  deleteSpecialMessageHandler (key) {
+    delete this.specialHandlers[key];
   }
 
   setTimelineEventHandler (timelineEventHandler) {
@@ -287,7 +292,15 @@ export default class RpcMessageHandler {
         await this.handleSpecialMessage('_rpc_reportConnectedDriverList:',
           plist.__argument);
       },
-      '_rpc_applicationSentData:': this.handleDataMessage.bind(this),
+      '_rpc_applicationSentData:': async (plist) => {
+        if (this.hasSpecialMessageHandler('_rpc_applicationSentData:')) {
+          await this.handleSpecialMessage('_rpc_applicationSentData:',
+            plist.__argument.WIRApplicationIdentifierKey,
+            plist.__argument.WIRMessageDataKey.toString());
+        } else {
+          await this.handleDataMessage(plist);
+        }
+      },
     };
   }
 }

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -356,19 +356,7 @@ class RemoteDebugger extends events.EventEmitter {
 
     log.debug(`Selecting page '${pageIdKey}' on app '${this.appIdKey}' and forwarding socket setup`);
 
-    await this.rpcClient.send('setSenderKey', {
-      appIdKey: this.appIdKey,
-      pageIdKey: this.pageIdKey
-    });
-    log.debug('Sender key set');
-
-    this.rpcClient.shouldCheckForTarget = true;
-    await this.rpcClient.send('enablePage', {
-      appIdKey: this.appIdKey,
-      pageIdKey: this.pageIdKey,
-      targetId: 'page-1',
-    });
-    log.debug('Enabled activity on page');
+    await this.rpcClient.selectPage(this.appIdKey, pageIdKey);
 
     // make sure everything is ready to go
     if (!skipReadyCheck && !await this.checkPageIsReady()) {

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -257,7 +257,11 @@ export default class RpcClient {
       // way to relate it back to the original message that was sent, and
       // thus to the app and page)
       this.setSpecialMessageHandler('_rpc_applicationSentData:', reject, (appId, data) => {
-        data = JSON.parse(data);
+        try {
+          data = JSON.parse(data);
+        } catch (err) {
+          return reject(err);
+        }
         const {targetInfo} = data.params;
         this.addTarget(appIdKey, pageIdKey, targetInfo);
         resolve();

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -57,21 +57,29 @@ export default class RpcClient {
     }
   }
 
-  async waitForTarget () {
-    if (!this.shouldCheckForTarget || !this.isTargetBased) {
+  needsTarget () {
+    return this.shouldCheckForTarget && this.isTargetBased;
+  }
+
+  async waitForTarget (appIdKey, pageIdKey) {
+    if (!this.needsTarget()) {
       return;
     }
 
     await retryInterval(WAIT_FOR_TARGET_RETRIES, WAIT_FOR_TARGET_INTERVAL, () => {
-      if (_.isEmpty(this.targets)) {
+      if (_.isEmpty(this.getTarget(appIdKey, pageIdKey))) {
         throw new Error('No targets found, unable to communicate with device');
       }
     });
   }
 
   async send (command, opts = {}) {
+    const {
+      appIdKey,
+      pageIdKey
+    } = opts;
     try {
-      await this.waitForTarget();
+      await this.waitForTarget(appIdKey, pageIdKey);
       return await this.sendToDevice(command, opts);
     } catch (err) {
       if (err.message.includes(`'Target' domain was not found`)) {
@@ -79,7 +87,7 @@ export default class RpcClient {
         return await this.sendToDevice(command, opts);
       } else if (err.message.includes(`domain was not found`)) {
         this.setCommunicationProtocol(true);
-        await this.waitForTarget();
+        await this.waitForTarget(appIdKey, pageIdKey);
         return await this.sendToDevice(command, opts);
       }
       throw err;
@@ -138,8 +146,8 @@ export default class RpcClient {
         // make sure the message being sent has all the information that is needed
         if (cmd.__argument.WIRSocketDataKey.params) {
           cmd.__argument.WIRSocketDataKey.params.id = msgId;
-          if (!cmd.__argument.WIRSocketDataKey.params.targetId) {
-            cmd.__argument.WIRSocketDataKey.params.targetId = `page-${sendOpts.pageIdKey}`;
+          if (!cmd.__argument.WIRSocketDataKey.params.targetId && this.needsTarget()) {
+            cmd.__argument.WIRSocketDataKey.params.targetId = this.getTarget(sendOpts.appIdKey, sendOpts.pageIdKey);
           }
           if (cmd.__argument.WIRSocketDataKey.params.message) {
             cmd.__argument.WIRSocketDataKey.params.message.id = msgId;
@@ -167,20 +175,21 @@ export default class RpcClient {
     throw new Error(`Sub-classes need to implement a 'sendMessage' function`);
   }
 
-  addTarget (targetInfo) {
+  addTarget (appIdKey, pageIdKey, targetInfo) {
     if (_.isUndefined(targetInfo) || _.isUndefined(targetInfo.targetId)) {
       log.debug(`Received 'targetCreated' event with no target. Skipping`);
       return;
     }
-    log.debug(`Target created: ${JSON.stringify(targetInfo)}`);
-    if (!this.targets.includes(targetInfo.targetId)) {
-      this.targets.push(targetInfo.targetId);
+    log.debug(`Target created for app '${appIdKey}' and page '${pageIdKey}': ${JSON.stringify(targetInfo)}`);
+    this.targets[appIdKey] = this.targets[appIdKey] || {};
+    if (_.isEmpty(this.targets[appIdKey][pageIdKey])) {
+      this.targets[appIdKey][pageIdKey] = targetInfo.targetId;
     }
   }
 
   removeTarget (targetInfo) {
     if (_.isUndefined(targetInfo) || _.isUndefined(targetInfo.targetId)) {
-      log.debug(`Received 'taretDestroyed' event with no target. Skipping`);
+      log.debug(`Received 'targetDestroyed' event with no target. Skipping`);
       return;
     }
     log.debug(`Target destroyed: ${JSON.stringify(targetInfo)}`);
@@ -188,18 +197,16 @@ export default class RpcClient {
   }
 
   get targets () {
-    this._targets = this._targets || [];
+    this._targets = this._targets || {};
     return this._targets;
   }
 
-  get target () {
-    if (_.isEmpty(this.targets)) {
+  getTarget (appIdKey, pageIdKey) {
+    const target = (this.targets[appIdKey] || {})[pageIdKey];
+    if (_.isEmpty(target)) {
       throw new Error('No targets found, unable to communicate with device');
     }
-
-    // at the moment, there is no indication of how the mapping works
-    // so take the first?
-    return _.first(this.targets);
+    return target;
   }
 
   get shouldCheckForTarget () {
@@ -230,12 +237,48 @@ export default class RpcClient {
     return this.messageHandler.getSpecialMessageHandler(key);
   }
 
+  deleteSpecialMessageHandler (key) {
+    this.messageHandler.deleteSpecialMessageHandler(key);
+  }
+
   setDataMessageHandler (key, errorHandler, handler) {
     this.messageHandler.setDataMessageHandler(key, errorHandler, handler);
   }
 
   allowNavigationWithoutReload (allow = true) {
     this.messageHandler.allowNavigationWithoutReload(allow);
+  }
+
+  async selectPage (appIdKey, pageIdKey) {
+    await new B(async (resolve, reject) => {
+      // this needs to be specially set here, rather than using the usual
+      // machinery, because the response is a generic data response, and it
+      // does not include the corresponding message id (i.e., there is no
+      // way to relate it back to the original message that was sent, and
+      // thus to the app and page)
+      this.setSpecialMessageHandler('_rpc_applicationSentData:', reject, (appId, data) => {
+        data = JSON.parse(data);
+        const {targetInfo} = data.params;
+        this.addTarget(appIdKey, pageIdKey, targetInfo);
+        resolve();
+      });
+      await this.send('setSenderKey', {
+        appIdKey,
+        pageIdKey,
+      });
+      log.debug('Sender key set');
+      if (!this.isTargetBased) {
+        resolve();
+      }
+    }).finally(() => {
+      this.deleteSpecialMessageHandler('_rpc_applicationSentData:');
+    });
+    this.shouldCheckForTarget = true;
+    await this.send('enablePage', {
+      appIdKey,
+      pageIdKey,
+    });
+    log.debug('Enabled activity on page');
   }
 
   async selectApp (appIdKey, applicationConnectedHandler) {

--- a/test/functional/safari-e2e-specs.js
+++ b/test/functional/safari-e2e-specs.js
@@ -36,6 +36,7 @@ async function deleteDeviceWithRetry (udid) {
 
 describe('Safari remote debugger', function () {
   this.timeout(240000);
+  this.retries(2);
 
   let sim;
   let simCreated = false;
@@ -76,7 +77,9 @@ describe('Safari remote debugger', function () {
     await openUrl(sim.udid, address);
   });
   afterEach(async function () {
-    await rd.disconnect();
+    if (rd) {
+      await rd.disconnect();
+    }
   });
 
   async function connect (rd) {

--- a/test/functional/safari-e2e-specs.js
+++ b/test/functional/safari-e2e-specs.js
@@ -80,6 +80,7 @@ describe('Safari remote debugger', function () {
     if (rd) {
       await rd.disconnect();
     }
+    rd = null;
   });
 
   async function connect (rd) {


### PR DESCRIPTION
It turns out that on iOS 13 there is no relation between target id and page id (earlier page id `1` would be `page-1` as a target).

So handle mapping the three variables (app id, page id, target id).

Add Xcode 11/iOS 13 to Travis build.