### PR TITLE
feat: add WIRTypeWebPage as an accepted web page type

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -11,9 +11,10 @@ const SAFARI_WEB_VIEW_BUNDLE_ID = 'process-SafariViewService';
 const SAFARI_WEB_VIEW_FULL_BUNDLE_ID = 'com.apple.SafariViewService';
 const WILDCARD_BUNDLE_ID = '*';
 
+// values for the page `WIRTypeKey` entry
 const ACCEPTED_PAGE_TYPES = [
-  'WIRTypeWeb',
-  'WIRTypeWebPage',
+  'WIRTypeWeb', // up to iOS 11.3
+  'WIRTypeWebPage', // iOS 11.4
 ];
 
 const RESPONSE_LOG_LENGTH = 100;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -11,6 +11,11 @@ const SAFARI_WEB_VIEW_BUNDLE_ID = 'process-SafariViewService';
 const SAFARI_WEB_VIEW_FULL_BUNDLE_ID = 'com.apple.SafariViewService';
 const WILDCARD_BUNDLE_ID = '*';
 
+const ACCEPTED_PAGE_TYPES = [
+  'WIRTypeWeb',
+  'WIRTypeWebPage',
+];
+
 const RESPONSE_LOG_LENGTH = 100;
 
 /*
@@ -60,7 +65,7 @@ function pageArrayFromDict (pageDict) {
   let newPageArray = [];
   for (const dict of _.values(pageDict)) {
     // count only WIRTypeWeb pages and ignore all others (WIRTypeJavaScript etc)
-    if (_.isUndefined(dict.WIRTypeKey) || dict.WIRTypeKey === 'WIRTypeWeb') {
+    if (_.isUndefined(dict.WIRTypeKey) || ACCEPTED_PAGE_TYPES.includes(dict.WIRTypeKey)) {
       newPageArray.push({
         id: dict.WIRPageIdentifierKey,
         title: dict.WIRTitleKey,

--- a/test/unit/helpers-specs.js
+++ b/test/unit/helpers-specs.js
@@ -71,6 +71,15 @@ describe('helpers', function () {
       let pageArray = pageArrayFromDict(basePageDict);
       pageArray.should.have.length(1);
     });
+    it('should return a valid page array with 13.4-style type key', function () {
+      const pageDict = _.defaults({
+        2: {
+          WIRTypeKey: 'WIRTypeWebPage'
+        }
+      }, basePageDict);
+      const pageArray = pageArrayFromDict(pageDict);
+      pageArray.should.have.length(2);
+    });
     it('should not count WIRTypeWeb entries', function () {
       let pageDict = _.defaults({
         2: {


### PR DESCRIPTION
iOS 13.4 uses `WIRTypeWebPage` as the web page type, so that must be accepted.

See https://github.com/appium/appium/issues/13948