### PR TITLE
fix: do not use user gestures

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,6 @@
 import { logger } from 'appium-support';
 
 
-const log = logger.getLogger();
+const log = logger.getLogger('RemoteDebugger');
 
 export default log;

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -344,7 +344,9 @@ class RemoteDebugger extends events.EventEmitter {
         throw new Error('Failed to find an app to select');
       }, 0);
     } catch (ign) {
+      log.debug(ign);
       log.errorAndThrow(`Could not connect to a valid app after ${maxTries} tries.`);
+
     }
   }
 

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -344,9 +344,7 @@ class RemoteDebugger extends events.EventEmitter {
         throw new Error('Failed to find an app to select');
       }, 0);
     } catch (ign) {
-      log.debug(ign);
       log.errorAndThrow(`Could not connect to a valid app after ${maxTries} tries.`);
-
     }
   }
 

--- a/lib/remote-messages.js
+++ b/lib/remote-messages.js
@@ -76,6 +76,14 @@ class RemoteMessages {
   getFullCommand (opts = {}) {
     const {method, params, connId, senderId, appIdKey, pageIdKey, targetId, id} = opts;
 
+    /* The Web Inspector has a number of parameters that can be passed in, as
+     * seen when dumping what Safari is doing when communicating with it. Most
+     * are kept as they are set for Safari. The exception is `emulateUserGesture`
+     * which, on iOS 13+, breaks popup blocking (i.e., even with the popup
+     * blocking setting on, new windows are openable both from links and from
+     * JAvaScript).
+     */
+
     let realMethod;
     let realParams;
     if (this.isTargetBased) {

--- a/lib/remote-messages.js
+++ b/lib/remote-messages.js
@@ -90,7 +90,7 @@ class RemoteMessages {
             objectGroup: 'console',
             includeCommandLineAPI: true,
             doNotPauseOnExceptionsAndMuteConsole: false,
-            emulateUserGesture: true,
+            emulateUserGesture: false,
             generatePreview: true,
             saveResult: true,
           }
@@ -103,7 +103,7 @@ class RemoteMessages {
         objectGroup: 'console',
         includeCommandLineAPI: true,
         doNotPauseOnExceptionsAndMuteConsole: false,
-        emulateUserGesture: true,
+        emulateUserGesture: false,
       };
     }
 

--- a/lib/rpc-client-real-device.js
+++ b/lib/rpc-client-real-device.js
@@ -24,6 +24,7 @@ export default class RpcClientRealDevice extends RpcClient {
       verboseHexDump: this.logAllCommunicationHexDump,
       socketChunkSize: this.socketChunkSize,
     });
+
     this.service.listenMessage(this.receive.bind(this));
     this.connected = true;
   }

--- a/lib/rpc-client-simulator.js
+++ b/lib/rpc-client-simulator.js
@@ -61,6 +61,7 @@ export default class RpcClientSimulator extends RpcClient {
     }
 
     this.socket.setNoDelay(true);
+    this.socket.setKeepAlive(true);
     this.socket.on('close', () => {
       if (this.connected) {
         log.debug('Debugger socket disconnected');

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^4.0.0",
-    "appium-ios-device": "^1.1.0",
+    "appium-ios-device": "^1.2.1",
     "appium-support": "^2.35.0",
     "async-lock": "^1.2.2",
     "asyncbox": "^2.6.0",


### PR DESCRIPTION
I had set the `emulateUserGesture` flag to `true` since it is what Safari sends. But in iOS 13+ this somehow bypasses the popup blocking in MobileSafari (so even set to true, new windows can be open).

I had also accidentally removed the prefix to the logger.