### PR TITLE
Throw 'TimeoutError' on executeAtomAsync when timeout is 0ms.

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -443,6 +443,11 @@ class RemoteDebugger extends events.EventEmitter {
       const timeout = (args.length >= 3) ? args[2] : RPC_RESPONSE_TIMEOUT_MS;
       const retries = parseInt(timeout / retryWait, 10);
       const startTime = process.hrtime();
+      
+      if (retries === 0) {
+          throw new errors.TimeoutError(`Timed out waiting for asynchronous script ` +
+                                        `result after ${getElapsedTime(startTime)} ms`);
+      }
       res = await retryInterval(retries, retryWait, async () => {
         // the atom _will_ return, either because it finished or an error
         // including a timeout error

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -443,10 +443,10 @@ class RemoteDebugger extends events.EventEmitter {
       const timeout = (args.length >= 3) ? args[2] : RPC_RESPONSE_TIMEOUT_MS;
       const retries = parseInt(timeout / retryWait, 10);
       const startTime = process.hrtime();
-      
+
       if (retries === 0) {
-          throw new errors.TimeoutError(`Timed out waiting for asynchronous script ` +
-                                        `result after ${getElapsedTime(startTime)} ms`);
+        throw new errors.TimeoutError(`Timed out waiting for asynchronous script ` +
+                                      `result after ${getElapsedTime(startTime)} ms`);
       }
       res = await retryInterval(retries, retryWait, async () => {
         // the atom _will_ return, either because it finished or an error

--- a/test/functional/safari-e2e-specs.js
+++ b/test/functional/safari-e2e-specs.js
@@ -162,6 +162,18 @@ describe('Safari remote debugger', function () {
       await rd.executeAtomAsync('execute_async_script', [script, [], timeout], [])
         .should.eventually.be.rejectedWith(/Timed out waiting for/);
     });
+
+    it('should timeout when callback is not invoked and script timeout is 0ms', async function () {
+      await connect(rd);
+      const page = _.find(await rd.selectApp(address), (page) => page.title === PAGE_TITLE);
+      const [appIdKey, pageIdKey] = page.id.split('.').map((id) => parseInt(id, 10));
+      await rd.selectPage(appIdKey, pageIdKey);
+
+      const zero_timeout = 0;
+      const script = 'return 1 + 2';
+      await rd.executeAtomAsync('execute_async_script', [script, [], zero_timeout], [])
+        .should.eventually.be.rejectedWith(/Timed out waiting for/);
+    });
   });
 
   it(`should be able to call 'selectApp' after already connecting to app`, async function () {


### PR DESCRIPTION
If the script timeout is set to 0ms and Runtime.awaitPromise is not available, executeAtomAsync never actually attempts to execute the script.

This causes an unclear error to be thrown from convertResult of helpers.js:  `Result has unexpected type: (object)`. The object is null.

With this PR, if script timeout is 0ms and Runtime.awaitPromise is not available, executeAtomAsync preemptively throws a TimeoutError.