### PR TITLE
refactor: use EventEmitter instead of passing callbacks all over

### DIFF
--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -9,7 +9,7 @@ import _ from 'lodash';
  * These will be added to the prototype.
  */
 
-async function onPageChange (appIdKey, pageDict) {
+async function onPageChange (err, appIdKey, pageDict) {
   if (_.isEmpty(pageDict)) {
     return;
   }
@@ -54,7 +54,7 @@ async function onPageChange (appIdKey, pageDict) {
   });
 }
 
-async function onAppConnect (dict) {
+async function onAppConnect (err, dict) {
   let appIdKey = dict.WIRApplicationIdentifierKey;
   log.debug(`Notified that new application '${appIdKey}' has connected`);
   await this.useAppDictLock((done) => {
@@ -66,7 +66,7 @@ async function onAppConnect (dict) {
   });
 }
 
-function onAppDisconnect (dict) {
+function onAppDisconnect (err, dict) {
   let appIdKey = dict.WIRApplicationIdentifierKey;
   log.debug(`Application '${appIdKey}' disconnected. Removing from app dictionary.`);
   log.debug(`Current app is ${this.appIdKey}`);
@@ -89,7 +89,7 @@ function onAppDisconnect (dict) {
   }
 }
 
-async function onAppUpdate (dict) {
+async function onAppUpdate (err, dict) {
   await this.useAppDictLock((done) => {
     try {
       this.updateAppsWithDict(dict);
@@ -99,7 +99,7 @@ async function onAppUpdate (dict) {
   });
 }
 
-function onConnectedDriverList (drivers) {
+function onConnectedDriverList (err, drivers) {
   this.connectedDrivers = drivers.WIRDriverDictionaryKey;
   log.debug(`Received connected driver list: ${JSON.stringify(this.connectedDrivers)}`);
 }

--- a/lib/remote-debugger-real-device.js
+++ b/lib/remote-debugger-real-device.js
@@ -23,7 +23,6 @@ export default class RemoteDebuggerRealDevice extends RemoteDebugger {
       host: this.host,
       port: this.port,
       socketPath: this.socketPath,
-      specialMessageHandlers: this.specialCbs,
       messageProxy: this.remoteDebugProxy,
       logAllCommunication: this.logAllCommunication,
       logAllCommunicationHexDump: this.logAllCommunicationHexDump,

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -182,7 +182,7 @@ class RemoteDebugger extends events.EventEmitter {
     this.teardown();
   }
 
-  isConnected () {
+  get isConnected () {
     return !!(this.rpcClient && this.rpcClient.isConnected);
   }
 
@@ -657,47 +657,41 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   /*
-   * Keep track of the console event listeners so they can be removed
+   * Keep track of the client event listeners so they can be removed
    */
-  get consoleListeners () {
-    this._consoleListeners = this._consoleListeners || [];
-    return this._consoleListeners;
+  addClientEventListener (eventName, listener) {
+    this._clientEventListeners = this._clientEventListeners || {};
+    this._clientEventListeners[eventName] = this._clientEventListeners[eventName] || [];
+    this._clientEventListeners[eventName].push(listener);
+    this.rpcClient.on(eventName, listener);
+  }
+
+  removeClientEventListener (eventName) {
+    for (const listener of (this._clientEventListeners[eventName] || [])) {
+      this.rpcClient.off(eventName, listener);
+    }
   }
 
   startConsole (listener) {
     log.debug('Starting to listen for JavaScript console');
-    this.consoleListeners.push(listener);
-    this.rpcClient.on('Console.messageAdded', listener);
-    this.rpcClient.on('Console.messageRepeatCountUpdated', listener);
+    this.addClientEventListener('Console.messageAdded', listener);
+    this.addClientEventListener('Console.messageRepeatCountUpdated', listener);
   }
 
   stopConsole () {
     log.debug('Stopping to listen for JavaScript console');
-    for (const listener of this.consoleListeners) {
-      this.rpcClient.off('Console.messageAdded', listener);
-      this.rpcClient.off('Console.messageRepeatCountUpdated', listener);
-    }
-  }
-
-  /*
-   * Keep track of the network event listeners, so they can be removed
-   */
-  get networkListeners () {
-    this._networkListeners = this._networkListeners || [];
-    return this._networkListeners;
+    this.removeClientEventListener('Console.messageAdded');
+    this.removeClientEventListener('Console.messageRepeatCountUpdated');
   }
 
   startNetwork (listener) {
     log.debug('Starting to listen for network events');
-    this.networkListeners.push(listener);
-    this.rpcClient.on('NetworkEvent', listener);
+    this.addClientEventListener('NetworkEvent', listener);
   }
 
   stopNetwork () {
     log.debug('Stopping to listen for network events');
-    for (const listener of this.networkListeners) {
-      this.rpcClient.off('NetworkEvent', listener);
-    }
+    this.removeClientEventListener('NetworkEvent');
   }
 
   async execute (command, override) {

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -116,19 +116,6 @@ class RemoteDebugger extends events.EventEmitter {
     this._navigatingToPage = false;
     this.allowNavigationWithoutReload = false;
 
-    // set up the special callbacks for handling rd events
-    this.specialCbs = {
-      '_rpc_reportIdentifier:': _.noop,
-      '_rpc_forwardGetListing:': this.onPageChange.bind(this),
-      '_rpc_reportConnectedApplicationList:': this.onConnectedApplicationList.bind(this),
-      '_rpc_applicationConnected:': this.onAppConnect.bind(this),
-      '_rpc_applicationDisconnected:': this.onAppDisconnect.bind(this),
-      '_rpc_applicationUpdated:': this.onAppUpdate.bind(this),
-      '_rpc_reportConnectedDriverList:': this.onConnectedDriverList.bind(this),
-      pageLoad: this.pageLoad.bind(this),
-      frameDetached: this.frameDetached.bind(this),
-    };
-
     this.rpcClient = null;
   }
 
@@ -139,8 +126,6 @@ class RemoteDebugger extends events.EventEmitter {
     this.appIdKey = null;
     this.pageIdKey = null;
     this.pageLoading = false;
-
-    this.specialCbs = {};
 
     this.rpcClient = null;
 
@@ -159,12 +144,23 @@ class RemoteDebugger extends events.EventEmitter {
       host: this.host,
       port: this.port,
       socketPath: this.socketPath,
-      specialMessageHandlers: this.specialCbs,
       messageProxy: this.remoteDebugProxy,
       logAllCommunication: this.logAllCommunication,
       logAllCommunicationHexDump: this.logAllCommunicationHexDump,
       fullPageInitialization: this.fullPageInitialization,
     });
+
+    // listen for basic debugger-level events
+    this.rpcClient.on('_rpc_reportSetup:', _.noop);
+    this.rpcClient.on('_rpc_forwardGetListing:', this.onPageChange.bind(this));
+    this.rpcClient.on('_rpc_reportConnectedApplicationList:', this.onConnectedApplicationList.bind(this));
+    this.rpcClient.on('_rpc_applicationConnected:', this.onAppConnect.bind(this));
+    this.rpcClient.on('_rpc_applicationDisconnected:', this.onAppDisconnect.bind(this));
+    this.rpcClient.on('_rpc_applicationUpdated:', this.onAppUpdate.bind(this));
+    this.rpcClient.on('_rpc_reportConnectedDriverList:', this.onConnectedDriverList.bind(this));
+    this.rpcClient.on('pageLoad', this.pageLoad.bind(this));
+    this.rpcClient.on('Page.frameDetached', this.frameDetached.bind(this));
+
     await this.rpcClient.connect();
 
     // get the connection information about the app
@@ -187,7 +183,7 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   isConnected () {
-    return !!(this.rpcClient && this.rpcClient.isConnected());
+    return !!(this.rpcClient && this.rpcClient.isConnected);
   }
 
   async setConnectionKey () {
@@ -261,7 +257,7 @@ class RemoteDebugger extends events.EventEmitter {
         return [];
       }
 
-      const { appIdKey, pageDict } = await this.searchForApp(currentUrl, maxTries, ignoreAboutBlankUrl);
+      const {appIdKey, pageDict} = await this.searchForApp(currentUrl, maxTries, ignoreAboutBlankUrl);
 
       // if, after all this, we have no dictionary, we have failed
       if (!appIdKey || !pageDict) {
@@ -390,7 +386,7 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   async executeAtom (atom, args, frames) {
-    if (!this.rpcClient.isConnected()) {
+    if (!this.rpcClient.isConnected) {
       throw new Error('Remote debugger is not connected');
     }
 
@@ -603,13 +599,13 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   async waitForFrameNavigated () {
-    return await new B(async (resolve, reject) => {
+    return await new B(async (resolve) => {
       log.debug('Waiting for frame navigated message...');
       let startMs = Date.now();
 
       // add a handler for the `Page.frameNavigated` message
       // from the remote debugger
-      const navEventListener = (value) => {
+      const navEventListener = (err, value) => {
         log.debug(`Frame navigated in ${((Date.now() - startMs) / 1000)}s from: ${value}`);
         if (!this.allowNavigationWithoutReload && !this.pageLoading) {
           resolve(value);
@@ -622,13 +618,14 @@ class RemoteDebugger extends events.EventEmitter {
           this.navigationDelay.cancel();
         }
       };
-      this.rpcClient.setSpecialMessageHandler('Page.frameNavigated', reject, navEventListener);
+
+      this.rpcClient.once('Page.frameNavigated', navEventListener);
 
       // timeout, in case remote debugger doesn't respond,
       // or takes a long time
       if (!this.useNewSafari || this.pageLoadMs >= 0) {
         // use pageLoadMs, or a small amount of time
-        let timeout = this.useNewSafari ? this.pageLoadMs : 500;
+        const timeout = this.useNewSafari ? this.pageLoadMs : 500;
         this.navigationDelay = util.cancellableDelay(timeout);
         try {
           await this.navigationDelay;
@@ -644,8 +641,8 @@ class RemoteDebugger extends events.EventEmitter {
 
   async startTimeline (fn) {
     log.debug('Starting to record the timeline');
-    this.rpcClient.timelineEventHandler = fn;
-    return await this.rpcClient.send('Timeline.start', {
+    this.rpcClient.on('Timeline.eventRecorded', fn);
+    return await this.rpcClient.send('startTimeline', {
       appIdKey: this.appIdKey,
       pageIdKey: this.pageIdKey,
     });
@@ -659,34 +656,48 @@ class RemoteDebugger extends events.EventEmitter {
     });
   }
 
-  async startConsole (fn) { // eslint-disable-line require-await
+  /*
+   * Keep track of the console event listeners so they can be removed
+   */
+  get consoleListeners () {
+    this._consoleListeners = this._consoleListeners || [];
+    return this._consoleListeners;
+  }
+
+  startConsole (listener) {
     log.debug('Starting to listen for JavaScript console');
-    if (_.isFunction(fn)) {
-      this.rpcClient.consoleLogEventHandler = fn;
-    }
+    this.consoleListeners.push(listener);
+    this.rpcClient.on('Console.messageAdded', listener);
+    this.rpcClient.on('Console.messageRepeatCountUpdated', listener);
   }
 
-  async stopConsole () {
+  stopConsole () {
     log.debug('Stopping to listen for JavaScript console');
-    await this.rpcClient.send('Console.disable', {
-      appIdKey: this.appIdKey,
-      pageIdKey: this.pageIdKey,
-    });
-  }
-
-  async startNetwork (fn) { // eslint-disable-line require-await
-    log.debug('Starting to listen for network events');
-    if (_.isFunction(fn)) {
-      this.rpcClient.networkLogEventHandler = fn;
+    for (const listener of this.consoleListeners) {
+      this.rpcClient.off('Console.messageAdded', listener);
+      this.rpcClient.off('Console.messageRepeatCountUpdated', listener);
     }
   }
 
-  async stopNetwork () {
+  /*
+   * Keep track of the network event listeners, so they can be removed
+   */
+  get networkListeners () {
+    this._networkListeners = this._networkListeners || [];
+    return this._networkListeners;
+  }
+
+  startNetwork (listener) {
+    log.debug('Starting to listen for network events');
+    this.networkListeners.push(listener);
+    this.rpcClient.on('NetworkEvent', listener);
+  }
+
+  stopNetwork () {
     log.debug('Stopping to listen for network events');
-    await this.rpcClient.send('Network.disable', {
-      appIdKey: this.appIdKey,
-      pageIdKey: this.pageIdKey,
-    });
+    for (const listener of this.networkListeners) {
+      this.rpcClient.off('NetworkEvent', listener);
+    }
   }
 
   async execute (command, override) {

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -117,6 +117,7 @@ class RemoteDebugger extends events.EventEmitter {
     this.allowNavigationWithoutReload = false;
 
     this.rpcClient = null;
+    this._clientEventListeners = {};
   }
 
   teardown () {
@@ -660,7 +661,6 @@ class RemoteDebugger extends events.EventEmitter {
    * Keep track of the client event listeners so they can be removed
    */
   addClientEventListener (eventName, listener) {
-    this._clientEventListeners = this._clientEventListeners || {};
     this._clientEventListeners[eventName] = this._clientEventListeners[eventName] || [];
     this._clientEventListeners[eventName].push(listener);
     this.rpcClient.on(eventName, listener);

--- a/lib/rpc-client-real-device.js
+++ b/lib/rpc-client-real-device.js
@@ -26,25 +26,28 @@ export default class RpcClientRealDevice extends RpcClient {
     });
 
     this.service.listenMessage(this.receive.bind(this));
-    this.connected = true;
+    this.isConnected = true;
   }
 
-  async disconnect () { // eslint-disable-line require-await
-    if (this.isConnected()) {
-      log.debug('Disconnecting from remote debugger');
-      this.service.close();
+  async disconnect () {
+    if (!this.isConnected) {
+      return;
     }
-    this.connected = false;
+
+    log.debug('Disconnecting from remote debugger');
+    await super.disconnect();
+    this.service.close();
+    this.isConnected = false;
   }
 
   async sendMessage (cmd) { // eslint-disable-line require-await
     this.service.sendMessage(cmd);
   }
 
-  async receive (data) { // eslint-disable-line require-await
-    if (!this.isConnected()) {
+  async receive (data) {
+    if (!this.isConnected) {
       return;
     }
-    this.messageHandler.handleMessage(data);
+    await this.messageHandler.handleMessage(data);
   }
 }

--- a/lib/rpc-client-simulator.js
+++ b/lib/rpc-client-simulator.js
@@ -40,7 +40,9 @@ export default class RpcClientSimulator extends RpcClient {
         // Forward the actual socketPath to the proxy
         this.socket.once('connect', () => {
           log.debug(`Forwarding the actual web inspector socket to the proxy: '${this.socketPath}'`);
-          this.socket.write(JSON.stringify({socketPath: this.socketPath}));
+          this.socket.write(JSON.stringify({
+            socketPath: this.socketPath
+          }));
         });
 
       } else {
@@ -63,14 +65,14 @@ export default class RpcClientSimulator extends RpcClient {
     this.socket.setNoDelay(true);
     this.socket.setKeepAlive(true);
     this.socket.on('close', () => {
-      if (this.connected) {
+      if (this.isConnected) {
         log.debug('Debugger socket disconnected');
       }
-      this.connected = false;
+      this.isConnected = false;
       this.socket = null;
     });
     this.socket.on('end', () => {
-      this.connected = false;
+      this.isConnected = false;
     });
     this.service = await services.startWebInspectorService(this.udid, {
       socket: this.socket,
@@ -86,14 +88,14 @@ export default class RpcClientSimulator extends RpcClient {
       // only resolve this function when we are actually connected
       this.socket.on('connect', () => {
         log.debug(`Debugger socket connected`);
-        this.connected = true;
+        this.isConnected = true;
 
         resolve();
       });
       this.socket.on('error', (err) => {
-        if (this.connected) {
+        if (this.isConnected) {
           log.error(`Socket error: ${err.message}`);
-          this.connected = false;
+          this.isConnected = false;
         }
 
         // the connection was refused, so reject the connect promise
@@ -102,14 +104,15 @@ export default class RpcClientSimulator extends RpcClient {
     });
   }
 
-  async disconnect () { // eslint-disable-line require-await
-    if (!this.isConnected()) {
+  async disconnect () {
+    if (!this.isConnected) {
       return;
-
     }
+
     log.debug('Disconnecting from remote debugger');
+    await super.disconnect();
     this.service.close();
-    this.connected = false;
+    this.isConnected = false;
   }
 
   async sendMessage (cmd) {
@@ -137,7 +140,7 @@ export default class RpcClientSimulator extends RpcClient {
   }
 
   async receive (data) {
-    if (!this.isConnected()) {
+    if (!this.isConnected) {
       return;
     }
 

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -54,12 +54,14 @@ export default class RpcClient {
     this.bundleId = bundleId;
     this.platformVersion = platformVersion;
 
+    this._contexts = [];
+    this._targets = {};
+
     // start with a best guess for the protocol
     this.setCommunicationProtocol(isTargetBased(isSafari, this.platformVersion));
   }
 
   get contexts () {
-    this._contexts = this._contexts || [];
     return this._contexts;
   }
 
@@ -68,7 +70,6 @@ export default class RpcClient {
   }
 
   get targets () {
-    this._targets = this._targets || {};
     return this._targets;
   }
 

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -32,7 +32,7 @@ export default class RpcClient {
       bundleId,
       platformVersion = {},
       isSafari = true,
-      specialMessageHandlers = {},
+      // specialMessageHandlers = {},
       logAllCommunication = false,
       logAllCommunicationHexDump = false,
       socketChunkSize,
@@ -41,7 +41,7 @@ export default class RpcClient {
 
     this.isSafari = isSafari;
 
-    this.connected = false;
+    this.isConnected = false;
     this.connId = UUID.create().toString();
     this.senderId = UUID.create().toString();
     this.msgId = 0;
@@ -55,17 +55,53 @@ export default class RpcClient {
     this.bundleId = bundleId;
     this.platformVersion = platformVersion;
 
-    // message handlers
-    this.specialMessageHandlers = specialMessageHandlers;
-    // add message handlers for events that are purely rpc related
-    this.specialMessageHandlers.targetCreated = this.addTarget.bind(this);
-    this.specialMessageHandlers.targetDestroyed = this.removeTarget.bind(this),
-    this.specialMessageHandlers.executionContextCreated = this.onExecutionContextAdded.bind(this);
-    this.specialMessageHandlers.garbageCollected = this.onGarbageCollected.bind(this);
-    this.specialMessageHandlers.scriptParsed = this.onScriptParsed.bind(this);
-
     // start with a best guess for the protocol
     this.setCommunicationProtocol(isTargetBased(isSafari, this.platformVersion));
+  }
+
+  get contexts () {
+    this._contexts = this._contexts || [];
+    return this._contexts;
+  }
+
+  get needsTarget () {
+    return this.shouldCheckForTarget && this.isTargetBased;
+  }
+
+  get targets () {
+    this._targets = this._targets || {};
+    return this._targets;
+  }
+
+  get shouldCheckForTarget () {
+    return this._shouldCheckForTarget;
+  }
+
+  set shouldCheckForTarget (shouldCheckForTarget) {
+    this._shouldCheckForTarget = !!shouldCheckForTarget;
+  }
+
+  get isConnected () {
+    return this.connected;
+  }
+
+  set isConnected (connected) {
+    this.connected = !!connected;
+  }
+
+  on (event, listener) {
+    this.messageHandler.on(event, listener);
+    return this;
+  }
+
+  once (event, listener) {
+    this.messageHandler.once(event, listener);
+    return this;
+  }
+
+  off (event, listener) {
+    this.messageHandler.off(event, listener);
+    return this;
   }
 
   setCommunicationProtocol (isTargetBased = false) {
@@ -79,14 +115,17 @@ export default class RpcClient {
     }
 
     if (!this.messageHandler) {
-      this.messageHandler = new RpcMessageHandler(this.specialMessageHandlers, isTargetBased);
+      this.messageHandler = new RpcMessageHandler(isTargetBased);
+
+      // add handlers for internal events
+      this.messageHandler.on('Target.targetCreated', this.addTarget.bind(this));
+      this.messageHandler.on('Target.targetDestroyed', this.removeTarget.bind(this));
+      this.messageHandler.on('Debugger.scriptParsed', this.onScriptParsed.bind(this));
+      this.messageHandler.on('Runtime.executionContextCreated', this.onExecutionContextCreated.bind(this));
+      this.messageHandler.on('Heap.garbageCollected', this.onGarbageCollected.bind(this));
     } else {
       this.messageHandler.setCommunicationProtocol(isTargetBased);
     }
-  }
-
-  get needsTarget () {
-    return this.shouldCheckForTarget && this.isTargetBased;
   }
 
   async waitForTarget (appIdKey, pageIdKey, force = false) {
@@ -151,7 +190,11 @@ export default class RpcClient {
         // for target-base communication, everything is wrapped up
         wrapperMsgId = this.msgId++;
         // acknowledge wrapper message
-        this.setDataMessageHandler(wrapperMsgId.toString(), reject, _.noop);
+        this.messageHandler.on(wrapperMsgId.toString(), function (err) {
+          if (err) {
+            reject(err);
+          }
+        });
       }
 
       const appIdKey = opts.appIdKey;
@@ -181,29 +224,24 @@ export default class RpcClient {
         // the promise will be resolved as soon as the socket has been sent
         messageHandled = false;
         // do not log receipts
-        this.setDataMessageHandler(msgId.toString(), reject, _.noop);
-      } else if (this.messageHandler.hasSpecialMessageHandler(cmd.__selector)) {
-        // special replies will return any number of arguments
-        // temporarily wrap with promise handling
-        const specialMessageHandler = this.getSpecialMessageHandler(cmd.__selector);
-        this.setSpecialMessageHandler(cmd.__selector, reject, (...args) => {
-          log.debug(`Received response from send (id: ${msgId}): '${_.truncate(JSON.stringify(args), DATA_LOG_LENGTH)}'`);
-
-          // call the original listener, and put it back, if necessary
-          specialMessageHandler(...args);
-          if (this.messageHandler.hasSpecialMessageHandler(cmd.__selector)) {
-            // this means that the system has not removed this listener
-            this.setSpecialMessageHandler(cmd.__selector, null, specialMessageHandler);
+        this.messageHandler.once(msgId.toString(), function (err) {
+          if (err) {
+            reject(err);
           }
-
+        });
+      } else if (this.messageHandler.listeners(cmd.__selector).length) {
+        this.messageHandler.prependOnceListener(cmd.__selector, function (err, ...args) {
+          if (err) {
+            return reject(err);
+          }
+          log.debug(`Received response from send (id: ${msgId}): '${_.truncate(JSON.stringify(args), DATA_LOG_LENGTH)}'`);
           resolve(args);
         });
       } else if (cmd.__argument && cmd.__argument.WIRSocketDataKey) {
-        const errorHandler = function (err) {
-          const msg = `Remote debugger error with code '${err.code}': ${err.message}`;
-          reject(new Error(msg));
-        };
-        this.setDataMessageHandler(msgId.toString(), errorHandler, (value) => {
+        this.messageHandler.once(msgId.toString(), function (err, value) {
+          if (err) {
+            return reject(new Error(`Remote debugger error with code '${err.code}': ${err.message}`));
+          }
           log.debug(`Received data response from send (id: ${msgId}): '${_.truncate(JSON.stringify(value), DATA_LOG_LENGTH)}'`);
           resolve(value);
         });
@@ -231,18 +269,30 @@ export default class RpcClient {
     });
   }
 
+  async connect () { // eslint-disable-line require-await
+    throw new Error(`Sub-classes need to implement a 'connect' function`);
+  }
+
+  async disconnect () { // eslint-disable-line require-await
+    this.messageHandler.removeAllListeners();
+  }
+
   async sendMessage (/* command */) { // eslint-disable-line require-await
     throw new Error(`Sub-classes need to implement a 'sendMessage' function`);
   }
 
-  addTarget (app, targetInfo) {
+  async receive (/* data */) { // eslint-disable-line require-await
+    throw new Error(`Sub-classes need to implement a 'receive' function`);
+  }
+
+  addTarget (err, app, targetInfo) {
     if (_.isUndefined(targetInfo) || _.isUndefined(targetInfo.targetId)) {
-      log.warn(`Received 'targetCreated' event with no target. Skipping`);
+      log.warn(`Received 'Target.targetCreated' event with no target. Skipping`);
 
       return;
     }
     if (_.isEmpty(this.pendingTargetNotification)) {
-      log.warn(`Received 'targetCreated' event with no pending request: ${JSON.stringify(targetInfo)}`);
+      log.warn(`Received 'Target.targetCreated' event with no pending request: ${JSON.stringify(targetInfo)}`);
       return;
     }
 
@@ -262,54 +312,17 @@ export default class RpcClient {
     this.targets[appIdKey][pageIdKey] = targetInfo.targetId;
   }
 
-  removeTarget (app, targetInfo) {
+  removeTarget (err, app, targetInfo) {
     if (_.isUndefined(targetInfo) || _.isUndefined(targetInfo.targetId)) {
-      log.debug(`Received 'targetDestroyed' event with no target. Skipping`);
+      log.debug(`Received 'Target.targetDestroyed' event with no target. Skipping`);
       return;
     }
     log.debug(`Target destroyed: ${JSON.stringify(targetInfo)}`);
     _.pull(this.targets, targetInfo.targetId);
   }
 
-  get targets () {
-    this._targets = this._targets || {};
-    return this._targets;
-  }
-
   getTarget (appIdKey, pageIdKey) {
     return (this.targets[appIdKey] || {})[pageIdKey];
-  }
-
-  get shouldCheckForTarget () {
-    return this._shouldCheckForTarget;
-  }
-
-  set shouldCheckForTarget (shouldCheckForTarget) {
-    this._shouldCheckForTarget = !!shouldCheckForTarget;
-  }
-
-  async connect () { // eslint-disable-line require-await
-    throw new Error(`Sub-classes need to implement a 'connect' function`);
-  }
-
-  async disconnect () { // eslint-disable-line require-await
-    throw new Error(`Sub-classes need to implement a 'disconnect' function`);
-  }
-
-  isConnected () {
-    return this.connected;
-  }
-
-  setSpecialMessageHandler (key, errorHandler, handler) {
-    this.messageHandler.setSpecialMessageHandler(key, errorHandler, handler);
-  }
-
-  getSpecialMessageHandler (key) {
-    return this.messageHandler.getSpecialMessageHandler(key);
-  }
-
-  setDataMessageHandler (key, errorHandler, handler) {
-    this.messageHandler.setDataMessageHandler(key, errorHandler, handler);
   }
 
   async selectPage (appIdKey, pageIdKey) {
@@ -324,6 +337,7 @@ export default class RpcClient {
       pageIdKey,
     };
 
+    // highlight and then un-highlight the webview
     for (const enabled of [true, false]) {
       await this.send('indicateWebView', {
         ...sendOpts,
@@ -441,15 +455,18 @@ export default class RpcClient {
     await this.send('Inspector.initialized', sendOpts, false);
   }
 
-  async selectApp (appIdKey, applicationConnectedHandler) {
+  async selectApp (appIdKey) {
     return await new B((resolve, reject) => {
       // local callback, temporarily added as callback to
       // `_rpc_applicationConnected:` remote debugger response
       // to handle the initial connection
-      const onAppChange = (dict) => {
+      const onAppChange = (err, dict) => {
+        if (err) {
+          return reject(err);
+        }
         // from the dictionary returned, get the ids
-        let oldAppIdKey = dict.WIRHostApplicationIdentifierKey;
-        let correctAppIdKey = dict.WIRApplicationIdentifierKey;
+        const oldAppIdKey = dict.WIRHostApplicationIdentifierKey;
+        const correctAppIdKey = dict.WIRApplicationIdentifierKey;
 
         // if this is a report of a proxy redirect from the remote debugger
         // we want to update our dictionary and get a new app id
@@ -458,10 +475,9 @@ export default class RpcClient {
                     `Using id ${correctAppIdKey} instead of ${oldAppIdKey}`);
         }
 
-        applicationConnectedHandler(dict);
         reject(new Error('New application has connected'));
       };
-      this.setSpecialMessageHandler('_rpc_applicationConnected:', reject, onAppChange);
+      this.messageHandler.prependOnceListener('_rpc_applicationConnected:', onAppChange);
 
       // do the actual connecting to the app
       return (async () => {
@@ -485,22 +501,10 @@ export default class RpcClient {
           resolve([connectedAppIdKey, pageDict]);
         }
       })();
-    }).finally(() => {
-      // no matter what, we want to restore the handler that was changed.
-      this.setSpecialMessageHandler('_rpc_applicationConnected:', null, applicationConnectedHandler);
     });
   }
 
-  async receive (/* data */) { // eslint-disable-line require-await
-    throw new Error(`Sub-classes need to implement a 'receive' function`);
-  }
-
-  get contexts () {
-    this._contexts = this._contexts || [];
-    return this._contexts;
-  }
-
-  onExecutionContextAdded (context) {
+  onExecutionContextCreated (err, context) {
     // { id: 2, isPageContext: true, name: '', frameId: '0.1' }
     // right now we have no way to map contexts to apps/pages
     // so just store
@@ -512,20 +516,8 @@ export default class RpcClient {
     log.debug(`Web Inspector garbage collected`);
   }
 
-  onScriptParsed (scriptInfo) {
+  onScriptParsed (err, scriptInfo) {
     // { scriptId: '13', url: '', startLine: 0, startColumn: 0, endLine: 82, endColumn: 3 }
     log.debug(`Script parsed: ${JSON.stringify(scriptInfo)}`);
-  }
-
-  set timelineEventHandler (handler) {
-    this.messageHandler.timelineEventHandler = handler;
-  }
-
-  set consoleLogEventHandler (handler) {
-    this.messageHandler.consoleLogEventHandler = handler;
-  }
-
-  set networkLogEventHandler (handler) {
-    this.messageHandler.networkEventHandler = handler;
   }
 }

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -32,7 +32,6 @@ export default class RpcClient {
       bundleId,
       platformVersion = {},
       isSafari = true,
-      // specialMessageHandlers = {},
       logAllCommunication = false,
       logAllCommunicationHexDump = false,
       socketChunkSize,

--- a/lib/rpc-message-handler.js
+++ b/lib/rpc-message-handler.js
@@ -129,21 +129,19 @@ export default class RpcMessageHandler extends EventEmitters {
         // pass
     }
 
-    if (_.isString(method) && method.startsWith('Network.')) {
+    if (_.startWith(method, 'Network.')) {
       // aggregate Network events, and add original method name to the arguments
       eventNames.push('NetworkEvent');
       args.push(method);
     }
-    if (_.isString(method) && method.startsWith('Console.')) {
+    if (_.startsWith(method, 'Console.')) {
       // aggregate Network events, and add original method name to the arguments
       eventNames.push('ConsoleEvent');
       args.push(method);
     }
 
-    if (eventNames.length) {
-      for (const name of eventNames) {
-        this.emit(name, error, ...args);
-      }
+    for (const name of eventNames) {
+      this.emit(name, error, ...args);
     }
   }
 
@@ -160,13 +158,11 @@ export default class RpcMessageHandler extends EventEmitters {
       // targetInfo: { targetId: 'page-1', type: 'page' }
       const app = plist.__argument.WIRApplicationIdentifierKey;
       const targetInfo = dataKey.params.targetInfo;
-      // await this.specialHandlers.targetCreated(app, targetInfo);
       this.emit('Target.targetCreated', null, app, targetInfo);
       return;
     } else if (method === 'Target.targetDestroyed') {
       const app = plist.__argument.WIRApplicationIdentifierKey;
       const targetInfo = dataKey.params.targetInfo || {targetId: dataKey.params.targetId};
-      // await this.specialHandlers.targetDestroyed(app, targetInfo);
       this.emit('Target.targetDestroyed', null, app, targetInfo);
       return;
     }

--- a/lib/rpc-message-handler.js
+++ b/lib/rpc-message-handler.js
@@ -90,7 +90,7 @@ export default class RpcMessageHandler extends EventEmitters {
     }
 
     if (msgId) {
-      if (this.listeners(msgId).length) {
+      if (this.listenerCount(msgId)) {
         if (result && result.result && result.result.value) {
           result = result.result.value;
         }
@@ -127,6 +127,7 @@ export default class RpcMessageHandler extends EventEmitters {
         break;
       default:
         // pass
+        break;
     }
 
     if (_.startsWith(method, 'Network.')) {

--- a/lib/rpc-message-handler.js
+++ b/lib/rpc-message-handler.js
@@ -1,81 +1,26 @@
 import log from './logger';
 import _ from 'lodash';
 import { util } from 'appium-support';
+import EventEmitters from 'events';
 
 
-// we will receive events that we do not listen to.
-// if we start to listen to one of these, remove it from the list
-const IGNORED_EVENTS = [
-  'ApplicationCache.networkStateUpdated',
-  'Console.messagesCleared',
-  'Debugger.globalObjectCleared',
-  'Debugger.scriptFailedToParse',
-  'DOM.documentUpdated',
-  'LayerTree.layerTreeDidChange',
-  'Page.defaultAppearanceDidChange',
-  'Page.domContentEventFired',
-  'Page.frameStartedLoading',
-  'Page.frameStoppedLoading',
-  'Page.frameScheduledNavigation',
-  'Page.frameClearedScheduledNavigation',
-  'Page.loadEventFired',
-];
-
-export default class RpcMessageHandler {
-  constructor (specialHandlers, isTargetBased = false) {
-    this.setHandlers();
-    this.errorHandlers = {};
-    this.specialHandlers = _.clone(specialHandlers);
-    this.dataHandlers = {};
+export default class RpcMessageHandler extends EventEmitters {
+  constructor (isTargetBased = false) {
+    super();
 
     this.isTargetBased = isTargetBased;
+  }
+
+  get isTargetBased () {
+    return this._isTargetBased;
+  }
+
+  set isTargetBased (isTargetBased) {
+    this._isTargetBased = !!isTargetBased;
   }
 
   setCommunicationProtocol (isTargetBased) {
     this.isTargetBased = isTargetBased;
-  }
-
-  setDataMessageHandler (key, errorHandler, handler) {
-    this.errorHandlers[key] = errorHandler;
-    this.dataHandlers[key] = handler;
-  }
-
-  setSpecialMessageHandler (key, errorHandler, handler) {
-    this.errorHandlers[key] = errorHandler;
-    this.specialHandlers[key] = handler;
-  }
-
-  getSpecialMessageHandler (key) {
-    return this.specialHandlers[key];
-  }
-
-  set timelineEventHandler (handler) {
-    this._timelineEventHandler = handler;
-  }
-  get timelineEventHandler () {
-    return this._timelineEventHandler;
-  }
-
-  set consoleLogEventHandler (handler) {
-    this._consoleLogEventHandler = handler;
-  }
-  get consoleLogEventHandler () {
-    return this._consoleLogEventHandler;
-  }
-
-  set networkEventHandler (handler) {
-    this._networkEventHandler = handler;
-  }
-  get networkEventHandler () {
-    return this._networkEventHandler;
-  }
-
-  hasErrorHandler (key) {
-    return _.has(this.errorHandlers, key);
-  }
-
-  hasSpecialMessageHandler (key) {
-    return _.has(this.specialHandlers, key);
   }
 
   async handleMessage (plist) {
@@ -85,32 +30,48 @@ export default class RpcMessageHandler {
       return;
     }
 
-    if (_.has(this.handlers, selector)) {
-      await this.handlers[selector](plist);
-    } else {
-      log.debug(`Debugger got a message for '${selector}' and have no ` +
-                `handler, doing nothing.`);
-    }
-  }
+    const argument = plist.__argument;
 
-  async handleSpecialMessage (handler, ...args) {
-    const fn = this.specialHandlers[handler];
-
-    if (fn) {
-      // most responses are only to be called once, then
-      // removed. But not the ones below, which handle
-      // page change and app connect/disconnect
-      if (handler !== '_rpc_forwardGetListing:' &&
-          handler !== '_rpc_applicationDisconnected:' &&
-          handler !== '_rpc_applicationConnected:' &&
-          handler !== '_rpc_applicationUpdated:' &&
-          handler !== '_rpc_reportConnectedDriverList:') {
-        this.specialHandlers[handler] = null;
-      }
-      await fn(...args);
-    } else {
-      log.warn(`Tried to access special message handler '${handler}' ` +
-               `but none was found`);
+    switch (selector) {
+      case '_rpc_reportSetup:':
+        this.emit('_rpc_reportSetup:',
+          null,
+          argument.WIRSimulatorNameKey,
+          argument.WIRSimulatorBuildKey,
+          argument.WIRSimulatorProductVersionKey
+        );
+        break;
+      case '_rpc_reportConnectedApplicationList:':
+        this.emit('_rpc_reportConnectedApplicationList:',
+          null,
+          argument.WIRApplicationDictionaryKey
+        );
+        break;
+      case '_rpc_applicationSentListing:':
+        this.emit('_rpc_forwardGetListing:',
+          null,
+          argument.WIRApplicationIdentifierKey,
+          argument.WIRListingKey
+        );
+        break;
+      case '_rpc_applicationConnected:':
+        this.emit('_rpc_applicationConnected:', null, argument);
+        break;
+      case '_rpc_applicationDisconnected:':
+        this.emit('_rpc_applicationDisconnected:', null, argument);
+        break;
+      case '_rpc_applicationUpdated:':
+        this.emit('_rpc_applicationUpdated:', null, argument);
+        break;
+      case '_rpc_reportConnectedDriverList:':
+        this.emit('_rpc_reportConnectedDriverList:', null, argument);
+        break;
+      case '_rpc_applicationSentData:':
+        await this.handleDataMessage(plist);
+        break;
+      default:
+        log.debug(`Debugger got a message for '${selector}' and have no ` +
+          `handler, doing nothing.`);
     }
   }
 
@@ -123,55 +84,65 @@ export default class RpcMessageHandler {
     }
   }
 
-  async dispatchDataMessage (msgId, method, params, result, error) {
+  async dispatchDataMessage (msgId, method, params, result, error) { // eslint-disable-line require-await
     if (!_.isEmpty(msgId)) {
       log.debug(`Handling message (id: '${msgId}')`);
     }
 
-    if (method === 'Profiler.resetProfiles') {
-      log.debug('Device is telling us to reset profiles. Should probably ' +
-                'do some kind of callback here');
-    } else if (method === 'Page.frameNavigated' || method === 'Page.frameStoppedLoading') {
-      if (_.isFunction(this.specialHandlers['Page.frameNavigated'])) {
-        await this.specialHandlers['Page.frameNavigated'](`'${method}' event`);
-        this.specialHandlers['Page.frameNavigated'] = null;
-      }
-    } else if (IGNORED_EVENTS.includes(method)) {
-      // pass
-    } else if (method === 'Page.frameDetached' && _.isFunction(this.specialHandlers.frameDetached)) {
-      await this.specialHandlers.frameDetached();
-    } else if (method === 'Timeline.eventRecorded' && _.isFunction(this.timelineEventHandler)) {
-      this.timelineEventHandler(params || params.record);
-    } else if (method === 'Console.messageAdded' && _.isFunction(this.consoleLogEventHandler)) {
-      this.consoleLogEventHandler(params.message);
-    } else if (method === 'Console.messageRepeatCountUpdated' && _.isFunction(this.consoleLogEventHandler)) {
-      this.consoleLogEventHandler(params);
-    } else if (_.isString(method) && method.startsWith('Network.') && _.isFunction(this.networkEventHandler)) {
-      this.networkEventHandler(method, params);
-    } else if (method === 'Runtime.executionContextCreated' && _.isFunction(this.specialHandlers.executionContextCreated)) {
-      await this.specialHandlers.executionContextCreated(params.context);
-    } else if (method === 'Heap.garbageCollected' && _.isFunction(this.specialHandlers.garbageCollected)) {
-      await this.specialHandlers.garbageCollected();
-    } else if (method === 'Debugger.scriptParsed' && _.isFunction(this.specialHandlers.scriptParsed)) {
-      await this.specialHandlers.scriptParsed(params);
-    } else if (_.isFunction(this.dataHandlers[msgId])) {
-      // we will either get back a result object that has a result.value
-      // in which case that is what we want,
-      // or else we return the whole thing
-      if (result.result && result.result.value) {
-        result = result.result.value;
-      }
-      this.dataHandlers[msgId](result);
-      this.dataHandlers[msgId] = null;
-    } else if (this.dataHandlers[msgId] === null) {
-      log.error(`Web Inspector returned data for message '${msgId}' ` +
-                `but we already ran that callback! WTF??`);
-    } else {
-      if (msgId || result || error) {
+    if (msgId) {
+      if (this.listeners(msgId).length) {
+        if (result && result.result && result.result.value) {
+          result = result.result.value;
+        }
+        this.emit(msgId, error, result);
+      } else {
         log.error(`Web Inspector returned data for message '${msgId}' ` +
-                  `but we were not waiting for that message! ` +
-                  `result: '${JSON.stringify(result)}'; ` +
-                  `error: '${error}'`);
+          `but we were not waiting for that message! ` +
+          `result: '${JSON.stringify(result)}'; ` +
+          `error: '${error}'`);
+      }
+      return;
+    }
+
+    let eventNames = [method];
+    let args = [params];
+
+    // some events have different names, or the arguments are mapped from the
+    // parameters received
+    switch (method) {
+      case 'Page.frameStoppedLoading':
+        eventNames.push('Page.frameNavigated');
+        // eslint-disable-line no-fallthrough
+      case 'Page.frameNavigated':
+        args = [`'${method}' event`];
+        break;
+      case 'Timeline.eventRecorded':
+        args = [params || params.record];
+        break;
+      case 'Console.messageAdded':
+        args = [params.message];
+        break;
+      case 'Runtime.executionContextCreated':
+        args = [params.context];
+        break;
+      default:
+        // pass
+    }
+
+    if (_.isString(method) && method.startsWith('Network.')) {
+      // aggregate Network events, and add original method name to the arguments
+      eventNames.push('NetworkEvent');
+      args.push(method);
+    }
+    if (_.isString(method) && method.startsWith('Console.')) {
+      // aggregate Network events, and add original method name to the arguments
+      eventNames.push('ConsoleEvent');
+      args.push(method);
+    }
+
+    if (eventNames.length) {
+      for (const name of eventNames) {
+        this.emit(name, error, ...args);
       }
     }
   }
@@ -189,12 +160,14 @@ export default class RpcMessageHandler {
       // targetInfo: { targetId: 'page-1', type: 'page' }
       const app = plist.__argument.WIRApplicationIdentifierKey;
       const targetInfo = dataKey.params.targetInfo;
-      await this.specialHandlers.targetCreated(app, targetInfo);
+      // await this.specialHandlers.targetCreated(app, targetInfo);
+      this.emit('Target.targetCreated', null, app, targetInfo);
       return;
     } else if (method === 'Target.targetDestroyed') {
       const app = plist.__argument.WIRApplicationIdentifierKey;
       const targetInfo = dataKey.params.targetInfo || {targetId: dataKey.params.targetId};
-      await this.specialHandlers.targetDestroyed(app, targetInfo);
+      // await this.specialHandlers.targetDestroyed(app, targetInfo);
+      this.emit('Target.targetDestroyed', null, app, targetInfo);
       return;
     }
 
@@ -233,55 +206,6 @@ export default class RpcMessageHandler {
       error = new Error(message);
     }
 
-    if (!error) {
-      return await this.dispatchDataMessage(msgId, method, params, result, error);
-    }
-
-    // handle the error
-    if (this.hasErrorHandler(msgId)) {
-      this.errorHandlers[msgId](error);
-    } else {
-      log.error(`Error occurred in handling data message: ${error}`);
-      log.error('No error handler present, ignoring');
-    }
-  }
-
-  setHandlers () {
-    this.handlers = {
-      '_rpc_reportSetup:': async (plist) => {
-        await this.handleSpecialMessage('_rpc_reportIdentifier:',
-          plist.__argument.WIRSimulatorNameKey,
-          plist.__argument.WIRSimulatorBuildKey,
-          plist.__argument.WIRSimulatorProductVersionKey);
-      },
-      '_rpc_reportConnectedApplicationList:': async (plist) => {
-        await this.handleSpecialMessage('_rpc_reportConnectedApplicationList:',
-          plist.__argument.WIRApplicationDictionaryKey);
-      },
-      '_rpc_applicationSentListing:': async (plist) => {
-        await this.handleSpecialMessage('_rpc_forwardGetListing:',
-          plist.__argument.WIRApplicationIdentifierKey,
-          plist.__argument.WIRListingKey);
-      },
-      '_rpc_applicationConnected:': async (plist) => {
-        await this.handleSpecialMessage('_rpc_applicationConnected:',
-          plist.__argument);
-      },
-      '_rpc_applicationDisconnected:': async (plist) => {
-        await this.handleSpecialMessage('_rpc_applicationDisconnected:',
-          plist.__argument);
-      },
-      '_rpc_applicationUpdated:': async (plist) => {
-        await this.handleSpecialMessage('_rpc_applicationUpdated:',
-          plist.__argument);
-      },
-      '_rpc_reportConnectedDriverList:': async (plist) => {
-        await this.handleSpecialMessage('_rpc_reportConnectedDriverList:',
-          plist.__argument);
-      },
-      '_rpc_applicationSentData:': async (plist) => {
-        await this.handleDataMessage(plist);
-      },
-    };
+    await this.dispatchDataMessage(msgId, method, params, result, error);
   }
 }

--- a/lib/rpc-message-handler.js
+++ b/lib/rpc-message-handler.js
@@ -129,7 +129,7 @@ export default class RpcMessageHandler extends EventEmitters {
         // pass
     }
 
-    if (_.startWith(method, 'Network.')) {
+    if (_.startsWith(method, 'Network.')) {
       // aggregate Network events, and add original method name to the arguments
       eventNames.push('NetworkEvent');
       args.push(method);

--- a/test/functional/safari-e2e-specs.js
+++ b/test/functional/safari-e2e-specs.js
@@ -187,7 +187,7 @@ describe('Safari remote debugger', function () {
     await rd.selectPage(appIdKey, pageIdKey);
 
     let lines = [];
-    rd.startConsole(function (line) {
+    rd.startConsole(function (err, line) {
       lines.push(line);
     });
 


### PR DESCRIPTION
Node has a great library for [event handling](https://nodejs.org/api/events.html#events_class_eventemitter). This package has been passing callbacks around to handle all the asynchronous messaging of the Web Inspector, which has outlived its usefulness.

So replace everything with `EventEmitter`. This is a **breaking change** due to the change in external events (adding an error parameter).

After this approach is vetted and in the module, it can be extended so that users of `appium-remote-debugger` can listen for whatever event form the Web Inspector they want to implement services.