### PR TITLE
fix: always do the loop once in async execute

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -441,7 +441,8 @@ class RemoteDebugger extends events.EventEmitter {
       // awaitPromise is not always available, so simulate it with poll
       const retryWait = 100;
       const timeout = (args.length >= 3) ? args[2] : RPC_RESPONSE_TIMEOUT_MS;
-      const retries = parseInt(timeout / retryWait, 10);
+      // if the timeout math turns up 0 retries, make sure it happens once
+      const retries = parseInt(timeout / retryWait, 10) || 1;
       const startTime = process.hrtime();
       res = await retryInterval(retries, retryWait, async () => {
         // the atom _will_ return, either because it finished or an error


### PR DESCRIPTION
It can happen that the math makes the retries be 0. But we need to try at least once.