### PR TITLE
feat: add timeout to connect, defaulting to 0

### DIFF
--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -8,7 +8,7 @@ import { appInfoFromDict, pageArrayFromDict, getDebuggerAppKey,
          simpleStringify, deferredPromise, convertResult,
          RESPONSE_LOG_LENGTH } from './helpers';
 import { util, timing } from 'appium-support';
-import { retryInterval } from 'asyncbox';
+import { retryInterval, waitForCondition } from 'asyncbox';
 import _ from 'lodash';
 import B from 'bluebird';
 import path from 'path';
@@ -21,6 +21,8 @@ try {
   VERSION = require(path.resolve(__dirname, '..', '..', 'package.json')).version;
 } catch (ign) {}
 
+const APP_CONNECT_TIMEOUT_MS = 0;
+const APP_CONNECT_INTERVAL_MS = 100;
 const SELECT_APP_RETRIES = 20;
 const SELECT_APP_RETRY_SLEEP_MS = 500;
 const REMOTE_DEBUGGER_PORT = 27753;
@@ -149,7 +151,7 @@ class RemoteDebugger extends events.EventEmitter {
     });
   }
 
-  async connect () {
+  async connect (timeout = APP_CONNECT_TIMEOUT_MS) {
     this.setup();
 
     // initialize the rpc client
@@ -171,6 +173,19 @@ class RemoteDebugger extends events.EventEmitter {
     // get the connection information about the app
     try {
       await this.setConnectionKey();
+      if (timeout) {
+        log.debug(`Waiting up to ${timeout}ms for applications to be reported`);
+        try {
+          await waitForCondition(() => {
+            return !_.isEmpty(this.appDict);
+          }, {
+            waitMs: timeout,
+            interval: APP_CONNECT_INTERVAL_MS,
+          });
+        } catch (err) {
+          log.debug(`Timed out waiting for applications to be reported`);
+        }
+      }
       return this.appDict || {};
     } catch (err) {
       log.error(`Error setting connection key: ${err.message}`);


### PR DESCRIPTION
Add a timeout to the `connect` function, which makes it wait for there to be apps reported. One there is at least one app it returns, or returns the empty app list as it used to.

Default to`0` so the behaviour is not changed. This will be configurable through the driver at the clients' discretion.