### PR TITLE
fix: better handling of targets

### DIFF
--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -43,10 +43,6 @@ export default class RpcMessageHandler {
     return this.specialHandlers[key];
   }
 
-  deleteSpecialMessageHandler (key) {
-    delete this.specialHandlers[key];
-  }
-
   setTimelineEventHandler (timelineEventHandler) {
     this.timelineEventHandler = timelineEventHandler;
   }
@@ -293,13 +289,7 @@ export default class RpcMessageHandler {
           plist.__argument);
       },
       '_rpc_applicationSentData:': async (plist) => {
-        if (this.hasSpecialMessageHandler('_rpc_applicationSentData:')) {
-          await this.handleSpecialMessage('_rpc_applicationSentData:',
-            plist.__argument.WIRApplicationIdentifierKey,
-            plist.__argument.WIRMessageDataKey.toString());
-        } else {
-          await this.handleDataMessage(plist);
-        }
+        await this.handleDataMessage(plist);
       },
     };
   }

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -339,17 +339,18 @@ class RemoteDebugger extends events.EventEmitter {
 
       let fullPageArray = [];
       for (const [app, info] of _.toPairs(this.appDict)) {
-        if (!_.isArray(info.pageArray)) continue; // eslint-disable-line curly
-        let id = app.replace('PID:', '');
+        if (!_.isArray(info.pageArray)) {
+          continue;
+        }
+        const id = app.replace('PID:', '');
         for (const page of info.pageArray) {
-          if (page.url && (!ignoreAboutBlankUrl || page.url !== 'about:blank') && (!currentUrl || page.url === currentUrl || page.url === `${currentUrl}/`)) {
+          if (page.url && (!ignoreAboutBlankUrl || page.url !== 'about:blank')) {
             let pageDict = _.clone(page);
             pageDict.id = `${id}.${pageDict.id}`;
             fullPageArray.push(pageDict);
           }
         }
       }
-
       return fullPageArray;
     } finally {
       this.rpcClient.shouldCheckForTarget = shouldCheckForTarget;

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -175,11 +175,19 @@ export default class RpcClient {
     throw new Error(`Sub-classes need to implement a 'sendMessage' function`);
   }
 
-  addTarget (appIdKey, pageIdKey, targetInfo) {
+  addTarget (targetInfo) {
     if (_.isUndefined(targetInfo) || _.isUndefined(targetInfo.targetId)) {
-      log.debug(`Received 'targetCreated' event with no target. Skipping`);
+      log.warn(`Received 'targetCreated' event with no target. Skipping`);
       return;
     }
+    if (_.isEmpty(this.pendingTargetNotification)) {
+      log.warn(`Received 'targetCreated' event with no pending request: ${JSON.stringify(targetInfo)}`);
+      return;
+    }
+
+    const [appIdKey, pageIdKey] = this.pendingTargetNotification || [];
+    this.pendingTargetNotification = null;
+
     log.debug(`Target created for app '${appIdKey}' and page '${pageIdKey}': ${JSON.stringify(targetInfo)}`);
     this.targets[appIdKey] = this.targets[appIdKey] || {};
     if (_.isEmpty(this.targets[appIdKey][pageIdKey])) {
@@ -234,10 +242,6 @@ export default class RpcClient {
     return this.messageHandler.getSpecialMessageHandler(key);
   }
 
-  deleteSpecialMessageHandler (key) {
-    this.messageHandler.deleteSpecialMessageHandler(key);
-  }
-
   setDataMessageHandler (key, errorHandler, handler) {
     this.messageHandler.setDataMessageHandler(key, errorHandler, handler);
   }
@@ -247,33 +251,14 @@ export default class RpcClient {
   }
 
   async selectPage (appIdKey, pageIdKey) {
-    await new B(async (resolve, reject) => {
-      // this needs to be specially set here, rather than using the usual
-      // machinery, because the response is a generic data response, and it
-      // does not include the corresponding message id (i.e., there is no
-      // way to relate it back to the original message that was sent, and
-      // thus to the app and page)
-      this.setSpecialMessageHandler('_rpc_applicationSentData:', reject, (appId, data) => {
-        try {
-          data = JSON.parse(data);
-        } catch (err) {
-          return reject(err);
-        }
-        const {targetInfo} = data.params;
-        this.addTarget(appIdKey, pageIdKey, targetInfo);
-        resolve();
-      });
-      await this.send('setSenderKey', {
-        appIdKey,
-        pageIdKey,
-      });
-      log.debug('Sender key set');
-      if (!this.isTargetBased) {
-        resolve();
-      }
-    }).finally(() => {
-      this.deleteSpecialMessageHandler('_rpc_applicationSentData:');
+    this.pendingTargetNotification = [appIdKey, pageIdKey];
+    this.shouldCheckForTarget = false;
+    await this.send('setSenderKey', {
+      appIdKey,
+      pageIdKey,
     });
+    log.debug('Sender key set');
+
     this.shouldCheckForTarget = true;
     await this.send('enablePage', {
       appIdKey,


### PR DESCRIPTION
The handling I had used would fail when there was lots of chatter, since the synchrony was not upheld.

Also return all the pages when selecting the app, even if the page is not the appropriate one, to help with maintaining page changes within the driver.

Tested with `appium-xcuitest-driver` safari tests, on iOS 12.2, 12.1, and 13.0.