### PR TITLE
fix: use promises instead of http/https for async execute

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,10 +4,13 @@ import _ from 'lodash';
 import assert from 'assert';
 import B from 'bluebird';
 import { util } from 'appium-support';
+import { errorFromMJSONWPStatusCode } from 'appium-base-driver';
 
 
 const WEB_CONTENT_BUNDLE_ID = 'com.apple.WebKit.WebContent';
 const MIN_PLATFORM_FOR_TARGET_BASED = '12.2';
+
+const RESPONSE_LOG_LENGTH = 100;
 
 /*
  * Takes a dictionary from the remote debugger and makes a more manageable
@@ -221,8 +224,33 @@ function getElapsedTime (startTime) {
   return parseInt((endTime[0] * 1e9 + endTime[1]) / 1e6, 10);
 }
 
+function convertResult (res) {
+  if (_.isUndefined(res)) {
+    throw new Error(`Did not get OK result from remote debugger. Result was: ${_.truncate(simpleStringify(res), {length: RESPONSE_LOG_LENGTH})}`);
+  } else if (_.isString(res)) {
+    try {
+      res = JSON.parse(res);
+    } catch (err) {
+      // we might get a serialized object, but we might not
+      // if we get here, it is just a value
+    }
+  } else if (!_.isObject(res)) {
+    throw new Error(`Result has unexpected type: (${typeof res}).`);
+  }
+
+  if (res.status && res.status !== 0) {
+    // we got some form of error.
+    throw errorFromMJSONWPStatusCode(res.status, res.value.message || res.value);
+  }
+
+  // with either have an object with a `value` property (even if `null`),
+  // or a plain object
+  return _.has(res, 'value') ? res.value : res;
+}
+
 export {
   appInfoFromDict, pageArrayFromDict, getDebuggerAppKey,
   getPossibleDebuggerAppKeys, checkParams, wrapScriptForFrame, getScriptForAtom,
   simpleStringify, deferredPromise, isTargetBased, getElapsedTime,
+  convertResult, RESPONSE_LOG_LENGTH,
 };

--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -181,27 +181,6 @@ export default class RpcMessageHandler {
     let msgId = (dataKey.id || '').toString();
     let result = dataKey.result;
 
-    // we can get an error, or we can get a response that is an error
-    let error = dataKey.error || null;
-    if (result && result.wasThrown) {
-      let message = (result.result && (result.result.value || result.result.description))
-        ? (result.result.value || result.result.description)
-        : 'Error occurred in handling data message';
-      error = new Error(message);
-    }
-
-    if (error) {
-      if (this.hasErrorHandler(msgId)) {
-        this.errorHandlers[msgId](error);
-      } else {
-        log.error(`Error occurred in handling data message: ${error}`);
-        log.error('No error handler present, ignoring');
-      }
-
-      // short circuit
-      return;
-    }
-
     let method = dataKey.method;
     let params;
     if (this.isTargetBased) {
@@ -240,6 +219,27 @@ export default class RpcMessageHandler {
       }
     } else {
       params = dataKey.params;
+    }
+
+    // we can get an error, or we can get a response that is an error
+    let error = dataKey.error || null;
+    if (result && result.wasThrown) {
+      let message = (result.result && (result.result.value || result.result.description))
+        ? (result.result.value || result.result.description)
+        : 'Error occurred in handling data message';
+      error = new Error(message);
+    }
+
+    if (error) {
+      if (this.hasErrorHandler(msgId)) {
+        this.errorHandlers[msgId](error);
+      } else {
+        log.error(`Error occurred in handling data message: ${error}`);
+        log.error('No error handler present, ignoring');
+      }
+
+      // short circuit
+      return;
     }
 
     if (!_.isEmpty(msgId)) {

--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -224,29 +224,27 @@ export default class RpcMessageHandler {
     // we can get an error, or we can get a response that is an error
     let error = dataKey.error || null;
     if (result && result.wasThrown) {
-      let message = (result.result && (result.result.value || result.result.description))
+      const message = (result.result && (result.result.value || result.result.description))
         ? (result.result.value || result.result.description)
         : 'Error occurred in handling data message';
       error = new Error(message);
     }
 
-    if (error) {
-      if (this.hasErrorHandler(msgId)) {
-        this.errorHandlers[msgId](error);
-      } else {
-        log.error(`Error occurred in handling data message: ${error}`);
-        log.error('No error handler present, ignoring');
+    if (!error) {
+      if (!_.isEmpty(msgId)) {
+        log.debug(`Received response for message '${msgId}'`);
       }
 
-      // short circuit
-      return;
+      return await this.dispatchDataMessage(msgId, method, params, result, error);
     }
 
-    if (!_.isEmpty(msgId)) {
-      log.debug(`Received response for message '${msgId}'`);
+    // handle the error
+    if (this.hasErrorHandler(msgId)) {
+      this.errorHandlers[msgId](error);
+    } else {
+      log.error(`Error occurred in handling data message: ${error}`);
+      log.error('No error handler present, ignoring');
     }
-
-    await this.dispatchDataMessage(msgId, method, params, result, error);
   }
 
   setHandlers () {

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -1,6 +1,6 @@
 import events from 'events';
 import log from './logger';
-import { errorFromMJSONWPStatusCode } from 'appium-base-driver';
+import { errorFromMJSONWPStatusCode, errors } from 'appium-base-driver';
 import RpcClientSimulator from './rpc-client-simulator';
 import messageHandlers from './message-handlers';
 import { appInfoFromDict, pageArrayFromDict, getDebuggerAppKey,
@@ -444,17 +444,23 @@ class RemoteDebugger extends events.EventEmitter {
         throw err;
       }
 
-      // awaitPromise is not always available, so simulate it!
-      while (true) { // eslint-disable-line no-constant-condition
+      // awaitPromise is not always available, so simulate it with poll
+      const retryWait = 100;
+      const timeout = (args.length >= 3) ? args[2] : RPC_RESPONSE_TIMEOUT_MS;
+      const retries = parseInt(timeout / retryWait, 10);
+      const startTime = process.hrtime();
+      res = await retryInterval(retries, retryWait, async () => {
         // the atom _will_ return, either because it finished or an error
-        // including a timeout error, so just go until it finishes
+        // including a timeout error
         if (await this.executeAtom('execute_script', [`return window.hasOwnProperty('${promiseName}Value');`, []], frames)) {
           // we only put the property on `window` when the callback is called,
           // so if it is there, everything is done
-          res = await this.executeAtom('execute_script', [`return window.${promiseName}Value;`, []], frames);
-          break;
+          return await this.executeAtom('execute_script', [`return window.${promiseName}Value;`, []], frames);
         }
-      }
+        // throw a TimeoutError, or else it needs to be caught and re-thrown
+        throw new errors.TimeoutError(`Timed out waiting for asynchronous script ` +
+                                      `result after ${getElapsedTime(startTime)} ms'));`);
+      });
     }
     res = JSON.parse(res);
     if (res.status !== 0) {

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -11,6 +11,7 @@ import { retryInterval } from 'asyncbox';
 import _ from 'lodash';
 import B from 'bluebird';
 import path from 'path';
+import UUID from 'uuid-js';
 
 
 let VERSION;
@@ -406,7 +407,7 @@ class RemoteDebugger extends events.EventEmitter {
   async executeAtomAsync (atom, args, frames) {
     // first create a Promise on the page, saving the resolve/reject functions
     // as properties
-    const promiseName = `appiumAsyncExecutePromise${Date.now()}`;
+    const promiseName = `appiumAsyncExecutePromise${UUID.create().toString().replace(/-/g, '')}`;
     let script = `var res, rej;` +
                  `window.${promiseName} = new Promise(function (resolve, reject) {` +
                  `  res = resolve;` +

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -432,6 +432,7 @@ class RemoteDebugger extends events.EventEmitter {
 
     // wait for the promise to be resolved
     let res;
+    const subcommandTimeout = 1000; // timeout on individual commands
     try {
       res = await this.rpcClient.send('awaitPromise', {
         promiseObjectId,
@@ -451,15 +452,20 @@ class RemoteDebugger extends events.EventEmitter {
       res = await retryInterval(retries, retryWait, async () => {
         // the atom _will_ return, either because it finished or an error
         // including a timeout error
-        if (await this.executeAtom('execute_script', [`return window.hasOwnProperty('${promiseName}Value');`, []], frames)) {
+        if (await this.executeAtom('execute_script', [`return window.hasOwnProperty('${promiseName}Value');`, [null, null], subcommandTimeout], frames)) {
           // we only put the property on `window` when the callback is called,
           // so if it is there, everything is done
-          return await this.executeAtom('execute_script', [`return window.${promiseName}Value;`, []], frames);
+          return await this.executeAtom('execute_script', [`return window.${promiseName}Value;`, [null, null], subcommandTimeout], frames);
         }
         // throw a TimeoutError, or else it needs to be caught and re-thrown
         throw new errors.TimeoutError(`Timed out waiting for asynchronous script ` +
                                       `result after ${getElapsedTime(startTime)} ms'));`);
       });
+    } finally {
+      try {
+        // try to get rid of the promise
+        await this.executeAtom('execute_script', [`delete window.${promiseName};`, [null, null], subcommandTimeout], frames);
+      } catch (ign) {}
     }
     return convertResult(res);
   }

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -1,11 +1,12 @@
 import events from 'events';
 import log from './logger';
-import { errorFromMJSONWPStatusCode, errors } from 'appium-base-driver';
+import { errors } from 'appium-base-driver';
 import RpcClientSimulator from './rpc-client-simulator';
 import messageHandlers from './message-handlers';
 import { appInfoFromDict, pageArrayFromDict, getDebuggerAppKey,
          getPossibleDebuggerAppKeys, checkParams, getScriptForAtom,
-         simpleStringify, deferredPromise, getElapsedTime } from './helpers';
+         simpleStringify, deferredPromise, getElapsedTime, convertResult,
+         RESPONSE_LOG_LENGTH } from './helpers';
 import { util } from 'appium-support';
 import { retryInterval } from 'asyncbox';
 import _ from 'lodash';
@@ -29,8 +30,6 @@ const BLANK_PAGE_URL = 'about:blank';
 const RPC_RESPONSE_TIMEOUT_MS = 5000;
 
 const PAGE_READY_TIMEOUT = 5000;
-
-const RESPONSE_LOG_LENGTH = 100;
 
 const GARBAGE_COLLECT_TIMEOUT = 5000;
 
@@ -462,11 +461,7 @@ class RemoteDebugger extends events.EventEmitter {
                                       `result after ${getElapsedTime(startTime)} ms'));`);
       });
     }
-    res = JSON.parse(res);
-    if (res.status !== 0) {
-      throw errorFromMJSONWPStatusCode(res.status, res.value.message);
-    }
-    return res.value;
+    return convertResult(res);
   }
 
   frameDetached () {
@@ -697,7 +692,7 @@ class RemoteDebugger extends events.EventEmitter {
       pageIdKey: this.pageIdKey,
     });
 
-    return this.convertResult(res);
+    return convertResult(res);
   }
 
   async callFunction (objId, fn, args) {
@@ -717,31 +712,7 @@ class RemoteDebugger extends events.EventEmitter {
       pageIdKey: this.pageIdKey,
     });
 
-    return this.convertResult(res);
-  }
-
-  convertResult (res) {
-    if (_.isUndefined(res)) {
-      throw new Error(`Did not get OK result from remote debugger. Result was: ${_.truncate(simpleStringify(res), {length: RESPONSE_LOG_LENGTH})}`);
-    } else if (_.isString(res)) {
-      try {
-        res = JSON.parse(res);
-      } catch (err) {
-        // we might get a serialized object, but we might not
-        // if we get here, it is just a value
-      }
-    } else if (!_.isObject(res)) {
-      throw new Error(`Result has unexpected type: (${typeof res}).`);
-    }
-
-    if (res.status && res.status !== 0) {
-      // we got some form of error.
-      throw errorFromMJSONWPStatusCode(res.status, res.value.message || res.value);
-    }
-
-    // with either have an object with a `value` property (even if `null`),
-    // or a plain object
-    return res.hasOwnProperty('value') ? res.value : res;
+    return convertResult(res);
   }
 
   allowNavigationWithoutReload (allow = true) {

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -1,6 +1,6 @@
 import events from 'events';
 import log from './logger';
-import { errorFromCode } from 'appium-base-driver';
+import { errorFromMJSONWPStatusCode } from 'appium-base-driver';
 import RpcClientSimulator from './rpc-client-simulator';
 import messageHandlers from './message-handlers';
 import { appInfoFromDict, pageArrayFromDict, getDebuggerAppKey,
@@ -403,13 +403,63 @@ class RemoteDebugger extends events.EventEmitter {
     return value;
   }
 
-  async executeAtomAsync (atom, args, frames, responseUrl) {
-    let asyncCallBack = `function (res) { xmlHttp = new XMLHttpRequest(); ` +
-                        `xmlHttp.open('POST', '${responseUrl}', true);` +
-                        `xmlHttp.setRequestHeader('Content-type','application/json'); ` +
-                        `xmlHttp.send(res); }`;
-    let script = await getScriptForAtom(atom, args, frames, asyncCallBack);
-    await this.execute(script);
+  async executeAtomAsync (atom, args, frames) {
+    // first create a Promise on the page, saving the resolve/reject functions
+    // as properties
+    const promiseName = `appiumAsyncExecutePromise${Date.now()}`;
+    let script = `var res, rej;` +
+                 `window.${promiseName} = new Promise(function (resolve, reject) {` +
+                 `  res = resolve;` +
+                 `  rej = reject;` +
+                 `});` +
+                 `window.${promiseName}.resolve = res;` +
+                 `window.${promiseName}.reject = rej;` +
+                 `window.${promiseName};`;
+    const obj = await this.rpcClient.send('sendJSCommand', {
+      command: script,
+      appIdKey: this.appIdKey,
+      pageIdKey: this.pageIdKey,
+      returnByValue: false,
+    });
+    const promiseObjectId = obj.result.objectId;
+
+    // execute the atom, calling back to the resolve function
+    const asyncCallBack = `function (res) {` +
+                          `  window.${promiseName}.resolve(res);` +
+                          `  window.${promiseName}Value = res;` +
+                          `}`;
+    await this.execute(await getScriptForAtom(atom, args, frames, asyncCallBack));
+
+    // wait for the promise to be resolved
+    let res;
+    try {
+      res = await this.rpcClient.send('awaitPromise', {
+        promiseObjectId,
+        appIdKey: this.appIdKey,
+        pageIdKey: this.pageIdKey,
+      });
+    } catch (err) {
+      if (!err.message.includes(`'Runtime.awaitPromise' was not found`)) {
+        throw err;
+      }
+
+      // awaitPromise is not always available, so simulate it!
+      while (true) { // eslint-disable-line no-constant-condition
+        // the atom _will_ return, either because it finished or an error
+        // including a timeout error, so just go until it finishes
+        if (await this.executeAtom('execute_script', [`return window.hasOwnProperty('${promiseName}Value');`, []], frames)) {
+          // we only put the property on `window` when the callback is called,
+          // so if it is there, everything is done
+          res = await this.executeAtom('execute_script', [`return window.${promiseName}Value;`, []], frames);
+          break;
+        }
+      }
+    }
+    res = JSON.parse(res);
+    if (res.status !== 0) {
+      throw errorFromMJSONWPStatusCode(res.status, res.value.message);
+    }
+    return res.value;
   }
 
   frameDetached () {
@@ -633,7 +683,7 @@ class RemoteDebugger extends events.EventEmitter {
       await this.garbageCollect();
     }
 
-    log.debug(`Sending javascript command ${_.truncate(command, {length: 50})}`);
+    log.debug(`Sending javascript command: '${_.truncate(command, {length: 50})}'`);
     let res = await this.rpcClient.send('sendJSCommand', {
       command,
       appIdKey: this.appIdKey,
@@ -679,7 +729,7 @@ class RemoteDebugger extends events.EventEmitter {
 
     if (res.status && res.status !== 0) {
       // we got some form of error.
-      throw errorFromCode(res.status, res.value.message || res.value);
+      throw errorFromMJSONWPStatusCode(res.status, res.value.message || res.value);
     }
 
     // with either have an object with a `value` property (even if `null`),

--- a/lib/remote-messages.js
+++ b/lib/remote-messages.js
@@ -83,7 +83,7 @@ class RemoteMessages {
     const method = 'Runtime.evaluate';
     const params = {
       expression: opts.command,
-      returnByValue: true,
+      returnByValue: _.isBoolean(opts.returnByValue) ? opts.returnByValue : true,
     };
     return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
   }
@@ -173,6 +173,17 @@ class RemoteMessages {
     return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
   }
 
+  awaitPromise (connId, senderId, appIdKey, pageIdKey, opts) {
+    const method = 'Runtime.awaitPromise';
+    const params = {
+      promiseObjectId: opts.promiseObjectId,
+      returnByValue: true,
+      generatePreview: true,
+      saveResult: true,
+    };
+    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
+  }
+
 
   /*
    * Internal functions
@@ -249,6 +260,8 @@ class RemoteMessages {
         return this.deleteCookie(connId, senderId, appIdKey, pageIdKey, opts);
       case 'garbageCollect':
         return this.garbageCollect(connId, senderId, appIdKey, pageIdKey);
+      case 'awaitPromise':
+        return this.awaitPromise(connId, senderId, appIdKey, pageIdKey, opts);
       default:
         throw new Error(`Unknown command: ${command}`);
     }

--- a/test/functional/safari-e2e-specs.js
+++ b/test/functional/safari-e2e-specs.js
@@ -7,6 +7,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { createRemoteDebugger } from '../..';
 import { startHttpServer, stopHttpServer, PAGE_TITLE } from './http-server';
+import B from 'bluebird';
 
 
 chai.should();
@@ -36,7 +37,7 @@ async function deleteDeviceWithRetry (udid) {
 
 describe('Safari remote debugger', function () {
   this.timeout(480000);
-  // this.retries(2);
+  this.retries(2);
 
   let sim;
   let simCreated = false;
@@ -85,6 +86,8 @@ describe('Safari remote debugger', function () {
     }, false);
 
     await openUrl(sim.udid, address);
+    // pause a moment while Safari loads
+    await B.delay(2000);
   });
   afterEach(async function () {
     if (rd) {

--- a/test/functional/safari-e2e-specs.js
+++ b/test/functional/safari-e2e-specs.js
@@ -36,7 +36,7 @@ async function deleteDeviceWithRetry (udid) {
 
 describe('Safari remote debugger', function () {
   this.timeout(480000);
-  this.retries(2);
+  // this.retries(2);
 
   let sim;
   let simCreated = false;
@@ -117,6 +117,42 @@ describe('Safari remote debugger', function () {
     const script = 'return 1 + 1;';
     const sum = await rd.executeAtom('execute_script', [script, []], []);
     sum.should.eql(2);
+  });
+
+  describe('executeAtomAsync', function () {
+    const timeout = 1000;
+    it('should be able to execute an atom asynchronously', async function () {
+      await connect(rd);
+      const page = _.find(await rd.selectApp(address), (page) => page.title === PAGE_TITLE);
+      const [appIdKey, pageIdKey] = page.id.split('.').map((id) => parseInt(id, 10));
+      await rd.selectPage(appIdKey, pageIdKey);
+
+      const script = 'arguments[arguments.length - 1](123);';
+      await rd.executeAtomAsync('execute_async_script', [script, [], timeout], [])
+        .should.eventually.eql(123);
+    });
+
+    it('should bubble up JS errors', async function () {
+      await connect(rd);
+      const page = _.find(await rd.selectApp(address), (page) => page.title === PAGE_TITLE);
+      const [appIdKey, pageIdKey] = page.id.split('.').map((id) => parseInt(id, 10));
+      await rd.selectPage(appIdKey, pageIdKey);
+
+      const script = `arguments[arguments.length - 1](1--);`;
+      await rd.executeAtomAsync('execute_async_script', [script, [], timeout], [])
+        .should.eventually.be.rejectedWith(/operator applied to value that is not a reference/);
+    });
+
+    it('should timeout when callback is not invoked', async function () {
+      await connect(rd);
+      const page = _.find(await rd.selectApp(address), (page) => page.title === PAGE_TITLE);
+      const [appIdKey, pageIdKey] = page.id.split('.').map((id) => parseInt(id, 10));
+      await rd.selectPage(appIdKey, pageIdKey);
+
+      const script = 'return 1 + 2';
+      await rd.executeAtomAsync('execute_async_script', [script, [], timeout], [])
+        .should.eventually.be.rejectedWith(/Timed out waiting for/);
+    });
   });
 
   it(`should be able to call 'selectApp' after already connecting to app`, async function () {


### PR DESCRIPTION
iOS 13 stopped allowing us to install a self-signed certificate, at least in the way we had been. This means that asynchronous execution also stopped working (see https://github.com/appium/appium/issues/13184). 

@umutuzgur found the `Runtime.awaitPromise` function in [WebKit](https://github.com/WebKit/webkit/blob/master/Source/JavaScriptCore/inspector/protocol/Runtime.json#L230-L245) and this PR implements the functionality of asynchronous execution using it.

Unfortunately the function is relatively new, so versions that don't have it fall back to polling for the result to exist. Luckily timeouts are still handled by the Selenium atom.