### PR TITLE
feat: allow passing in a list of additional possible bundle identifiers

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -124,7 +124,9 @@ function getPossibleDebuggerAppKeys (bundleIds, appDict) {
   let proxiedAppIds = [];
 
   // go through the possible bundle identifiers, along with the wildcard
-  for (const bundleId of [...bundleIds, WILDCARD_BUNDLE_ID]) {
+  const possibleBundleIds = [...bundleIds, WILDCARD_BUNDLE_ID];
+  log.debug(`Checking for bundle identifiers: ${possibleBundleIds.join(', ')}`);
+  for (const bundleId of possibleBundleIds) {
     const appId = appIdForBundle(bundleId, appDict);
 
     // now we need to determine if we should pick a proxy for this instead

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -40,6 +40,8 @@ class RemoteDebugger extends events.EventEmitter {
   /*
    * The constructor takes an opts hash with the following properties:
    *   - bundleId - id of the app being connected to
+   *   - additionalBundleIds - array of possible bundle ids that the inspector
+   *                           could return
    *   - platformVersion - version of iOS
    *   - useNewSafari - for web inspector, whether this is a new Safari instance
    *   - pageLoadMs - the time, in ms, that should be waited for page loading
@@ -58,6 +60,7 @@ class RemoteDebugger extends events.EventEmitter {
 
     const {
       bundleId,
+      additionalBundleIds = [],
       platformVersion,
       isSafari = true,
       includeSafari = false,
@@ -76,6 +79,7 @@ class RemoteDebugger extends events.EventEmitter {
     } = opts;
 
     this.bundleId = bundleId;
+    this.additionalBundleIds = additionalBundleIds;
     this.platformVersion = platformVersion;
     this.isSafari = isSafari;
     this.includeSafari = includeSafari;
@@ -297,8 +301,8 @@ class RemoteDebugger extends events.EventEmitter {
 
   async searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
     const bundleIds = this.includeSafari && !this.isSafari
-      ? [this.bundleId, SAFARI_BUNDLE_ID]
-      : [this.bundleId];
+      ? [this.bundleId, ...this.additionalBundleIds, SAFARI_BUNDLE_ID]
+      : [this.bundleId, ...this.additionalBundleIds];
     try {
       return await retryInterval(maxTries, SELECT_APP_RETRY_SLEEP_MS, async (retryCount) => {
         this.logApplicationDictionary(this.appDict);


### PR DESCRIPTION
Allow an array of additional bundle identifiers to be passed in. These will be added to the list of bundle ids looked for when finding attached apps.

This is needed sometimes when app resigning changes the behaviour of the Web Inspector for reasons we are not entirely understanding.