### PR TITLE
fix: do not wait for reply on setup commands

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -676,7 +676,7 @@ class RemoteDebugger extends events.EventEmitter {
     return await this.rpcClient.send('startNetwork', {
       appIdKey: this.appIdKey,
       pageIdKey: this.pageIdKey,
-    });
+    }, false);
   }
 
   async stopNetwork () {

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -79,12 +79,12 @@ export default class RpcClient {
     }
   }
 
-  needsTarget () {
+  get needsTarget () {
     return this.shouldCheckForTarget && this.isTargetBased;
   }
 
-  async waitForTarget (appIdKey, pageIdKey) {
-    if (!this.needsTarget()) {
+  async waitForTarget (appIdKey, pageIdKey, force = false) {
+    if (!force && !this.needsTarget) {
       return;
     }
 
@@ -209,7 +209,7 @@ export default class RpcClient {
       const msg = `Sending '${cmd.__selector}' message` +
         (fullOpts.appIdKey ? ` to app '${fullOpts.appIdKey}'` : '') +
         (fullOpts.pageIdKey ? `, page '${fullOpts.pageIdKey}'` : '') +
-        (this.needsTarget() ? `, target '${targetId}'` : '') +
+        (this.needsTarget ? `, target '${targetId}'` : '') +
         ` (id: ${msgId})`;
       log.debug(msg);
       try {
@@ -324,12 +324,12 @@ export default class RpcClient {
 
     this.shouldCheckForTarget = true;
 
-    await this.send('enableInspector', sendOpts);
-    await this.send('enablePage', sendOpts);
-    await this.send('enableRuntime', sendOpts);
-    await this.send('enableDebugger', sendOpts);
-    await this.send('enableConsole', sendOpts);
-    await this.send('inspectorInitialized', sendOpts);
+    await this.send('enableInspector', sendOpts, false);
+    await this.send('enablePage', sendOpts, false);
+    await this.send('enableRuntime', sendOpts, false);
+    await this.send('enableDebugger', sendOpts, false);
+    await this.send('enableConsole', sendOpts, false);
+    await this.send('inspectorInitialized', sendOpts, false);
   }
 
   async selectApp (appIdKey, applicationConnectedHandler) {


### PR DESCRIPTION
There turns out to be no reason to wait for these calls to return. 