### PR TITLE
fix: do not receive rpc messages when 'disconnected'

### DIFF
--- a/lib/rpc-client-real-device.js
+++ b/lib/rpc-client-real-device.js
@@ -37,6 +37,9 @@ export default class RpcClientRealDevice extends RpcClient {
   }
 
   async receive (data) { // eslint-disable-line require-await
+    if (!this.isConnected()) {
+      return;
+    }
     this.messageHandler.handleMessage(data);
   }
 }

--- a/lib/rpc-client-simulator.js
+++ b/lib/rpc-client-simulator.js
@@ -133,6 +133,10 @@ export default class RpcClientSimulator extends RpcClient {
   }
 
   async receive (data) {
+    if (!this.isConnected()) {
+      return;
+    }
+
     if (!data) {
       return;
     }


### PR DESCRIPTION
The remote debugger keeps listening to the socket until it is fully destroyed, which leads to weird logs where we've finished a session but events keep happening. This is easily rectified.