### PR TITLE
refactor: move callbacks into correct places

### DIFF
--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -99,14 +99,6 @@ async function onAppUpdate (dict) {
   });
 }
 
-function onTargetCreated (app, targetInfo) {
-  this.rpcClient.addTarget(app, targetInfo);
-}
-
-function onTargetDestroyed (app, targetInfo) {
-  this.rpcClient.removeTarget(app, targetInfo);
-}
-
 function onConnectedDriverList (drivers) {
   this.connectedDrivers = drivers.WIRDriverDictionaryKey;
   log.debug(`Received connected driver list: ${JSON.stringify(this.connectedDrivers)}`);
@@ -140,8 +132,6 @@ const messageHandlers = {
   onAppConnect,
   onAppDisconnect,
   onAppUpdate,
-  onTargetCreated,
-  onTargetDestroyed,
   onConnectedDriverList,
   onConnectedApplicationList,
 };

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -107,6 +107,7 @@ class RemoteDebugger extends events.EventEmitter {
     this.pageIdKey = null;
     this.pageLoading = false;
     this._navigatingToPage = false;
+    this.allowNavigationWithoutReload = false;
 
     // set up the special callbacks for handling rd events
     this.specialCbs = {
@@ -119,8 +120,6 @@ class RemoteDebugger extends events.EventEmitter {
       '_rpc_reportConnectedDriverList:': this.onConnectedDriverList.bind(this),
       pageLoad: this.pageLoad.bind(this),
       frameDetached: this.frameDetached.bind(this),
-      targetCreated: this.onTargetCreated.bind(this),
-      targetDestroyed: this.onTargetDestroyed.bind(this),
     };
 
     this.rpcClient = null;
@@ -468,7 +467,9 @@ class RemoteDebugger extends events.EventEmitter {
   async pageLoad (startPageLoadMs, pageLoadVerifyHook) {
     let timeoutMs = 500;
     let start = startPageLoadMs || Date.now();
+
     log.debug('Page loaded, verifying whether ready');
+    this.pageLoading = true;
 
     const verify = async () => {
       this.pageLoadDelay = util.cancellableDelay(timeoutMs);
@@ -516,7 +517,6 @@ class RemoteDebugger extends events.EventEmitter {
 
   async pageUnload () {
     log.debug('Page unloading');
-    this.pageLoading = true;
     await this.waitForDom();
   }
 
@@ -562,6 +562,10 @@ class RemoteDebugger extends events.EventEmitter {
 
     try {
       log.debug(`Navigating to new URL: '${url}'`);
+
+      // begin listening for frame navigation event, which will be waited for later
+      const waitForFramePromise = this.waitForFrameNavigated();
+
       await this.rpcClient.send('setUrl', {
         url,
         appIdKey: this.appIdKey,
@@ -573,7 +577,8 @@ class RemoteDebugger extends events.EventEmitter {
         await B.delay(1000);
       }
 
-      await this.waitForFrameNavigated();
+      // wait until the page has been navigated
+      await waitForFramePromise;
 
       await this.waitForDom(Date.now(), pageLoadVerifyHook);
 
@@ -596,11 +601,17 @@ class RemoteDebugger extends events.EventEmitter {
       // add a handler for the `Page.frameNavigated` message
       // from the remote debugger
       const navEventListener = (value) => {
-        log.debug(`Frame navigated in ${((Date.now() - startMs) / 1000)} sec from source: ${value}`);
+        log.debug(`Frame navigated in ${((Date.now() - startMs) / 1000)}s from: ${value}`);
+        if (!this.allowNavigationWithoutReload && !this.pageLoading) {
+          resolve(value);
+        } else {
+          log.debug('Frame navigated but we were warned about it, not ' +
+                    'considering page state unloaded');
+          this.allowNavigationWithoutReload = false;
+        }
         if (this.navigationDelay) {
           this.navigationDelay.cancel();
         }
-        resolve(value);
       };
       this.rpcClient.setSpecialMessageHandler('Page.frameNavigated', reject, navEventListener);
 
@@ -717,10 +728,12 @@ class RemoteDebugger extends events.EventEmitter {
     return convertResult(res);
   }
 
-  allowNavigationWithoutReload (allow = true) {
-    if (_.isFunction(this.rpcClient.allowNavigationWithoutReload)) {
-      this.rpcClient.allowNavigationWithoutReload(allow);
-    }
+  set allowNavigationWithoutReload (allow) {
+    this._allowNavigationWithoutReload = allow;
+  }
+
+  get allowNavigationWithoutReload () {
+    return this._allowNavigationWithoutReload;
   }
 
   async getCookies (urls) {

--- a/lib/remote-messages.js
+++ b/lib/remote-messages.js
@@ -74,7 +74,16 @@ class RemoteMessages {
   }
 
   getFullCommand (opts = {}) {
-    const {method, params, connId, senderId, appIdKey, pageIdKey, targetId, id} = opts;
+    const {
+      method,
+      params,
+      connId,
+      senderId,
+      appIdKey,
+      pageIdKey,
+      targetId,
+      id,
+    } = opts;
 
     /* The Web Inspector has a number of parameters that can be passed in, as
      * seen when dumping what Safari is doing when communicating with it. Most

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -14,8 +14,6 @@ const DATA_LOG_LENGTH = {length: 200};
 const WAIT_FOR_TARGET_TIMEOUT = 10000;
 const WAIT_FOR_TARGET_INTERVAL = 1000;
 
-const TARGET_PAGE_PREFIX = 'page-';
-
 const MIN_PLATFORM_FOR_TARGET_BASED = '12.2';
 
 function isTargetBased (isSafari, platformVersion) {
@@ -57,6 +55,9 @@ export default class RpcClient {
 
     // message handlers
     this.specialMessageHandlers = specialMessageHandlers;
+    // add message handlers for events that are purely rpc related
+    this.specialMessageHandlers.targetCreated = this.addTarget.bind(this);
+    this.specialMessageHandlers.targetDestroyed = this.removeTarget.bind(this),
 
     // start with a best guess for the protocol
     this.setCommunicationProtocol(isTargetBased(isSafari, this.platformVersion));
@@ -90,15 +91,6 @@ export default class RpcClient {
 
     if (this.getTarget(appIdKey, pageIdKey)) {
       return;
-    }
-
-    // iOS less than 13 have targets that can be computed easily
-    // and sometimes is not reported by the Web Inspector
-    if (util.compareVersions(this.platformVersion, '<', '13.0') && _.isEmpty(this.getTarget(appIdKey, pageIdKey))) {
-      if (this.isSafari) {
-        this.addTarget(appIdKey, {targetId: `${TARGET_PAGE_PREFIX}${pageIdKey}`});
-        return;
-      }
     }
 
     // otherwise waiting is necessary to see what the target is
@@ -162,7 +154,12 @@ export default class RpcClient {
       const targetId = this.getTarget(appIdKey, pageIdKey);
 
       // retrieve the correct command to send
-      const fullOpts = _.defaults({connId: this.connId, senderId: this.senderId, targetId, id: msgId}, opts);
+      const fullOpts = _.defaults({
+        connId: this.connId,
+        senderId: this.senderId,
+        targetId,
+        id: msgId,
+      }, opts);
       const cmd = this.remoteMessages.getRemoteCommand(command, fullOpts);
 
       if (cmd.__argument && cmd.__argument.WIRSocketDataKey) {
@@ -308,10 +305,6 @@ export default class RpcClient {
 
   setDataMessageHandler (key, errorHandler, handler) {
     this.messageHandler.setDataMessageHandler(key, errorHandler, handler);
-  }
-
-  allowNavigationWithoutReload (allow = true) {
-    this.messageHandler.allowNavigationWithoutReload(allow);
   }
 
   async selectPage (appIdKey, pageIdKey) {

--- a/lib/rpc-message-handler.js
+++ b/lib/rpc-message-handler.js
@@ -26,7 +26,6 @@ export default class RpcMessageHandler {
     this.errorHandlers = {};
     this.specialHandlers = _.clone(specialHandlers);
     this.dataHandlers = {};
-    this.willNavigateWithoutReload = false;
 
     this.isTargetBased = isTargetBased;
   }
@@ -67,10 +66,6 @@ export default class RpcMessageHandler {
 
   hasSpecialMessageHandler (key) {
     return _.has(this.specialHandlers, key);
-  }
-
-  allowNavigationWithoutReload (allow = true) {
-    this.willNavigateWithoutReload = allow;
   }
 
   async handleMessage (plist) {
@@ -125,16 +120,10 @@ export default class RpcMessageHandler {
     if (method === 'Profiler.resetProfiles') {
       log.debug('Device is telling us to reset profiles. Should probably ' +
                 'do some kind of callback here');
-    } else if (method === 'Page.frameNavigated') {
-      if (!this.willNavigateWithoutReload && !this.pageLoading) {
-        if (_.isFunction(this.specialHandlers['Page.frameNavigated'])) {
-          await this.specialHandlers['Page.frameNavigated']('remote-debugger');
-          this.specialHandlers['Page.frameNavigated'] = null;
-        }
-      } else {
-        log.debug('Frame navigated but we were warned about it, not ' +
-                  'considering page state unloaded');
-        this.willNavigateWithoutReload = false;
+    } else if (method === 'Page.frameNavigated' || method === 'Page.frameStoppedLoading') {
+      if (_.isFunction(this.specialHandlers['Page.frameNavigated'])) {
+        await this.specialHandlers['Page.frameNavigated'](`'${method}' event`);
+        this.specialHandlers['Page.frameNavigated'] = null;
       }
     } else if (IGNORED_EVENTS.includes(method)) {
       // pass
@@ -158,7 +147,7 @@ export default class RpcMessageHandler {
       this.dataHandlers[msgId](result);
       this.dataHandlers[msgId] = null;
     } else if (this.dataHandlers[msgId] === null) {
-      log.error(`Debugger returned data for message ${msgId} ` +
+      log.error(`Debugger returned data for message '${msgId}' ` +
                 `but we already ran that callback! WTF??`);
     } else {
       if (msgId || result || error) {


### PR DESCRIPTION
There were a number of places where callbacks were in the wrong place, so, for instance, an event would come in and be passed up to the RemoteDebugger from the RPC client, only to be passed back down to the RPC client.

So, move some of those around into the right places.