### PR TITLE
fix: connection issues

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -21,6 +21,13 @@ function appInfoFromDict (dict) {
   const isProxy = _.isString(dict.WIRIsApplicationProxyKey)
     ? dict.WIRIsApplicationProxyKey.toLowerCase() === 'true'
     : dict.WIRIsApplicationProxyKey;
+  const isAutomationEnabled = _.has(dict, 'WIRAutomationAvailabilityKey')
+    ? _.isString(dict.WIRAutomationAvailabilityKey)
+      ? dict.WIRAutomationAvailabilityKey === 'WIRAutomationAvailabilityUnknown'
+        ? 'Unknown'
+        : dict.WIRAutomationAvailabilityKey === 'WIRAutomationAvailabilityAvailable'
+      : dict.WIRAutomationAvailabilityKey
+    : !!dict.WIRRemoteAutomationEnabledKey;
   const entry = {
     id,
     isProxy,
@@ -28,7 +35,7 @@ function appInfoFromDict (dict) {
     bundleId: dict.WIRApplicationBundleIdentifierKey,
     hostId: dict.WIRHostApplicationIdentifierKey,
     isActive: dict.WIRIsApplicationActiveKey,
-    isAutomationEnabled: !!dict.WIRRemoteAutomationEnabledKey,
+    isAutomationEnabled,
   };
 
   return [id, entry];

--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -1,6 +1,6 @@
 import log from './logger';
 import { RemoteDebugger } from './remote-debugger';
-import { pageArrayFromDict, getDebuggerAppKey, simpleStringify } from './helpers';
+import { pageArrayFromDict, getDebuggerAppKey, simpleStringify, appInfoFromDict } from './helpers';
 import _ from 'lodash';
 
 
@@ -100,6 +100,28 @@ function onTargetDestroyed (app, targetInfo) {
   this.rpcClient.removeTarget(targetInfo);
 }
 
+function onConnectedDriverList (drivers) {
+  this.connectedDrivers = drivers.WIRDriverDictionaryKey;
+  log.debug(`Received connected driver list: ${JSON.stringify(this.connectedDrivers)}`);
+}
+
+function onConnectedApplicationList (apps) {
+  log.debug(`Received connected applications list: ${_.keys(apps).join(', ')}`);
+
+  // translate the received information into an easier-to-manage
+  // hash with app id as key, and app info as value
+  let newDict = {};
+  for (const dict of _.values(apps)) {
+    const [id, entry] = appInfoFromDict(dict);
+    if (this.skippedApps.includes(entry.name)) {
+      continue;
+    }
+    newDict[id] = entry;
+  }
+  // update the object's list of apps
+  _.defaults(this.appDict, newDict);
+}
+
 const messageHandlers = {
   onPageChange,
   onAppConnect,
@@ -107,6 +129,8 @@ const messageHandlers = {
   onAppUpdate,
   onTargetCreated,
   onTargetDestroyed,
+  onConnectedDriverList,
+  onConnectedApplicationList,
 };
 
 export default messageHandlers;

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -99,11 +99,11 @@ class RemoteDebugger extends events.EventEmitter {
     this.specialCbs = {
       '_rpc_reportIdentifier:': _.noop,
       '_rpc_forwardGetListing:': this.onPageChange.bind(this),
-      '_rpc_reportConnectedApplicationList:': _.noop,
+      '_rpc_reportConnectedApplicationList:': this.onConnectedApplicationList.bind(this),
       '_rpc_applicationConnected:': this.onAppConnect.bind(this),
       '_rpc_applicationDisconnected:': this.onAppDisconnect.bind(this),
       '_rpc_applicationUpdated:': this.onAppUpdate.bind(this),
-      '_rpc_reportConnectedDriverList:': _.noop,
+      '_rpc_reportConnectedDriverList:': this.onConnectedDriverList.bind(this),
       pageLoad: this.pageLoad.bind(this),
       frameDetached: this.frameDetached.bind(this),
       targetCreated: this.onTargetCreated.bind(this),
@@ -148,12 +148,12 @@ class RemoteDebugger extends events.EventEmitter {
 
     // get the connection information about the app
     try {
-      const appInfo = await this.setConnectionKey();
-      log.debug('Connected to application');
-      return appInfo;
+      await this.setConnectionKey();
+      return this.appDict || {};
     } catch (err) {
+      log.error(`Error setting connection key: ${err.message}`);
       await this.disconnect();
-      return null;
+      throw err;
     }
   }
 
@@ -168,41 +168,10 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   async setConnectionKey () {
-    // only resolve when the connection response is received
-    return await new B((resolve, reject) => {
-      // local callback, called when the remote debugger has established
-      // a connection to the app under test
-      // `app` will be an array of dictionaries of app information
-      let connectCb = (apps) => {
-        if (_.isUndefined(apps) || _.keys(apps).length === 0) {
-          log.debug('Received no apps from remote debugger. Unable to connect.');
-          return resolve(this.appDict);
-        }
-        let newDict = {};
-
-        // translate the received information into an easier-to-manage
-        // hash with app id as key, and app info as value
-        for (const dict of _.values(apps)) {
-          const [id, entry] = appInfoFromDict(dict);
-          if (this.skippedApps.includes(entry.name)) {
-            continue;
-          }
-          newDict[id] = entry;
-        }
-        // update the object's list of apps, and return it through the promise
-        _.defaults(this.appDict, newDict);
-        resolve(newDict);
-      };
-      this.rpcClient.setSpecialMessageHandler('_rpc_reportConnectedApplicationList:', reject, connectCb);
-
-      log.debug('Sending connection key request');
-      return (async () => {
-        const [simNameKey, simBuildKey, simPlatformVersion] = await this.rpcClient.send('setConnectionKey');
-        log.debug(`Sim name: ${simNameKey}`);
-        log.debug(`Sim build: ${simBuildKey}`);
-        log.debug(`Sim platform version: ${simPlatformVersion}`);
-      })();
-    });
+    log.debug('Sending connection key request');
+    // send but only wait to make sure the socket worked
+    // as response from Web Inspector can take a long time
+    await this.rpcClient.send('setConnectionKey', {}, false);
   }
 
   updateAppsWithDict (dict) {

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -73,18 +73,22 @@ export default class RpcClient {
       return;
     }
 
+    function getNewTargetId (targets) {
+      const targetIds = _.values(targets)
+        .map((targetId) => targetId.replace('page-', ''))
+        .map((targetId) => parseInt(targetId, 10))
+        .sort();
+      const lastTargetId = _.last(targetIds) || 0;
+      return lastTargetId + 1;
+    }
+
     // on iOS less than 13 have targets that can be computed easily
     // and sometimes is not reported by the Web Inspector
     if (util.compareVersions(this.platformVersion, '<', '13.0') && _.isEmpty(this.getTarget(appIdKey, pageIdKey))) {
       if (this.isSafari) {
         this.addTarget({targetId: `page-${pageIdKey}`});
       } else {
-        const targets = this.targets[appIdKey];
-        const targetIds = _.values(targets)
-          .map((targetId) => targetId.replace('page-', ''))
-          .sort();
-        const lastTargetId = _.last(targetIds) || 0;
-        this.addTarget({targetId: `page-${lastTargetId + 1}`});
+        this.addTarget({targetId: `page-${getNewTargetId(this.targets[appIdKey])}`});
       }
       return;
     }
@@ -99,8 +103,11 @@ export default class RpcClient {
     } catch (err) {
       // on some systems sometimes the Web Inspector never sends the target event
       // though the target is available
-      log.debug(`No target found. Trying '${GENERIC_TARGET_ID}', which seems to work`);
-      this.addTarget({targetId: GENERIC_TARGET_ID});
+      let newTargetId = getNewTargetId(this.targets[appIdKey]);
+      // if this is the first one, use the "generic" id
+      newTargetId = newTargetId === 1 ? GENERIC_TARGET_ID : newTargetId;
+      log.debug(`No target found. Trying '${newTargetId}', which seems to work`);
+      this.addTarget({targetId: newTargetId});
     }
   }
 
@@ -252,8 +259,7 @@ export default class RpcClient {
   }
 
   getTarget (appIdKey, pageIdKey) {
-    const target = (this.targets[appIdKey] || {})[pageIdKey];
-    return target;
+    return (this.targets[appIdKey] || {})[pageIdKey];
   }
 
   get shouldCheckForTarget () {

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -33,6 +33,7 @@ export default class RpcClient {
 
     this.connected = false;
     this.connId = UUID.create().toString();
+    // this.connId = 'F8532879-C583-45E1-974C-101AE3D8EEF3';
     this.senderId = UUID.create().toString();
     this.msgId = 0;
     this.logFullResponse = logFullResponse;
@@ -111,7 +112,7 @@ export default class RpcClient {
     }
   }
 
-  async send (command, opts = {}) {
+  async send (command, opts = {}, waitForResponse = true) {
     const startTime = process.hrtime();
     const {
       appIdKey,
@@ -119,15 +120,15 @@ export default class RpcClient {
     } = opts;
     try {
       await this.waitForTarget(appIdKey, pageIdKey);
-      return await this.sendToDevice(command, opts);
+      return await this.sendToDevice(command, opts, waitForResponse);
     } catch (err) {
       if (err.message.includes(`'Target' domain was not found`)) {
         this.setCommunicationProtocol(false);
-        return await this.sendToDevice(command, opts);
+        return await this.sendToDevice(command, opts, waitForResponse);
       } else if (err.message.includes(`domain was not found`)) {
         this.setCommunicationProtocol(true);
         await this.waitForTarget(appIdKey, pageIdKey);
-        return await this.sendToDevice(command, opts);
+        return await this.sendToDevice(command, opts, waitForResponse);
       }
       throw new Error(err);
     } finally {
@@ -143,7 +144,7 @@ export default class RpcClient {
         : _.truncate(JSON.stringify(res), DATA_LOG_LENGTH);
   }
 
-  async sendToDevice (command, opts = {}) {
+  async sendToDevice (command, opts = {}, waitForResponse = true) {
     return await new B(async (resolve, reject) => {
       // promise to be resolved whenever remote debugger
       // replies to our request
@@ -156,51 +157,54 @@ export default class RpcClient {
       const cmd = this.remoteMessages.getRemoteCommand(command, sendOpts);
 
       let messageHandled = false;
-      if (this.messageHandler.hasSpecialMessageHandler(cmd.__selector)) {
-        messageHandled = true;
+      // if we do not want to wait for response, just pass through here
+      if (waitForResponse) {
+        if (this.messageHandler.hasSpecialMessageHandler(cmd.__selector)) {
+          messageHandled = true;
 
-        // special replies will return any number of arguments
-        // temporarily wrap with promise handling
-        const specialMessageHandler = this.getSpecialMessageHandler(cmd.__selector);
-        this.setSpecialMessageHandler(cmd.__selector, reject, (...args) => {
-          log.debug(`Received response from send (id: ${msgId}): '${this.getLoggableResponse(args)}'`);
+          // special replies will return any number of arguments
+          // temporarily wrap with promise handling
+          const specialMessageHandler = this.getSpecialMessageHandler(cmd.__selector);
+          this.setSpecialMessageHandler(cmd.__selector, reject, (...args) => {
+            log.debug(`Received response from send (id: ${msgId}): '${this.getLoggableResponse(args)}'`);
 
-          // call the original listener, and put it back, if necessary
-          specialMessageHandler(...args);
-          if (this.messageHandler.hasSpecialMessageHandler(cmd.__selector)) {
-            // this means that the system has not removed this listener
-            this.setSpecialMessageHandler(cmd.__selector, null, specialMessageHandler);
+            // call the original listener, and put it back, if necessary
+            specialMessageHandler(...args);
+            if (this.messageHandler.hasSpecialMessageHandler(cmd.__selector)) {
+              // this means that the system has not removed this listener
+              this.setSpecialMessageHandler(cmd.__selector, null, specialMessageHandler);
+            }
+
+            resolve(args);
+          });
+        } else if (cmd.__argument && cmd.__argument.WIRSocketDataKey) {
+          messageHandled = true;
+
+          const errorHandler = function (err) {
+            const msg = `Remote debugger error with code '${err.code}': ${err.message}`;
+            reject(new Error(msg));
+          };
+
+          this.setDataMessageHandler(msgId.toString(), errorHandler, (value) => {
+            log.debug(`Received data response from send (id: ${msgId}): '${this.getLoggableResponse(value)}'`);
+            resolve(value);
+          });
+
+          // make sure the message being sent has all the information that is needed
+          if (cmd.__argument.WIRSocketDataKey.params) {
+            cmd.__argument.WIRSocketDataKey.params.id = msgId;
+            if (!cmd.__argument.WIRSocketDataKey.params.targetId && this.needsTarget()) {
+              cmd.__argument.WIRSocketDataKey.params.targetId = this.getTarget(sendOpts.appIdKey, sendOpts.pageIdKey);
+            }
+            if (cmd.__argument.WIRSocketDataKey.params.message) {
+              cmd.__argument.WIRSocketDataKey.params.message.id = msgId;
+              cmd.__argument.WIRSocketDataKey.params.message = JSON.stringify(cmd.__argument.WIRSocketDataKey.params.message);
+            }
           }
-
-          resolve(args);
-        });
-      } else if (cmd.__argument && cmd.__argument.WIRSocketDataKey) {
-        messageHandled = true;
-
-        const errorHandler = function (err) {
-          const msg = `Remote debugger error with code '${err.code}': ${err.message}`;
-          reject(new Error(msg));
-        };
-
-        this.setDataMessageHandler(msgId.toString(), errorHandler, (value) => {
-          log.debug(`Received data response from send (id: ${msgId}): '${this.getLoggableResponse(value)}'`);
-          resolve(value);
-        });
-
-        // make sure the message being sent has all the information that is needed
-        if (cmd.__argument.WIRSocketDataKey.params) {
-          cmd.__argument.WIRSocketDataKey.params.id = msgId;
-          if (!cmd.__argument.WIRSocketDataKey.params.targetId && this.needsTarget()) {
-            cmd.__argument.WIRSocketDataKey.params.targetId = this.getTarget(sendOpts.appIdKey, sendOpts.pageIdKey);
-          }
-          if (cmd.__argument.WIRSocketDataKey.params.message) {
-            cmd.__argument.WIRSocketDataKey.params.message.id = msgId;
-            cmd.__argument.WIRSocketDataKey.params.message = JSON.stringify(cmd.__argument.WIRSocketDataKey.params.message);
-          }
+          cmd.__argument.WIRSocketDataKey.id = msgId;
+          cmd.__argument.WIRSocketDataKey =
+            Buffer.from(JSON.stringify(cmd.__argument.WIRSocketDataKey));
         }
-        cmd.__argument.WIRSocketDataKey.id = msgId;
-        cmd.__argument.WIRSocketDataKey =
-          Buffer.from(JSON.stringify(cmd.__argument.WIRSocketDataKey));
       }
 
       const msg = `Sending '${cmd.__selector}' message` +

--- a/test/functional/safari-e2e-specs.js
+++ b/test/functional/safari-e2e-specs.js
@@ -97,10 +97,13 @@ describe('Safari remote debugger', function () {
   });
 
   async function connect (rd) {
-    return await retryInterval(10, 1000, async function () {
-      const apps = await rd.connect();
-      _.isEmpty(apps).should.be.equal(false);
-      return apps;
+    await rd.connect();
+    return await retryInterval(30, 1000, async function () {
+      if (!_.isEmpty(rd.appDict)) {
+        return rd.appDict;
+      }
+      await rd.setConnectionKey();
+      throw new Error('No apps connected');
     });
   }
 


### PR DESCRIPTION
**Breaking change**

Simplify how connected apps are treated. Mostly, do not wait after setting the connection key in the Web Inspector, then allow them to be handled asynchronously.