### PR TITLE
Update proxy connection ability

### DIFF
--- a/lib/rpc-client-simulator.js
+++ b/lib/rpc-client-simulator.js
@@ -40,9 +40,12 @@ export default class RpcClientSimulator extends RpcClient {
         // Forward the actual socketPath to the proxy
         this.socket.once('connect', () => {
           log.debug(`Forwarding the actual web inspector socket to the proxy: '${this.socketPath}'`);
-          this.socket.write(JSON.stringify({socketPath: this.socketPath}));
+          this.socket.write(JSON.stringify({
+            socketPath: this.socketPath,
+            udid: this.udid,
+            osVersion: this.platformVersion
+          }));
         });
-
       } else {
         // unix domain socket
         log.debug(`Connecting to remote debugger through unix domain socket: '${this.socketPath}'`);
@@ -101,8 +104,8 @@ export default class RpcClientSimulator extends RpcClient {
   async disconnect () { // eslint-disable-line require-await
     if (!this.isConnected()) {
       return;
-
     }
+
     log.debug('Disconnecting from remote debugger');
     this.service.close();
     this.connected = false;

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -119,15 +119,15 @@ export default class RpcClient {
     } = opts;
     try {
       await this.waitForTarget(appIdKey, pageIdKey);
-      return await this.sendToDevice(command, opts, waitForResponse);
+      return this.sendToDevice(command, opts, waitForResponse);
     } catch (err) {
       if (err.message.includes(`'Target' domain was not found`)) {
         this.setCommunicationProtocol(false);
-        return await this.sendToDevice(command, opts, waitForResponse);
+        return this.sendToDevice(command, opts, waitForResponse);
       } else if (err.message.includes(`domain was not found`)) {
         this.setCommunicationProtocol(true);
         await this.waitForTarget(appIdKey, pageIdKey);
-        return await this.sendToDevice(command, opts, waitForResponse);
+        return this.sendToDevice(command, opts, waitForResponse);
       }
       throw new Error(err);
     } finally {

--- a/package.json
+++ b/package.json
@@ -61,13 +61,13 @@
   "devDependencies": {
     "ajv": "^6.5.3",
     "appium-gulp-plugins": "^4.2.0",
-    "appium-ios-simulator": "^3.10.0",
+    "appium-ios-simulator": "^3.14.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "eslint-config-appium": "^4.2.0",
     "gulp": "^4.0.0",
     "mocha": "^6.0.0",
-    "node-simctl": "^5.0.0",
+    "node-simctl": "^5.1.1",
     "pre-commit": "^1.1.3",
     "uuid-js": "^0.7.5"
   },


### PR DESCRIPTION
Since we have implemented the ability to route the socket connection to the iOS device via a proxy some things have updated (e.g. the way we communicate to the device with `appium-ios-device`). This PR intends to update the current behavior so that a proper connection on the proxy side can be established.

__Note:__ this is work in progress but I don't think much changes will be applied at this point.