### PR TITLE
refactor: try to get the protocol right

### DIFF
--- a/bin/web_inspector_proxy.js
+++ b/bin/web_inspector_proxy.js
@@ -23,7 +23,7 @@ async function getSocket (udid) {
   return await sim.getWebInspectorSocket();
 }
 
-async function moveSocket (socket) {
+async function moveSocket (socket) { // eslint-disable-line no-unused-vars
   await exec('mv', [socket, `${socket}.original`]);
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,4 +5,5 @@ const boilerplate = require('appium-gulp-plugins').boilerplate.use(gulp);
 
 boilerplate({
   build: 'appium-remote-debugger',
+  files: ['*.js', 'lib/**/*.js', 'bin/**/*.js', 'test/**/*.js', '!gulpfile.js'],
 });

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,12 +3,10 @@ import getAtom from './atoms';
 import _ from 'lodash';
 import assert from 'assert';
 import B from 'bluebird';
-import { util } from 'appium-support';
 import { errorFromMJSONWPStatusCode } from 'appium-base-driver';
 
 
 const WEB_CONTENT_BUNDLE_ID = 'com.apple.WebKit.WebContent';
-const MIN_PLATFORM_FOR_TARGET_BASED = '12.2';
 
 const RESPONSE_LOG_LENGTH = 100;
 
@@ -224,14 +222,6 @@ function deferredPromise () {
   };
 }
 
-function isTargetBased (isSafari, platformVersion) {
-  // on iOS 12.2 the messages get sent through the Target domain
-  const isHighVersion = util.compareVersions(platformVersion, '>=', MIN_PLATFORM_FOR_TARGET_BASED);
-  log.debug(`Checking which communication style to use (${isSafari ? '' : 'non-'}Safari on platform version '${platformVersion}')`);
-  log.debug(`Platform version equal or higher than '${MIN_PLATFORM_FOR_TARGET_BASED}': ${isHighVersion}`);
-  return isSafari && isHighVersion;
-}
-
 function getElapsedTime (startTime) {
   const endTime = process.hrtime(startTime);
   return parseInt((endTime[0] * 1e9 + endTime[1]) / 1e6, 10);
@@ -264,6 +254,6 @@ function convertResult (res) {
 export {
   appInfoFromDict, pageArrayFromDict, getDebuggerAppKey,
   getPossibleDebuggerAppKeys, checkParams, wrapScriptForFrame, getScriptForAtom,
-  simpleStringify, deferredPromise, isTargetBased, getElapsedTime,
+  simpleStringify, deferredPromise, getElapsedTime,
   convertResult, RESPONSE_LOG_LENGTH,
 };

--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -12,6 +12,10 @@ const IGNORED_EVENTS = [
   'Page.frameScheduledNavigation',
   'Page.frameClearedScheduledNavigation',
   'Console.messagesCleared',
+  'Debugger.scriptParsed',
+  'Debugger.globalObjectCleared',
+  'Runtime.executionContextCreated',
+  'Heap.garbageCollected',
 ];
 
 export default class RpcMessageHandler {
@@ -185,20 +189,23 @@ export default class RpcMessageHandler {
 
     let method = dataKey.method;
     let params;
-    if (this.isTargetBased) {
-      if (method === 'Target.targetCreated') {
-        // this is in response to a `_rpc_forwardSocketSetup:` call
-        // targetInfo: { targetId: 'page-1', type: 'page' }
-        const app = plist.__argument.WIRApplicationIdentifierKey;
-        const targetInfo = dataKey.params.targetInfo;
-        await this.specialHandlers.targetCreated(app, targetInfo);
-        return;
-      } if (method === 'Target.targetDestroyed') {
-        const app = plist.__argument.WIRApplicationIdentifierKey;
-        const targetInfo = dataKey.params.targetInfo;
-        await this.specialHandlers.targetDestroyed(app, targetInfo);
-        return;
-      } else if (dataKey.method !== 'Target.dispatchMessageFromTarget') {
+
+    if (method === 'Target.targetCreated') {
+      // this is in response to a `_rpc_forwardSocketSetup:` call
+      // targetInfo: { targetId: 'page-1', type: 'page' }
+      const app = plist.__argument.WIRApplicationIdentifierKey;
+      const targetInfo = dataKey.params.targetInfo;
+      await this.specialHandlers.targetCreated(app, targetInfo);
+      return;
+    } else if (method === 'Target.targetDestroyed') {
+      const app = plist.__argument.WIRApplicationIdentifierKey;
+      const targetInfo = dataKey.params.targetInfo || {targetId: dataKey.params.targetId};
+      await this.specialHandlers.targetDestroyed(app, targetInfo);
+      return;
+    }
+
+    if (!dataKey.error && this.isTargetBased) {
+      if (dataKey.method !== 'Target.dispatchMessageFromTarget') {
         // this sort of message, at this point, is just an acknowledgement
         // that the original message was received
         return;
@@ -233,10 +240,6 @@ export default class RpcMessageHandler {
     }
 
     if (!error) {
-      if (!_.isEmpty(msgId)) {
-        log.debug(`Received response for message '${msgId}'`);
-      }
-
       return await this.dispatchDataMessage(msgId, method, params, result, error);
     }
 

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -613,18 +613,16 @@ class RemoteDebugger extends events.EventEmitter {
     });
   }
 
-  async startConsole (fn) {
+  async startConsole (fn) { // eslint-disable-line require-await
     log.debug('Starting to listen for JavaScript console');
-    this.rpcClient.setConsoleLogEventHandler(fn);
-    return await this.rpcClient.send('startConsole', {
-      appIdKey: this.appIdKey,
-      pageIdKey: this.pageIdKey,
-    });
+    if (_.isFunction(fn)) {
+      this.rpcClient.setConsoleLogEventHandler(fn);
+    }
   }
 
   async stopConsole () {
     log.debug('Stopping to listen for JavaScript console');
-    await this.rpcClient.send('stopConsole', {
+    await this.rpcClient.send('disableConsole', {
       appIdKey: this.appIdKey,
       pageIdKey: this.pageIdKey,
     });

--- a/lib/remote-messages.js
+++ b/lib/remote-messages.js
@@ -14,7 +14,8 @@ class RemoteMessages {
    * Connection functions
    */
 
-  setConnectionKey (connId) {
+  setConnectionKey (opts = {}) {
+    const {connId} = opts;
     return {
       __argument: {
         WIRConnectionIdentifierKey: connId
@@ -23,7 +24,8 @@ class RemoteMessages {
     };
   }
 
-  connectToApp (connId, appIdKey) {
+  connectToApp (opts = {}) {
+    const {connId, appIdKey} = opts;
     return {
       __argument: {
         WIRConnectionIdentifierKey: connId,
@@ -33,7 +35,8 @@ class RemoteMessages {
     };
   }
 
-  setSenderKey (connId, senderId, appIdKey, pageIdKey) {
+  setSenderKey (opts = {}) {
+    const {connId, senderId, appIdKey, pageIdKey} = opts;
     return {
       __argument: {
         WIRApplicationIdentifierKey: appIdKey,
@@ -46,8 +49,9 @@ class RemoteMessages {
     };
   }
 
-  indicateWebView (connId, appIdKey, pageIdKey, opts) {
-    const {enabled} = opts;
+  indicateWebView (opts = {}) {
+    const {connId, appIdKey, pageIdKey} = opts;
+    const {enabled} = opts.opts;
     return {
       __argument: {
         WIRApplicationIdentifierKey: appIdKey,
@@ -59,7 +63,8 @@ class RemoteMessages {
     };
   }
 
-  launchApplication (bundleId) {
+  launchApplication (opts = {}) {
+    const {bundleId} = opts;
     return {
       __argument: {
         WIRApplicationBundleIdentifierKey: bundleId
@@ -68,211 +73,281 @@ class RemoteMessages {
     };
   }
 
-  /*
-   * Action functions
-   */
+  getFullCommand (opts = {}) {
+    const {method, params, connId, senderId, appIdKey, pageIdKey, targetId, id} = opts;
 
-  getFullCommand (connId, senderId, appIdKey, pageIdKey, method, params) {
-    const [realMethod, realParams] = this.isTargetBased
-      ? ['Target.sendMessageToTarget', {message: {method, params}}]
-      : [method, params];
-    return this.command(realMethod, realParams, connId, senderId, appIdKey, pageIdKey);
-  }
-
-  enableInspector (connId, senderId) {
-    const method = 'Inspector.enable';
-    const params = {};
-    return this.command(method, params, connId, senderId);
-  }
-
-  sendJSCommand (connId, senderId, appIdKey, pageIdKey, opts = {}) {
-    const method = 'Runtime.evaluate';
-    const params = {
-      expression: opts.command,
-      returnByValue: _.isBoolean(opts.returnByValue) ? opts.returnByValue : true,
-    };
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-  callJSFunction (connId, senderId, appIdKey, pageIdKey, opts = {}) {
-    const method = 'Runtime.callFunctionOn';
-    const params = {
-      objectId: opts.objId,
-      functionDeclaration: opts.fn,
-      arguments: opts.args,
-      returnByValue: true,
-    };
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-  setUrl (connId, senderId, appIdKey, pageIdKey, opts = {}) {
-    const method = 'Page.navigate';
-    const params = {
-      url: opts.url,
-    };
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-  enablePage (connId, senderId, appIdKey, pageIdKey) {
-    const method = 'Page.enable';
-    const params = {};
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-  startTimeline (connId, senderId, appIdKey, pageIdKey) {
-    const method = 'Timeline.start';
-    const params = {};
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-  stopTimeline (connId, senderId, appIdKey, pageIdKey) {
-    const method = 'Timeline.stop';
-    const params = {};
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-  startConsole (connId, senderId, appIdKey, pageIdKey) {
-    const method = 'Console.enable';
-    const params = {};
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-  stopConsole (connId, senderId, appIdKey, pageIdKey) {
-    const method = 'Console.disable';
-    const params = {};
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-  startNetwork (connId, senderId, appIdKey, pageIdKey) {
-    const method = 'Network.enable';
-    const params = {};
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-  stopNetwork (connId, senderId, appIdKey, pageIdKey) {
-    const method = 'Network.disable';
-    const params = {};
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-  getCookies (connId, senderId, appIdKey, pageIdKey, opts = {}) {
-    const method = 'Page.getCookies';
-    const params = {
-      urls: opts.url,
-    };
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-  deleteCookie (connId, senderId, appIdKey, pageIdKey, opts = {}) {
-    const method = 'Page.deleteCookie';
-    const params = {
-      cookieName: opts.cookieName,
-      url: opts.url,
-    };
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-  garbageCollect (connId, senderId, appIdKey, pageIdKey) {
-    const method = 'Heap.gc';
-    const params = {};
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-  awaitPromise (connId, senderId, appIdKey, pageIdKey, opts) {
-    const method = 'Runtime.awaitPromise';
-    const params = {
-      promiseObjectId: opts.promiseObjectId,
-      returnByValue: true,
-      generatePreview: true,
-      saveResult: true,
-    };
-    return this.getFullCommand(connId, senderId, appIdKey, pageIdKey, method, params);
-  }
-
-
-  /*
-   * Internal functions
-   */
-
-  command (method, params, connId, senderId, appIdKey, pageIdKey) {
-    let plist = {
-      __argument: {
-        WIRSocketDataKey: {
+    let realMethod;
+    let realParams;
+    if (this.isTargetBased) {
+      realMethod = 'Target.sendMessageToTarget';
+      realParams = {
+        targetId,
+        message: JSON.stringify({
+          id,
           method,
           params: {
+            ...params,
             objectGroup: 'console',
             includeCommandLineAPI: true,
-            doNotPauseOnExceptionsAndMuteConsole: true,
+            doNotPauseOnExceptionsAndMuteConsole: false,
+            emulateUserGesture: false,
           }
+        }),
+      };
+    } else {
+      realMethod = method;
+      realParams = {
+        ...params,
+        objectGroup: 'console',
+        includeCommandLineAPI: true,
+        doNotPauseOnExceptionsAndMuteConsole: false,
+        emulateUserGesture: false,
+      };
+    }
+
+    const plist = {
+      __argument: {
+        WIRSocketDataKey: {
+          method: realMethod,
+          params: realParams,
         },
         WIRConnectionIdentifierKey: connId,
         WIRSenderKey: senderId,
-        WIRAutomaticallyPause: true,
+        WIRApplicationIdentifierKey: appIdKey,
+        WIRPageIdentifierKey: pageIdKey,
+      },
+      __selector: '_rpc_forwardSocketData:',
+    };
+    return _.omitBy(plist, _.isNil);
+  }
+
+  getMinimalCommand (opts = {}) {
+    const {method, params, connId, senderId, appIdKey, pageIdKey, targetId, id} = opts;
+
+    let realMethod = method;
+    let realParams = params;
+    if (this.isTargetBased) {
+      realMethod = 'Target.sendMessageToTarget';
+      realParams = {
+        targetId,
+        message: JSON.stringify({
+          id,
+          method,
+          params,
+        }),
+      };
+    }
+
+    const plist = {
+      __argument: {
+        WIRSocketDataKey: {
+          method: realMethod,
+          params: realParams,
+        },
+        WIRConnectionIdentifierKey: connId,
+        WIRSenderKey: senderId,
+        WIRApplicationIdentifierKey: appIdKey,
+        WIRPageIdentifierKey: pageIdKey,
       },
       __selector: '_rpc_forwardSocketData:'
     };
-    if (appIdKey) {
-      plist.__argument.WIRApplicationIdentifierKey = appIdKey;
-    }
-    if (pageIdKey) {
-      plist.__argument.WIRPageIdentifierKey = pageIdKey;
-    }
-    if (params) {
-      plist.__argument.WIRSocketDataKey.params =
-        _.extend(plist.__argument.WIRSocketDataKey.params, params);
-    }
-    return plist;
+    return _.omitBy(plist, _.isNil);
+  }
+
+  getDirectCommand (opts = {}) {
+    const {method, params, connId, senderId, appIdKey, pageIdKey, id} = opts;
+
+    const plist = {
+      __argument: {
+        WIRSocketDataKey: {
+          id,
+          method,
+          params,
+        },
+        WIRConnectionIdentifierKey: connId,
+        WIRSenderKey: senderId,
+        WIRApplicationIdentifierKey: appIdKey,
+        WIRPageIdentifierKey: pageIdKey,
+      },
+      __selector: '_rpc_forwardSocketData:'
+    };
+    return _.omitBy(plist, _.isNil);
   }
 
   getRemoteCommand (command, opts) {
     const {
+      id,
       connId,
       appIdKey,
       senderId,
       pageIdKey,
+      targetId,
     } = opts;
+
+    let method, params;
 
     switch (command) {
       case 'setConnectionKey':
-        return this.setConnectionKey(connId);
-      case 'enableInspector':
-        return this.enableInspector(connId, senderId);
-      case 'launchApplication':
-        return this.launchApplication(opts.bundleId);
-      case 'connectToApp':
-        return this.connectToApp(connId, appIdKey);
-      case 'setSenderKey':
-        return this.setSenderKey(connId, senderId, appIdKey, pageIdKey);
+        return this.setConnectionKey({connId});
       case 'indicateWebView':
-        return this.indicateWebView(connId, appIdKey, pageIdKey, opts);
+        return this.indicateWebView({connId, appIdKey, pageIdKey, opts});
+      case 'connectToApp':
+        return this.connectToApp({connId, appIdKey});
+      case 'setSenderKey':
+        return this.setSenderKey({connId, senderId, appIdKey, pageIdKey});
+      case 'launchApplication':
+        return this.launchApplication(opts);
+
+      case 'targetExists':
+        method = 'Target.exists';
+        return this.getDirectCommand({method, connId, senderId, appIdKey, pageIdKey, id});
+      case 'enableInspector':
+        method = 'Inspector.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'inspectorInitialized':
+        method = 'Inspector.initialized';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'enableDomStorage':
+        method = 'DOMStorage.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'enableDatabase':
+        method = 'Database.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'enableIndexDB':
+        method = 'IndexDB.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'enableCSS':
+        method = 'CSS.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'enableRuntime':
+        method = 'Runtime.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'enableHeap':
+        method = 'Heap.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'enableMemory':
+        method = 'Memory.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'enableApplicationCache':
+        method = 'ApplicationCache.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'enableDebugger':
+        method = 'Debugger.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'setBreakpointsActive':
+        method = 'Debugger.setBreakpointsActive';
+        params = {
+          active: opts.active,
+        };
+        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'setPauseOnExceptions':
+        method = 'Debugger.setPauseOnExceptions';
+        params = {
+          state: opts.state,
+        };
+        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'setPauseOnAssertions':
+        method = 'Debugger.setPauseOnAssertions';
+        params = {
+          enabled: opts.enabled,
+        };
+        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'setAsyncStackTraceDepth':
+        method = 'Debugger.setAsyncStackTraceDepth';
+        params = {
+          depth: opts.depth,
+        };
+        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'setPauseForInternalScripts':
+        method = 'Debugger.setPauseForInternalScripts';
+        params = {
+          shouldPause: opts.shouldPause,
+        };
+        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'enableLayerTree':
+        method = 'LayerTree.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'enableWorker':
+        method = 'Worker.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'enableCanvas':
+        method = 'Canvas.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
       case 'sendJSCommand':
-        return this.sendJSCommand(connId, senderId, appIdKey, pageIdKey, opts);
+        method = 'Runtime.evaluate';
+        params = {
+          expression: opts.command,
+          returnByValue: _.isBoolean(opts.returnByValue) ? opts.returnByValue : true,
+        };
+        return this.getFullCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
       case 'callJSFunction':
-        return this.callJSFunction(connId, senderId, appIdKey, pageIdKey, opts);
+        method = 'Runtime.callFunctionOn';
+        params = {
+          objectId: opts.objId,
+          functionDeclaration: opts.fn,
+          arguments: opts.args,
+          returnByValue: true,
+        };
+        return this.getFullCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
       case 'setUrl':
-        return this.setUrl(connId, senderId, appIdKey, pageIdKey, opts);
+        method = 'Page.navigate';
+        params = {
+          url: opts.url,
+        };
+        return this.getFullCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
       case 'enablePage':
-        return this.enablePage(connId, senderId, appIdKey, pageIdKey);
+        method = 'Page.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
       case 'startTimeline':
-        return this.startTimeline(connId, senderId, appIdKey, pageIdKey);
+        method = 'Timeline.start';
+        return this.getFullCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
       case 'stopTimeline':
-        return this.stopTimeline(connId, senderId, appIdKey, pageIdKey);
-      case 'startConsole':
-        return this.startConsole(connId, senderId, appIdKey, pageIdKey);
-      case 'stopConsole':
-        return this.stopConsole(connId, senderId, appIdKey, pageIdKey);
+        method = 'Timeline.stop';
+        return this.getFullCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'getConsoleLoggingChannels':
+        method = 'Console.getLoggingChannels';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'setConsoleLoggingChannelLevel':
+        method = 'Console.setLoggingChannelLevel';
+        params = {
+          source: opts.source,
+          level: opts.level,
+        };
+        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'enableConsole':
+        method = 'Console.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
+      case 'disableConsole':
+        method = 'Console.disable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
       case 'startNetwork':
-        return this.startNetwork(connId, senderId, appIdKey, pageIdKey);
+        method = 'Network.enable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
       case 'stopNetwork':
-        return this.stopNetwork(connId, senderId, appIdKey, pageIdKey);
+        method = 'Network.disable';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
       case 'getCookies':
-        return this.getCookies(connId, senderId, appIdKey, pageIdKey, opts);
+        method = 'Page.getCookies';
+        return this.getFullCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
       case 'deleteCookie':
-        return this.deleteCookie(connId, senderId, appIdKey, pageIdKey, opts);
+        method = 'Page.deleteCookie';
+        params = {
+          cookieName: opts.cookieName,
+          url: opts.url,
+        };
+        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
       case 'garbageCollect':
-        return this.garbageCollect(connId, senderId, appIdKey, pageIdKey);
+        method = 'Heap.gc';
+        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
       case 'awaitPromise':
-        return this.awaitPromise(connId, senderId, appIdKey, pageIdKey, opts);
+        method = 'Runtime.awaitPromise';
+        params = {
+          promiseObjectId: opts.promiseObjectId,
+          returnByValue: true,
+          generatePreview: true,
+          saveResult: true,
+        };
+        return this.getFullCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
       default:
         throw new Error(`Unknown command: ${command}`);
     }

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import B from 'bluebird';
 import UUID from 'uuid-js';
 import RpcMessageHandler from './remote-debugger-message-handler';
-import { isTargetBased, getElapsedTime } from './helpers';
+import { getElapsedTime } from './helpers';
 import { util } from 'appium-support';
 
 
@@ -16,8 +16,17 @@ const WAIT_FOR_TARGET_INTERVAL = 1000;
 
 const ENABLE_PAGE_TIMEOUT = 2000;
 
-const GENERIC_TARGET_ID = 6;
 const TARGET_PAGE_PREFIX = 'page-';
+
+const MIN_PLATFORM_FOR_TARGET_BASED = '12.2';
+
+function isTargetBased (isSafari, platformVersion) {
+  // on iOS 12.2 the messages get sent through the Target domain
+  const isHighVersion = util.compareVersions(platformVersion, '>=', MIN_PLATFORM_FOR_TARGET_BASED);
+  log.debug(`Checking which communication style to use (${isSafari ? '' : 'non-'}Safari on platform version '${platformVersion}')`);
+  log.debug(`Platform version equal or higher than '${MIN_PLATFORM_FOR_TARGET_BASED}': ${isHighVersion}`);
+  return isSafari && isHighVersion;
+}
 
 export default class RpcClient {
   constructor (opts = {}) {
@@ -114,22 +123,15 @@ export default class RpcClient {
       pageIdKey
     } = opts;
     try {
-      await this.waitForTarget(appIdKey, pageIdKey);
-      const sendPromise = this.sendToDevice(command, opts, waitForResponse);
-
-      // dummy call to ensure that the actual command returns
-      this.sendToDevice('sendJSCommand', {
-        command: '1;',
-        appIdKey,
-        pageIdKey,
-      }, true).catch(function () {});
-
-      return await sendPromise;
+      if (!_.isEmpty(appIdKey) && !_.isEmpty(pageIdKey)) {
+        await this.waitForTarget(appIdKey, pageIdKey);
+      }
+      return await this.sendToDevice(command, opts, waitForResponse);
     } catch (err) {
       if (err.message.includes(`'Target' domain was not found`)) {
         this.setCommunicationProtocol(false);
         return await this.sendToDevice(command, opts, waitForResponse);
-      } else if (err.message.includes(`domain was not found`)) {
+      } else if (err.message.includes(`domain was not found`) || err.message.includes(`Some arguments of method`)) {
         this.setCommunicationProtocol(true);
         await this.waitForTarget(appIdKey, pageIdKey);
         return await this.sendToDevice(command, opts, waitForResponse);
@@ -155,24 +157,27 @@ export default class RpcClient {
 
       // keep track of the messages coming and going using a simple sequential id
       const msgId = this.msgId++;
+      let wrapperMsgId = msgId;
+      if (this.isTargetBased) {
+        // for target-base communication, everything is wrapped up
+        wrapperMsgId = this.msgId++;
+        // acknowledge wrapper message
+        this.setDataMessageHandler(wrapperMsgId.toString(), reject, _.noop);
+      }
+
+      const appIdKey = opts.appIdKey;
+      const pageIdKey = opts.pageIdKey;
+      const targetId = this.getTarget(appIdKey, pageIdKey);
 
       // retrieve the correct command to send
-      const sendOpts = _.defaults({connId: this.connId, senderId: this.senderId}, opts);
-      const cmd = this.remoteMessages.getRemoteCommand(command, sendOpts);
+      const fullOpts = _.defaults({connId: this.connId, senderId: this.senderId, targetId, id: msgId}, opts);
+      const cmd = this.remoteMessages.getRemoteCommand(command, fullOpts);
 
       if (cmd.__argument && cmd.__argument.WIRSocketDataKey) {
         // make sure the message being sent has all the information that is needed
-        if (cmd.__argument.WIRSocketDataKey.params) {
-          cmd.__argument.WIRSocketDataKey.params.id = msgId;
-          if (!cmd.__argument.WIRSocketDataKey.params.targetId && this.needsTarget()) {
-            cmd.__argument.WIRSocketDataKey.params.targetId = this.getTarget(sendOpts.appIdKey, sendOpts.pageIdKey);
-          }
-          if (cmd.__argument.WIRSocketDataKey.params.message) {
-            cmd.__argument.WIRSocketDataKey.params.message.id = msgId;
-            cmd.__argument.WIRSocketDataKey.params.message = JSON.stringify(cmd.__argument.WIRSocketDataKey.params.message);
-          }
+        if (_.isNil(cmd.__argument.WIRSocketDataKey.id)) {
+          cmd.__argument.WIRSocketDataKey.id = wrapperMsgId;
         }
-        cmd.__argument.WIRSocketDataKey.id = msgId;
         cmd.__argument.WIRSocketDataKey =
           Buffer.from(JSON.stringify(cmd.__argument.WIRSocketDataKey));
       }
@@ -181,6 +186,8 @@ export default class RpcClient {
       if (!waitForResponse) {
         // the promise will be resolved as soon as the socket has been sent
         messageHandled = false;
+        // do not log receipts
+        this.setDataMessageHandler(msgId.toString(), reject, _.noop);
       } else if (this.messageHandler.hasSpecialMessageHandler(cmd.__selector)) {
         // special replies will return any number of arguments
         // temporarily wrap with promise handling
@@ -202,20 +209,19 @@ export default class RpcClient {
           const msg = `Remote debugger error with code '${err.code}': ${err.message}`;
           reject(new Error(msg));
         };
-
         this.setDataMessageHandler(msgId.toString(), errorHandler, (value) => {
           log.debug(`Received data response from send (id: ${msgId}): '${this.getLoggableResponse(value)}'`);
           resolve(value);
         });
       } else {
-        // nothing else is handling things, so just resolve when the socket is sent
+        // nothing else is handling things, so just resolve when the message is sent
         messageHandled = false;
       }
 
       const msg = `Sending '${cmd.__selector}' message` +
-        (sendOpts.appIdKey ? ` to app '${sendOpts.appIdKey}'` : '') +
-        (sendOpts.pageIdKey ? `, page '${sendOpts.pageIdKey}'` : '') +
-        (this.needsTarget() ? `, target '${this.getTarget(sendOpts.appIdKey, sendOpts.pageIdKey)}'` : '') +
+        (fullOpts.appIdKey ? ` to app '${fullOpts.appIdKey}'` : '') +
+        (fullOpts.pageIdKey ? `, page '${fullOpts.pageIdKey}'` : '') +
+        (this.needsTarget() ? `, target '${targetId}'` : '') +
         ` (id: ${msgId})`;
       log.debug(msg);
       try {
@@ -238,6 +244,7 @@ export default class RpcClient {
   addTarget (app, targetInfo) {
     if (_.isUndefined(targetInfo) || _.isUndefined(targetInfo.targetId)) {
       log.warn(`Received 'targetCreated' event with no target. Skipping`);
+
       return;
     }
     if (_.isEmpty(this.pendingTargetNotification)) {
@@ -273,26 +280,6 @@ export default class RpcClient {
   get targets () {
     this._targets = this._targets || {};
     return this._targets;
-  }
-
-  getAvailableTargets (appIdKey) {
-    // get the next target id for the app
-    const targetIds = _.values(this.targets[appIdKey])
-      .map((targetId) => targetId.replace(TARGET_PAGE_PREFIX, ''))
-      .map((targetId) => parseInt(targetId, 10))
-      .sort();
-    const lastTargetId = (_.last(targetIds) || 0) + 1;
-
-    // construct a range of possible targets
-    // start with the generic target id, then the next for this app, then the whole range
-    const possibleTargets = [GENERIC_TARGET_ID, lastTargetId, ..._.range(1, 100)];
-    // get the targets already in use, and remove the prefix
-    const currentTargets = _.reduce(this.targets, function (acc, app) {
-      acc.push(..._.values(app));
-      return acc;
-    }, []).map((target) => target.replace(TARGET_PAGE_PREFIX, ''));
-    // find the range that does not include already used targets
-    return _.uniq(_.difference(possibleTargets, currentTargets));
   }
 
   getTarget (appIdKey, pageIdKey) {
@@ -338,51 +325,23 @@ export default class RpcClient {
   async selectPage (appIdKey, pageIdKey) {
     this.pendingTargetNotification = [appIdKey, pageIdKey];
     this.shouldCheckForTarget = false;
-    await this.send('setSenderKey', {
+
+    const sendOpts = {
       appIdKey,
       pageIdKey,
-    });
+    };
+
+    await this.send('setSenderKey', sendOpts);
     log.debug('Sender key set');
+
+    await this.send('targetExists', sendOpts, false);
 
     this.shouldCheckForTarget = true;
 
-    // this call will require a target, so if there isn't one an error
-    // will be thrown and the process of finding a target can begin
-    try {
-      await this.send('enablePage', {
-        appIdKey,
-        pageIdKey,
-      });
-      return;
-    } catch (err) {
-      if (!err.message.includes('No targets found')) {
-        throw err;
-      }
-    }
-
-    log.debug(`No targets have been indicated by the Web Inspector. Trying out possibilities`);
-
-    // try out the targets that aren't being used
-    for (const i of this.getAvailableTargets(appIdKey)) {
-      const targetId = `${TARGET_PAGE_PREFIX}${i}`;
-      log.debug(`Trying target '${targetId}'`);
-      this.pendingTargetNotification = [appIdKey, pageIdKey];
-      this.addTarget(appIdKey, {targetId});
-      try {
-        await B.resolve(this.send('enablePage', {
-          appIdKey,
-          pageIdKey,
-        }, true)).timeout(this.connectionHandshakeTimeout);
-        log.debug('Enabled activity on page');
-        return;
-      } catch (err) {
-        if (!(err instanceof B.TimeoutError)) {
-          throw err;
-        }
-      }
-    }
-
-    throw new Error('Unable to find target for application');
+    await this.send('enableInspector', sendOpts);
+    await this.send('enablePage', sendOpts);
+    await this.send('enableConsole', sendOpts);
+    await this.send('inspectorInitialized', sendOpts);
   }
 
   async selectApp (appIdKey, applicationConnectedHandler) {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "precommit-test": "REPORTER=dot gulp once",
     "lint": "gulp lint",
-    "lint:fix": "gulp eslint --fix"
+    "lint:fix": "gulp eslint --fix",
+    "inspect-safari": "node build/bin/web_inspector_proxy.js"
   },
   "pre-commit": [
     "precommit-msg",


### PR DESCRIPTION
The next iteration in trying to get the protocol right. I've mimicked what Safari does on a Web Inspector session, and it seems to work much better now for both systems using the `Target` API and those using the old style.

Run against reproduction cases noted by @wswebcreation such as https://github.com/appium/appium/issues/13171 and https://github.com/appium/appium/issues/13248