### PR TITLE
feat: add option to include Safari in apps to listen for

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -111,9 +111,10 @@ function appIdForBundle (bundleId, appDict) {
   return appId;
 }
 
-function getPossibleDebuggerAppKeys (bundleId, platformVersion, appDict) {
+function getPossibleDebuggerAppKeys (bundleIds, platformVersion, appDict) {
   let proxiedAppIds = [];
-  if (parseFloat(platformVersion) >= 8) {
+
+  for (const bundleId of bundleIds) {
     const appId = appIdForBundle(bundleId, appDict);
 
     // now we need to determine if we should pick a proxy for this instead
@@ -127,10 +128,6 @@ function getPossibleDebuggerAppKeys (bundleId, platformVersion, appDict) {
           proxiedAppIds.push(key);
         }
       }
-    }
-  } else {
-    if (_.has(appDict, bundleId)) {
-      proxiedAppIds = [bundleId];
     }
   }
 

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -54,6 +54,7 @@ class RemoteDebugger extends events.EventEmitter {
       bundleId,
       platformVersion,
       isSafari = true,
+      includeSafari = false,
       useNewSafari = false,
       pageLoadMs,
       host,
@@ -68,6 +69,7 @@ class RemoteDebugger extends events.EventEmitter {
     this.bundleId = bundleId;
     this.platformVersion = platformVersion;
     this.isSafari = isSafari;
+    this.includeSafari = includeSafari;
     this.useNewSafari = useNewSafari;
     this.pageLoadMs = pageLoadMs;
     log.debug(`useNewSafari --> ${this.useNewSafari}`);
@@ -266,7 +268,7 @@ class RemoteDebugger extends events.EventEmitter {
         return [];
       }
 
-      const { appIdKey, pageDict } = await this.searchApp(currentUrl, maxTries, ignoreAboutBlankUrl);
+      const { appIdKey, pageDict } = await this.searchForApp(currentUrl, maxTries, ignoreAboutBlankUrl);
 
       // if, after all this, we have no dictionary, we have failed
       if (!appIdKey || !pageDict) {
@@ -307,11 +309,14 @@ class RemoteDebugger extends events.EventEmitter {
     }
   }
 
-  async searchApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
+  async searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
+    const bundleIds = this.includeSafari
+      ? [this.bundleId, SAFARI_BUNDLE_ID]
+      : [this.bundleId];
     try {
       return await retryInterval(maxTries, SELECT_APP_RETRY_SLEEP_MS, async (retryCount) => {
         this.logApplicationDictionary(this.appDict);
-        const possibleAppIds = getPossibleDebuggerAppKeys(this.bundleId, this.platformVersion, this.appDict);
+        const possibleAppIds = getPossibleDebuggerAppKeys(bundleIds, this.platformVersion, this.appDict);
         log.debug(`Trying out the possible app ids: ${possibleAppIds.join(', ')}`);
         for (const attemptedAppIdKey of possibleAppIds) {
           try {


### PR DESCRIPTION
Right now, we only ever allow a user to get a webview associated with the main bundle under test. That is, we check the apps the Web Inspector returns against the bundle identifier for the app under test, and only return those.

There is no theoretical reason for this. While we may at some point want to be able to do multiple bundle ids, this PR simply allows an option to sent to the remote debugger to include Safari, if it is there, in the apps.

This has the effect that if an app opens Safari (as in https://github.com/appium/appium/issues/13171) from their app, they can automate it.