### PR TITLE
fix: make sure that app dict is not modified at the same time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,13 @@ jobs:
         - TEST=e2e-test
 
     - stage:
+      osx_image: xcode7.3
+      env:
+        - PLATFORM_VERSION=9.3
+        - DEVICE_NAME="iPhone 5s"
+        - TEST=e2e-test
+
+    - stage:
       osx_image: xcode11
       env:
         - PLATFORM_VERSION=13.0

--- a/bin/web_inspector_proxy.js
+++ b/bin/web_inspector_proxy.js
@@ -1,23 +1,11 @@
 /* eslint-disable no-console */
 import { exec, SubProcess } from 'teen_process';
-import { plist } from 'appium-support';
+import { plist, util } from 'appium-support';
 import { asyncify } from 'asyncbox';
 import B from 'bluebird';
 import { getSimulator } from 'appium-ios-simulator';
 import _ from 'lodash';
 
-
-function logFullMessage (plist) {
-  // Buffers cannot be serialized in a readable way
-  const bufferToJSON = Buffer.prototype.toJSON;
-  delete Buffer.prototype.toJSON;
-  try {
-    console.log(JSON.stringify(plist, (k, v) => Buffer.isBuffer(v) ? v.toString('utf8') : v, 2));
-  } finally {
-    // restore the function, so as to not break further serialization
-    Buffer.prototype.toJSON = bufferToJSON;
-  }
-}
 
 async function getSocket (udid) {
   const sim = await getSimulator(udid);
@@ -61,7 +49,7 @@ function printRecord (lines) {
     const buf = Buffer.from(data);
     try {
       const doc = plist.parsePlist(buf);
-      logFullMessage(doc);
+      console.log(util.jsonStringify(doc));
     } catch (err) {
       if (err.message.includes('maxObjectCount exceeded')) {
         return str;

--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -17,23 +17,26 @@ async function onPageChange (appIdKey, pageDict) {
   const pageArray = pageArrayFromDict(pageDict);
 
   await this.useAppDictLock((done) => {
-    // save the page dict for this app
-    if (this.appDict[appIdKey]) {
-      if (this.appDict[appIdKey].pageArray) {
-        if (this.appDict[appIdKey].pageArray.resolve) {
-          // pageDict is a pending promise, so resolve
-          this.appDict[appIdKey].pageArray.resolve();
-        } else {
-          // we have a pre-existing pageDict
-          if (_.isEqual(this.appDict[appIdKey].pageArray, pageArray)) {
-            log.debug(`Received page change notice for app '${appIdKey}' ` +
-                      `but the listing has not changed. Ignoring.`);
-            return done();
+    try {
+      // save the page dict for this app
+      if (this.appDict[appIdKey]) {
+        if (this.appDict[appIdKey].pageArray) {
+          if (this.appDict[appIdKey].pageArray.resolve) {
+            // pageDict is a pending promise, so resolve
+            this.appDict[appIdKey].pageArray.resolve();
+          } else {
+            // we have a pre-existing pageDict
+            if (_.isEqual(this.appDict[appIdKey].pageArray, pageArray)) {
+              log.debug(`Received page change notice for app '${appIdKey}' ` +
+                        `but the listing has not changed. Ignoring.`);
+              return done();
+            }
           }
         }
+        // keep track of the page dictionary
+        this.appDict[appIdKey].pageArray = pageArray;
       }
-      // keep track of the page dictionary
-      this.appDict[appIdKey].pageArray = pageArray;
+    } finally {
       done();
     }
   });
@@ -55,8 +58,11 @@ async function onAppConnect (dict) {
   let appIdKey = dict.WIRApplicationIdentifierKey;
   log.debug(`Notified that new application '${appIdKey}' has connected`);
   await this.useAppDictLock((done) => {
-    this.updateAppsWithDict(dict);
-    done();
+    try {
+      this.updateAppsWithDict(dict);
+    } finally {
+      done();
+    }
   });
 }
 
@@ -85,8 +91,11 @@ function onAppDisconnect (dict) {
 
 async function onAppUpdate (dict) {
   await this.useAppDictLock((done) => {
-    this.updateAppsWithDict(dict);
-    done();
+    try {
+      this.updateAppsWithDict(dict);
+    } finally {
+      done();
+    }
   });
 }
 
@@ -118,8 +127,11 @@ async function onConnectedApplicationList (apps) {
   }
   // update the object's list of apps
   await this.useAppDictLock((done) => {
-    _.defaults(this.appDict, newDict);
-    done();
+    try {
+      _.defaults(this.appDict, newDict);
+    } finally {
+      done();
+    }
   });
 }
 

--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -9,14 +9,14 @@ import _ from 'lodash';
  * These will be added to the prototype.
  */
 
-function onPageChange (appIdKey, pageDict) {
+async function onPageChange (appIdKey, pageDict) {
   if (_.isEmpty(pageDict)) {
     return;
   }
 
   const pageArray = pageArrayFromDict(pageDict);
 
-  this.useAppDictLock((done) => {
+  await this.useAppDictLock((done) => {
     // save the page dict for this app
     if (this.appDict[appIdKey]) {
       if (this.appDict[appIdKey].pageArray) {
@@ -51,10 +51,10 @@ function onPageChange (appIdKey, pageDict) {
   });
 }
 
-function onAppConnect (dict) {
+async function onAppConnect (dict) {
   let appIdKey = dict.WIRApplicationIdentifierKey;
   log.debug(`Notified that new application '${appIdKey}' has connected`);
-  this.useAppDictLock((done) => {
+  await this.useAppDictLock((done) => {
     this.updateAppsWithDict(dict);
     done();
   });
@@ -83,8 +83,8 @@ function onAppDisconnect (dict) {
   }
 }
 
-function onAppUpdate (dict) {
-  this.useAppDictLock((done) => {
+async function onAppUpdate (dict) {
+  await this.useAppDictLock((done) => {
     this.updateAppsWithDict(dict);
     done();
   });
@@ -103,7 +103,7 @@ function onConnectedDriverList (drivers) {
   log.debug(`Received connected driver list: ${JSON.stringify(this.connectedDrivers)}`);
 }
 
-function onConnectedApplicationList (apps) {
+async function onConnectedApplicationList (apps) {
   log.debug(`Received connected applications list: ${_.keys(apps).join(', ')}`);
 
   // translate the received information into an easier-to-manage
@@ -117,7 +117,7 @@ function onConnectedApplicationList (apps) {
     newDict[id] = entry;
   }
   // update the object's list of apps
-  this.useAppDictLock((done) => {
+  await this.useAppDictLock((done) => {
     _.defaults(this.appDict, newDict);
     done();
   });

--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -9,7 +9,6 @@ import _ from 'lodash';
  * These will be added to the prototype.
  */
 
-
 function onPageChange (appIdKey, pageDict) {
   if (_.isEmpty(pageDict)) {
     return;
@@ -17,24 +16,27 @@ function onPageChange (appIdKey, pageDict) {
 
   const pageArray = pageArrayFromDict(pageDict);
 
-  // save the page dict for this app
-  if (this.appDict[appIdKey]) {
-    if (this.appDict[appIdKey].pageArray) {
-      if (this.appDict[appIdKey].pageArray.resolve) {
-        // pageDict is a pending promise, so resolve
-        this.appDict[appIdKey].pageArray.resolve();
-      } else {
-        // we have a pre-existing pageDict
-        if (_.isEqual(this.appDict[appIdKey].pageArray, pageArray)) {
-          log.debug(`Received page change notice for app '${appIdKey}' ` +
-                    `but the listing has not changed. Ignoring.`);
-          return;
+  this.useAppDictLock((done) => {
+    // save the page dict for this app
+    if (this.appDict[appIdKey]) {
+      if (this.appDict[appIdKey].pageArray) {
+        if (this.appDict[appIdKey].pageArray.resolve) {
+          // pageDict is a pending promise, so resolve
+          this.appDict[appIdKey].pageArray.resolve();
+        } else {
+          // we have a pre-existing pageDict
+          if (_.isEqual(this.appDict[appIdKey].pageArray, pageArray)) {
+            log.debug(`Received page change notice for app '${appIdKey}' ` +
+                      `but the listing has not changed. Ignoring.`);
+            return done();
+          }
         }
       }
+      // keep track of the page dictionary
+      this.appDict[appIdKey].pageArray = pageArray;
+      done();
     }
-    // keep track of the page dictionary
-    this.appDict[appIdKey].pageArray = pageArray;
-  }
+  });
 
   if (this._navigatingToPage) {
     // in the middle of navigating, so reporting a page change will cause problems
@@ -52,8 +54,10 @@ function onPageChange (appIdKey, pageDict) {
 function onAppConnect (dict) {
   let appIdKey = dict.WIRApplicationIdentifierKey;
   log.debug(`Notified that new application '${appIdKey}' has connected`);
-
-  this.updateAppsWithDict(dict);
+  this.useAppDictLock((done) => {
+    this.updateAppsWithDict(dict);
+    done();
+  });
 }
 
 function onAppDisconnect (dict) {
@@ -80,7 +84,10 @@ function onAppDisconnect (dict) {
 }
 
 function onAppUpdate (dict) {
-  this.updateAppsWithDict(dict);
+  this.useAppDictLock((done) => {
+    this.updateAppsWithDict(dict);
+    done();
+  });
 }
 
 function onTargetCreated (app, targetInfo) {
@@ -110,7 +117,10 @@ function onConnectedApplicationList (apps) {
     newDict[id] = entry;
   }
   // update the object's list of apps
-  _.defaults(this.appDict, newDict);
+  this.useAppDictLock((done) => {
+    _.defaults(this.appDict, newDict);
+    done();
+  });
 }
 
 const messageHandlers = {

--- a/lib/remote-debugger-message-handler.js
+++ b/lib/remote-debugger-message-handler.js
@@ -1,5 +1,6 @@
 import log from './logger';
 import _ from 'lodash';
+import { util } from 'appium-support';
 
 
 // we will receive events that we do not listen to.
@@ -170,18 +171,6 @@ export default class RpcMessageHandler {
     }
   }
 
-  logFullMessage (plist) {
-    // Buffers cannot be serialized in a readable way
-    const bufferToJSON = Buffer.prototype.toJSON;
-    delete Buffer.prototype.toJSON;
-    try {
-      log(JSON.stringify(plist, (k, v) => Buffer.isBuffer(v) ? v.toString('utf8') : v, 2));
-    } finally {
-      // restore the function, so as to not break further serialization
-      Buffer.prototype.toJSON = bufferToJSON;
-    }
-  }
-
   async handleDataMessage (plist) {
     const dataKey = this.parseDataKey(plist);
     let msgId = (dataKey.id || '').toString();
@@ -223,7 +212,7 @@ export default class RpcMessageHandler {
         // if this happens then some aspect of the protocol is missing to us
         // so print the entire message to get visibiity into what is going on
         log.error(`Unexpected message format from Web Inspector:`);
-        this.logFullMessage(plist);
+        this.warn(util.jsonStringify(plist));
         throw err;
       }
     } else {

--- a/lib/remote-debugger-real-device.js
+++ b/lib/remote-debugger-real-device.js
@@ -25,7 +25,7 @@ export default class RemoteDebuggerRealDevice extends RemoteDebugger {
       socketPath: this.socketPath,
       specialMessageHandlers: this.specialCbs,
       messageProxy: this.remoteDebugProxy,
-      logFullResponse: this.logFullResponse,
+      logAllCommunication: this.logAllCommunication,
       udid: this.udid
     });
     await this.rpcClient.connect();

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -748,8 +748,8 @@ class RemoteDebugger extends events.EventEmitter {
     });
   }
 
-  useAppDictLock (fn) {
-    this._lock.acquire('appDict', fn);
+  async useAppDictLock (fn) {
+    return await this._lock.acquire('appDict', fn);
   }
 }
 

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -13,6 +13,7 @@ import _ from 'lodash';
 import B from 'bluebird';
 import path from 'path';
 import UUID from 'uuid-js';
+import AsyncLock from 'async-lock';
 
 
 let VERSION;
@@ -64,6 +65,7 @@ class RemoteDebugger extends events.EventEmitter {
       remoteDebugProxy,
       garbageCollectOnExecute = false,
       logFullResponse = false,
+      logAllCommunication = false,
       connectionHandshakeTimeout,
     } = opts;
 
@@ -84,9 +86,11 @@ class RemoteDebugger extends events.EventEmitter {
     this.remoteDebugProxy = remoteDebugProxy;
     this.pageReadyTimeout = pageReadyTimeout;
 
-    this.logFullResponse = logFullResponse;
+    this.logAllCommunication = _.isNil(logAllCommunication) ? !!logFullResponse : !!logAllCommunication;
 
     this.skippedApps = [];
+
+    this._lock = new AsyncLock();
   }
 
   setup () {
@@ -144,7 +148,7 @@ class RemoteDebugger extends events.EventEmitter {
       socketPath: this.socketPath,
       specialMessageHandlers: this.specialCbs,
       messageProxy: this.remoteDebugProxy,
-      logFullResponse: this.logFullResponse,
+      logAllCommunication: this.logAllCommunication,
       connectionHandshakeTimeout: this.connectionHandshakeTimeout,
     });
     await this.rpcClient.connect();
@@ -306,8 +310,10 @@ class RemoteDebugger extends events.EventEmitter {
             // save the page array for this app
             this.appDict[appIdKey].pageArray = pageArrayFromDict(pageDict);
 
-            // if we are looking for a particular url, make sure we have the right page. Ignore empty or undefined urls. Ignore about:blank if requested.
-            const result = this.searchPage(this.appDict, currentUrl, ignoreAboutBlankUrl);
+            // if we are looking for a particular url, make sure we
+            // have the right page. Ignore empty or undefined urls.
+            // Ignore about:blank if requested.
+            const result = this.searchForPage(this.appDict, currentUrl, ignoreAboutBlankUrl);
             if (result) {
               return result;
             }
@@ -329,7 +335,7 @@ class RemoteDebugger extends events.EventEmitter {
     }
   }
 
-  searchPage (appsDict, currentUrl = null, ignoreAboutBlankUrl = false) {
+  searchForPage (appsDict, currentUrl = null, ignoreAboutBlankUrl = false) {
     for (const appDict of _.values(appsDict)) {
       if (!appDict || !appDict.pageArray || appDict.pageArray.promise) {
         continue;
@@ -740,6 +746,10 @@ class RemoteDebugger extends events.EventEmitter {
         log.debug(`Unable to collect garbage: ${err.message}`);
       }
     });
+  }
+
+  useAppDictLock (fn) {
+    this._lock.acquire('appDict', fn);
   }
 }
 

--- a/lib/rpc-client-real-device.js
+++ b/lib/rpc-client-real-device.js
@@ -19,6 +19,8 @@ export default class RpcClientRealDevice extends RpcClient {
   async connect () {
     this.service = await services.startWebInspectorService(this.udid, {
       osVersion: this.platformVersion,
+      isSimulator: false,
+      verbose: this.logAllCommunication,
     });
     this.service.listenMessage(this.receive.bind(this));
     this.connected = true;

--- a/lib/rpc-client-simulator.js
+++ b/lib/rpc-client-simulator.js
@@ -73,7 +73,9 @@ export default class RpcClientSimulator extends RpcClient {
     });
     this.service = await services.startWebInspectorService(this.udid, {
       socket: this.socket,
+      isSimulator: true,
       osVersion: this.platformVersion,
+      verbose: this.logAllCommunication,
     });
     this.service.listenMessage(this.receive.bind(this));
 

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -38,7 +38,7 @@ export default class RpcClient {
       platformVersion = {},
       isSafari = true,
       specialMessageHandlers = {},
-      logFullResponse = false,
+      logAllCommunication = false,
       connectionHandshakeTimeout = ENABLE_PAGE_TIMEOUT,
     } = opts;
 
@@ -48,7 +48,7 @@ export default class RpcClient {
     this.connId = UUID.create().toString();
     this.senderId = UUID.create().toString();
     this.msgId = 0;
-    this.logFullResponse = logFullResponse;
+    this.logAllCommunication = logAllCommunication;
 
     this.connectionHandshakeTimeout = connectionHandshakeTimeout;
 
@@ -142,14 +142,6 @@ export default class RpcClient {
     }
   }
 
-  getLoggableResponse (res) {
-    return _.isString(res)
-      ? res
-      : this.logFullResponse
-        ? JSON.stringify(res, null, 2)
-        : _.truncate(JSON.stringify(res), DATA_LOG_LENGTH);
-  }
-
   async sendToDevice (command, opts = {}, waitForResponse = true) {
     return await new B(async (resolve, reject) => {
       // promise to be resolved whenever remote debugger
@@ -193,7 +185,7 @@ export default class RpcClient {
         // temporarily wrap with promise handling
         const specialMessageHandler = this.getSpecialMessageHandler(cmd.__selector);
         this.setSpecialMessageHandler(cmd.__selector, reject, (...args) => {
-          log.debug(`Received response from send (id: ${msgId}): '${this.getLoggableResponse(args)}'`);
+          log.debug(`Received response from send (id: ${msgId}): '${_.truncate(JSON.stringify(args), DATA_LOG_LENGTH)}'`);
 
           // call the original listener, and put it back, if necessary
           specialMessageHandler(...args);
@@ -210,7 +202,7 @@ export default class RpcClient {
           reject(new Error(msg));
         };
         this.setDataMessageHandler(msgId.toString(), errorHandler, (value) => {
-          log.debug(`Received data response from send (id: ${msgId}): '${this.getLoggableResponse(value)}'`);
+          log.debug(`Received data response from send (id: ${msgId}): '${_.truncate(JSON.stringify(value), DATA_LOG_LENGTH)}'`);
           resolve(value);
         });
       } else {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^4.0.0",
-    "appium-ios-device": "^0.11.0",
-    "appium-support": "^2.28.0",
+    "appium-ios-device": "^0.12.0",
+    "appium-support": "^2.35.0",
+    "async-lock": "^1.2.2",
     "asyncbox": "^2.6.0",
     "bluebird": "^3.4.7",
     "lodash": "^4.17.11",

--- a/test/functional/safari-e2e-specs.js
+++ b/test/functional/safari-e2e-specs.js
@@ -111,7 +111,7 @@ describe('Safari remote debugger', function () {
     await connect(rd);
     const pageArray = await rd.selectApp(address);
     _.filter(pageArray, (page) => page.title === PAGE_TITLE)
-      .should.have.length(1);
+      .should.have.length.at.least(1);
   });
 
   it('should be able to execute an atom', async function () {


### PR DESCRIPTION
Use `async-lock` to make sure that the callbacks that adjust the application dictionary do not do so at the same time.

Also do a couple of other things:
1. Change `logFullResponse ` to `logAllCommunication` and use `appium-ios-device` to do this logging. This will continue to work through the calling code.
1. Ensure `appium-ios-device` gets the `isSimulator` parameter for creating Web Inspector service.

This ought to help support lower iOS versions (see https://github.com/appium/appium/issues/13388). Tests for iOS 9.3 fail with current master (https://travis-ci.org/appium/appium-remote-debugger/jobs/603818016) but work with this branch (https://travis-ci.org/appium/appium-remote-debugger/jobs/603816787).