### PR TITLE
fix: add safariviewcontroller bundle id to standard list

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -124,12 +124,10 @@ function appIdForBundle (bundleId, appDict) {
 function getPossibleDebuggerAppKeys (bundleIds, appDict) {
   let proxiedAppIds = [];
 
-  const extraBundleIds = bundleIds.includes(SAFARI_WEB_VIEW_BUNDLE_ID)
-    ? [WILDCARD_BUNDLE_ID]
-    : [SAFARI_WEB_VIEW_BUNDLE_ID, WILDCARD_BUNDLE_ID];
 
-  // go through the possible bundle identifiers, along with the wildcard
-  const possibleBundleIds = [...bundleIds, ...extraBundleIds];
+
+  // go through the possible bundle identifiers
+  const possibleBundleIds = _.uniq([SAFARI_WEB_VIEW_BUNDLE_ID, WILDCARD_BUNDLE_ID, ...bundleIds]);
   log.debug(`Checking for bundle identifiers: ${possibleBundleIds.join(', ')}`);
   for (const bundleId of possibleBundleIds) {
     const appId = appIdForBundle(bundleId, appDict);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -7,6 +7,7 @@ import { errorFromMJSONWPStatusCode } from 'appium-base-driver';
 
 
 const WEB_CONTENT_BUNDLE_ID = 'com.apple.WebKit.WebContent';
+const SAFARI_WEB_VIEW_BUNDLE_ID = 'process-SafariViewService';
 const WILDCARD_BUNDLE_ID = '*';
 
 const RESPONSE_LOG_LENGTH = 100;
@@ -123,8 +124,12 @@ function appIdForBundle (bundleId, appDict) {
 function getPossibleDebuggerAppKeys (bundleIds, appDict) {
   let proxiedAppIds = [];
 
+  const extraBundleIds = bundleIds.includes(SAFARI_WEB_VIEW_BUNDLE_ID)
+    ? [WILDCARD_BUNDLE_ID]
+    : [SAFARI_WEB_VIEW_BUNDLE_ID, WILDCARD_BUNDLE_ID];
+
   // go through the possible bundle identifiers, along with the wildcard
-  const possibleBundleIds = [...bundleIds, WILDCARD_BUNDLE_ID];
+  const possibleBundleIds = [...bundleIds, ...extraBundleIds];
   log.debug(`Checking for bundle identifiers: ${possibleBundleIds.join(', ')}`);
   for (const bundleId of possibleBundleIds) {
     const appId = appIdForBundle(bundleId, appDict);


### PR DESCRIPTION
Automatically find SafariViewController apps if available.