### PR TITLE
feat: handle new provisional target creation

### DIFF
--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -119,6 +119,7 @@ export default class RpcClient {
 
       // add handlers for internal events
       this.messageHandler.on('Target.targetCreated', this.addTarget.bind(this));
+      this.messageHandler.on('Target.didCommitProvisionalTarget', this.updateTarget.bind(this));
       this.messageHandler.on('Target.targetDestroyed', this.removeTarget.bind(this));
       this.messageHandler.on('Debugger.scriptParsed', this.onScriptParsed.bind(this));
       this.messageHandler.on('Runtime.executionContextCreated', this.onExecutionContextCreated.bind(this));
@@ -312,12 +313,44 @@ export default class RpcClient {
     this.targets[appIdKey][pageIdKey] = targetInfo.targetId;
   }
 
+  updateTarget (err, app, oldTargetId, newTargetId) {
+    log.debug(`Target updated for app '${app}'. Old target: '${oldTargetId}', new target: '${newTargetId}'`);
+    if (!this.targets[app]) {
+      log.warn(`No existing target for app '${app}'. Not sure what to do`);
+      return;
+    }
+    // save this, to be used if/when the existing target is destroyed
+    this.targets[app].provisional = {
+      oldTargetId,
+      newTargetId,
+    };
+  }
+
   removeTarget (err, app, targetInfo) {
     if (_.isUndefined(targetInfo) || _.isUndefined(targetInfo.targetId)) {
       log.debug(`Received 'Target.targetDestroyed' event with no target. Skipping`);
       return;
     }
-    log.debug(`Target destroyed: ${JSON.stringify(targetInfo)}`);
+
+    log.debug(`Target destroyed for app '${app}': ${targetInfo.targetId}`);
+    if (this.targets[app]?.provisional && this.targets[app].provisional.oldTargetId === targetInfo.targetId) {
+      const {oldTargetId, newTargetId} = this.targets[app].provisional;
+      delete this.targets[app].provisional;
+
+      // we do not know the page, so go through and find the existing target
+      const targets = this.targets[app];
+      for (const [page, targetId] of _.toPairs(targets)) {
+        if (targetId === oldTargetId) {
+          log.debug(`Found provisional target for app '${app}'. Old target: '${oldTargetId}', new target: '${newTargetId}'. Updating`);
+          targets[page] = newTargetId;
+          return;
+        }
+      }
+      log.warn(`Provisional target for app '${app}' found, but no suitable existing target found. This may cause problems`);
+      log.warn(`Old target: '${oldTargetId}', new target: '${newTargetId}'. Existing targets: ${JSON.stringify(targets)}`);
+    }
+
+    // if there is no waiting provisional target, just get rid of the existing one
     _.pull(this.targets, targetInfo.targetId);
   }
 

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -327,13 +327,13 @@ export default class RpcClient {
   }
 
   removeTarget (err, app, targetInfo) {
-    if (_.isUndefined(targetInfo) || _.isUndefined(targetInfo.targetId)) {
+    if (_.isNil(targetInfo?.targetId)) {
       log.debug(`Received 'Target.targetDestroyed' event with no target. Skipping`);
       return;
     }
 
     log.debug(`Target destroyed for app '${app}': ${targetInfo.targetId}`);
-    if (this.targets[app]?.provisional && this.targets[app].provisional.oldTargetId === targetInfo.targetId) {
+    if (this.targets[app]?.provisional?.oldTargetId === targetInfo.targetId) {
       const {oldTargetId, newTargetId} = this.targets[app].provisional;
       delete this.targets[app].provisional;
 

--- a/lib/rpc-message-handler.js
+++ b/lib/rpc-message-handler.js
@@ -160,6 +160,12 @@ export default class RpcMessageHandler extends EventEmitters {
       const targetInfo = dataKey.params.targetInfo;
       this.emit('Target.targetCreated', null, app, targetInfo);
       return;
+    } else if (method === 'Target.didCommitProvisionalTarget') {
+      const app = plist.__argument.WIRApplicationIdentifierKey;
+      const oldTargetId = dataKey.params.oldTargetId;
+      const newTargetId = dataKey.params.newTargetId;
+      this.emit('Target.didCommitProvisionalTarget', null, app, oldTargetId, newTargetId);
+      return;
     } else if (method === 'Target.targetDestroyed') {
       const app = plist.__argument.WIRApplicationIdentifierKey;
       const targetInfo = dataKey.params.targetInfo || {targetId: dataKey.params.targetId};


### PR DESCRIPTION
On iOS 13.4 there started to be target replacement during the normal flow of events. 

To handle, catch the `Target.didCommitProvisionalTarget` event and keep track, so when the correct target is destroyed, the new target can be used as a replacement.

As with all target handling, there is no page associated with it, so tracking is made more difficult.