### PR TITLE
fix: do not ignore empty urls

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -284,7 +284,7 @@ class RemoteDebugger extends events.EventEmitter {
         }
         const id = app.replace('PID:', '');
         for (const page of info.pageArray) {
-          if (page.url && (!ignoreAboutBlankUrl || page.url !== BLANK_PAGE_URL)) {
+          if (!(ignoreAboutBlankUrl && page.url === BLANK_PAGE_URL)) {
             let pageDict = _.clone(page);
             pageDict.id = `${id}.${pageDict.id}`;
             fullPageArray.push(pageDict);


### PR DESCRIPTION
There is no reason to ignore apps with empty urls. All the `appium-xcuitest-driver` tests run with this change (https://travis-ci.org/imurchie/appium-xcuitest-driver/builds/633862057)