### PR TITLE
fix: get real devices working correctly

### DIFF
--- a/lib/remote-debugger-real-device.js
+++ b/lib/remote-debugger-real-device.js
@@ -1,5 +1,4 @@
-import log from './logger';
-import { RemoteDebugger } from './remote-debugger';
+import RemoteDebugger from './remote-debugger';
 import RpcClientRealDevice from './rpc-client-real-device';
 
 
@@ -12,10 +11,7 @@ export default class RemoteDebuggerRealDevice extends RemoteDebugger {
     this.skippedApps = ['lockdownd'];
   }
 
-  async connect () {
-    this.setup();
-
-    // initialize the rpc client
+  initRpcClient () {
     this.rpcClient = new RpcClientRealDevice({
       bundleId: this.bundleId,
       platformVersion: this.platformVersion,
@@ -29,16 +25,5 @@ export default class RemoteDebuggerRealDevice extends RemoteDebugger {
       socketChunkSize: this.socketChunkSize,
       udid: this.udid
     });
-    await this.rpcClient.connect();
-
-    // get the connection information about the app
-    try {
-      const appInfo = await this.setConnectionKey();
-      log.debug('Connected to application');
-      return appInfo;
-    } catch (err) {
-      await this.disconnect();
-      return null;
-    }
   }
 }

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -134,10 +134,7 @@ class RemoteDebugger extends events.EventEmitter {
     this.removeAllListeners(RemoteDebugger.EVENT_DISCONNECT);
   }
 
-  async connect () {
-    this.setup();
-
-    // initialize the rpc client
+  initRpcClient () {
     this.rpcClient = new RpcClientSimulator({
       bundleId: this.bundleId,
       platformVersion: this.platformVersion,
@@ -150,6 +147,13 @@ class RemoteDebugger extends events.EventEmitter {
       logAllCommunicationHexDump: this.logAllCommunicationHexDump,
       fullPageInitialization: this.fullPageInitialization,
     });
+  }
+
+  async connect () {
+    this.setup();
+
+    // initialize the rpc client
+    this.initRpcClient();
 
     // listen for basic debugger-level events
     this.rpcClient.on('_rpc_reportSetup:', _.noop);
@@ -808,6 +812,7 @@ for (const [name, handler] of _.toPairs(messageHandlers)) {
   RemoteDebugger.prototype[name] = handler;
 }
 
+export default RemoteDebugger;
 export {
   RemoteDebugger, REMOTE_DEBUGGER_PORT, RPC_RESPONSE_TIMEOUT_MS,
 };

--- a/lib/rpc-message-handler.js
+++ b/lib/rpc-message-handler.js
@@ -31,7 +31,6 @@ export default class RpcMessageHandler extends EventEmitters {
     }
 
     const argument = plist.__argument;
-
     switch (selector) {
       case '_rpc_reportSetup:':
         this.emit('_rpc_reportSetup:',

--- a/test/functional/safari-e2e-specs.js
+++ b/test/functional/safari-e2e-specs.js
@@ -187,7 +187,7 @@ describe('Safari remote debugger', function () {
     await rd.selectPage(appIdKey, pageIdKey);
 
     let lines = [];
-    rd.startConsole(function (err, line) {
+    rd.startConsole(function (err, line) { // eslint-disable-line promise/prefer-await-to-callbacks
       lines.push(line);
     });
 


### PR DESCRIPTION
On real devices the internal listeners were not being initialized, so nothing was getting through. I've tested this thoroughly through `appium-xcuitest-driver` on both MobileSafari and hybrid apps and it works with this change.