### PR TITLE
chore: update appium-base-driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-base-driver": "^3.0.0",
+    "appium-base-driver": "^5.0.2",
     "appium-support": "^2.28.0",
     "asyncbox": "^2.5.2",
     "bluebird": "^3.4.7",


### PR DESCRIPTION
Update `appium-base-driver` in the v4 line of `appium-remote-debugger`.