### PR TITLE
fix: compute target if we can

### DIFF
--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -66,6 +66,14 @@ export default class RpcClient {
       return;
     }
 
+    // on iOS less than 13 have targets that can be computed easily
+    // and sometimes is not reported by the Web Inspector
+    if (parseInt(this.platformVersion, 10) < 13 && _.isEmpty(this.getTarget(appIdKey, pageIdKey))) {
+      this.addTarget({targetId: `page-${pageIdKey}`});
+      return;
+    }
+
+    // otherwise waiting is necessary to see what the target is
     await retryInterval(WAIT_FOR_TARGET_RETRIES, WAIT_FOR_TARGET_INTERVAL, () => {
       if (_.isEmpty(this.getTarget(appIdKey, pageIdKey))) {
         throw new Error('No targets found, unable to communicate with device');
@@ -98,7 +106,6 @@ export default class RpcClient {
   }
 
   getLoggableResponse (res) {
-
     return _.isString(res)
       ? res
       : this.logFullResponse


### PR DESCRIPTION
On iOS 12 the targets are always `page-<page id>`, while the id can be different, and needs to be waited for.

So, when we can, just compute the target id.