### PR TITLE
fix: remove dependencies we no longer use

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,8 @@
     "appium-support": "^2.28.0",
     "asyncbox": "^2.5.2",
     "bluebird": "^3.4.7",
-    "bufferpack": "0.0.6",
-    "es6-error": "^4.1.1",
     "lodash": "^4.17.11",
-    "request": "^2.79.0",
-    "request-promise": "^4.1.1",
-    "source-map-support": "^0.5.5",
-    "ws": "^7.0.0"
+    "source-map-support": "^0.5.5"
   },
   "scripts": {
     "prepare": "gulp prepublish",
@@ -74,7 +69,6 @@
     "mocha": "^6.0.0",
     "node-simctl": "^5.0.0",
     "pre-commit": "^1.1.3",
-    "sinon": "^7.2.3",
     "uuid-js": "^0.7.5"
   },
   "greenkeeper": {


### PR DESCRIPTION
In the recent shift in implementation in this repo, there were a bunch of dependencies that are no longer being used. So remove them.