### PR TITLE
feat: allow '*' as bundle id reported by Safari

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -85,17 +85,17 @@ function getDebuggerAppKey (bundleId, appDict) {
   // now we need to determine if we should pick a proxy for this instead
   if (appId) {
     log.debug(`Found app id key '${appId}' for bundle '${bundleId}'`);
-    let proxiedAppIds = [];
+    let proxyAppId;
     for (const [key, data] of _.toPairs(appDict)) {
       if (data.isProxy && data.hostId === appId) {
         log.debug(`Found separate bundleId '${data.bundleId}' ` +
                   `acting as proxy for '${bundleId}', with app id '${key}'`);
-        proxiedAppIds.push(key);
+        // set the app id... the last one will be used, so just keep re-assigning
+        proxyAppId = key;
       }
     }
-    if (proxiedAppIds.length) {
-      // use the last app being proxied
-      appId = _.last(proxiedAppIds);
+    if (proxyAppId) {
+      appId = proxyAppId;
       log.debug(`Using proxied app id '${appId}'`);
     }
   }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -7,6 +7,7 @@ import { errorFromMJSONWPStatusCode } from 'appium-base-driver';
 
 
 const WEB_CONTENT_BUNDLE_ID = 'com.apple.WebKit.WebContent';
+const WILDCARD_BUNDLE_ID = '*';
 
 const RESPONSE_LOG_LENGTH = 100;
 
@@ -25,7 +26,7 @@ function appInfoFromDict (dict) {
   let isAutomationEnabled = !!dict.WIRRemoteAutomationEnabledKey;
   if (_.has(dict, 'WIRAutomationAvailabilityKey')) {
     if (_.isString(dict.WIRAutomationAvailabilityKey)) {
-      dict.WIRAutomationAvailabilityKey === 'WIRAutomationAvailabilityUnknown'
+      isAutomationEnabled = dict.WIRAutomationAvailabilityKey === 'WIRAutomationAvailabilityUnknown'
         ? 'Unknown'
         : dict.WIRAutomationAvailabilityKey === 'WIRAutomationAvailabilityAvailable';
     } else {
@@ -73,35 +74,29 @@ function pageArrayFromDict (pageDict) {
  * Given a bundle id, finds the correct remote debugger app that is
  * connected.
  */
-function getDebuggerAppKey (bundleId, platformVersion, appDict) {
+function getDebuggerAppKey (bundleId, appDict) {
   let appId;
-  if (parseFloat(platformVersion) >= 8) {
+  for (const [key, data] of _.toPairs(appDict)) {
+    if (data.bundleId === bundleId) {
+      appId = key;
+      break;
+    }
+  }
+  // now we need to determine if we should pick a proxy for this instead
+  if (appId) {
+    log.debug(`Found app id key '${appId}' for bundle '${bundleId}'`);
+    let proxiedAppIds = [];
     for (const [key, data] of _.toPairs(appDict)) {
-      if (data.bundleId === bundleId) {
-        appId = key;
-        break;
+      if (data.isProxy && data.hostId === appId) {
+        log.debug(`Found separate bundleId '${data.bundleId}' ` +
+                  `acting as proxy for '${bundleId}', with app id '${key}'`);
+        proxiedAppIds.push(key);
       }
     }
-    // now we need to determine if we should pick a proxy for this instead
-    if (appId) {
-      log.debug(`Found app id key '${appId}' for bundle '${bundleId}'`);
-      let proxiedAppIds = [];
-      for (const [key, data] of _.toPairs(appDict)) {
-        if (data.isProxy && data.hostId === appId) {
-          log.debug(`Found separate bundleId '${data.bundleId}' ` +
-                    `acting as proxy for '${bundleId}', with app id '${key}'`);
-          proxiedAppIds.push(key);
-        }
-      }
-      if (proxiedAppIds.length) {
-        // use the last app being proxied
-        appId = _.last(proxiedAppIds);
-        log.debug(`Using proxied app id '${appId}'`);
-      }
-    }
-  } else {
-    if (_.has(appDict, bundleId)) {
-      appId = bundleId;
+    if (proxiedAppIds.length) {
+      // use the last app being proxied
+      appId = _.last(proxiedAppIds);
+      log.debug(`Using proxied app id '${appId}'`);
     }
   }
 
@@ -125,10 +120,11 @@ function appIdForBundle (bundleId, appDict) {
   return appId;
 }
 
-function getPossibleDebuggerAppKeys (bundleIds, platformVersion, appDict) {
+function getPossibleDebuggerAppKeys (bundleIds, appDict) {
   let proxiedAppIds = [];
 
-  for (const bundleId of bundleIds) {
+  // go through the possible bundle identifiers, along with the wildcard
+  for (const bundleId of [...bundleIds, WILDCARD_BUNDLE_ID]) {
     const appId = appIdForBundle(bundleId, appDict);
 
     // now we need to determine if we should pick a proxy for this instead

--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -78,7 +78,7 @@ function onAppDisconnect (dict) {
   // if the disconnected app is the one we are connected to, try to find another
   if (this.appIdKey === appIdKey) {
     log.debug(`No longer have app id. Attempting to find new one.`);
-    this.appIdKey = getDebuggerAppKey(this.bundleId, this.platformVersion, this.appDict);
+    this.appIdKey = getDebuggerAppKey(this.bundleId, this.appDict);
   }
 
   if (!this.appDict) {

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -208,7 +208,7 @@ class RemoteDebugger extends events.EventEmitter {
 
     // try to get the app id from our connected apps
     if (!this.appIdKey) {
-      this.appIdKey = getDebuggerAppKey(this.bundleId, this.platformVersion, this.appDict);
+      this.appIdKey = getDebuggerAppKey(this.bundleId, this.appDict);
     }
   }
 
@@ -303,7 +303,7 @@ class RemoteDebugger extends events.EventEmitter {
     try {
       return await retryInterval(maxTries, SELECT_APP_RETRY_SLEEP_MS, async (retryCount) => {
         this.logApplicationDictionary(this.appDict);
-        const possibleAppIds = getPossibleDebuggerAppKeys(bundleIds, this.platformVersion, this.appDict);
+        const possibleAppIds = getPossibleDebuggerAppKeys(bundleIds, this.appDict);
         log.debug(`Trying out the possible app ids: ${possibleAppIds.join(', ')} (try #${retryCount + 1} of ${maxTries})`);
         for (const attemptedAppIdKey of possibleAppIds) {
           try {

--- a/test/unit/helpers-specs.js
+++ b/test/unit/helpers-specs.js
@@ -37,7 +37,7 @@ describe('helpers', function () {
           bundleId: 'io.appium.bundle'
         }
       };
-      getDebuggerAppKey('io.appium.bundle', '8.3', appDict).should.equal('42');
+      getDebuggerAppKey('io.appium.bundle', appDict).should.equal('42');
     });
     it('should return the app key for the bundle when proxied', function () {
       let appDict = {
@@ -51,10 +51,10 @@ describe('helpers', function () {
           hostId: '42'
         }
       };
-      getDebuggerAppKey('io.appium.bundle', '8.3', appDict).should.equal('43');
+      getDebuggerAppKey('io.appium.bundle', appDict).should.equal('43');
     });
     it('should return undefined when there is no appropriate app', function () {
-      expect(getDebuggerAppKey('io.appium.bundle', '8.3', {})).to.not.exist;
+      expect(getDebuggerAppKey('io.appium.bundle', {})).to.not.exist;
     });
   });
   describe('pageArrayFromDict', function () {


### PR DESCRIPTION
Use apps with the bundle identifier `"*"`.

In doing this there was some code that could be yanked relating to old platforms that this version does not support.

Related to https://github.com/appium/appium/issues/13622