### PR TITLE
fix: ignore add target event if provisional

### DIFF
--- a/lib/message-handlers.js
+++ b/lib/message-handlers.js
@@ -69,7 +69,7 @@ async function onAppConnect (err, dict) {
 function onAppDisconnect (err, dict) {
   let appIdKey = dict.WIRApplicationIdentifierKey;
   log.debug(`Application '${appIdKey}' disconnected. Removing from app dictionary.`);
-  log.debug(`Current app is ${this.appIdKey}`);
+  log.debug(`Current app is '${this.appIdKey}'`);
 
   // get rid of the entry in our app dictionary,
   // since it is no longer available

--- a/lib/rpc-client.js
+++ b/lib/rpc-client.js
@@ -287,29 +287,27 @@ export default class RpcClient {
   }
 
   addTarget (err, app, targetInfo) {
-    if (_.isUndefined(targetInfo) || _.isUndefined(targetInfo.targetId)) {
-      log.warn(`Received 'Target.targetCreated' event with no target. Skipping`);
-
+    if (_.isNil(targetInfo?.targetId)) {
+      log.warn(`Received 'Target.targetCreated' event for app '${app}' with no target. Skipping`);
       return;
     }
-    if (_.isEmpty(this.pendingTargetNotification)) {
-      log.warn(`Received 'Target.targetCreated' event with no pending request: ${JSON.stringify(targetInfo)}`);
+    if (_.isEmpty(this.pendingTargetNotification) && !targetInfo.isProvisional) {
+      log.warn(`Received 'Target.targetCreated' event for app '${app}' with no pending request: ${JSON.stringify(targetInfo)}`);
+      return;
+    }
+
+    if (targetInfo.isProvisional) {
+      log.debug(`Provisional target created for app '${app}', '${targetInfo.targetId}'. Ignoring until target update event`);
       return;
     }
 
     const [appIdKey, pageIdKey] = this.pendingTargetNotification;
-    if (_.has(targetInfo, 'type')) {
-      // real target notifications (from Web Inspector, not from Appium)
-      // have a 'type'. If we have already set the target, and get a new
-      // notification, we want to follow it
-      this.pendingTargetNotification = null;
-    }
 
     log.debug(`Target created for app '${appIdKey}' and page '${pageIdKey}': ${JSON.stringify(targetInfo)}`);
     if (_.has(this.targets[appIdKey], pageIdKey)) {
       log.debug(`There is already a target for this app and page ('${this.targets[appIdKey][pageIdKey]}'). This might cause problems`);
     }
-    this.targets[appIdKey] = this.targets[appIdKey] || {};
+    this.targets[app] = this.targets[app] || {};
     this.targets[appIdKey][pageIdKey] = targetInfo.targetId;
   }
 
@@ -333,6 +331,8 @@ export default class RpcClient {
     }
 
     log.debug(`Target destroyed for app '${app}': ${targetInfo.targetId}`);
+
+    // go through the targets and find the one that has a waiting provisional target
     if (this.targets[app]?.provisional?.oldTargetId === targetInfo.targetId) {
       const {oldTargetId, newTargetId} = this.targets[app].provisional;
       delete this.targets[app].provisional;
@@ -351,7 +351,14 @@ export default class RpcClient {
     }
 
     // if there is no waiting provisional target, just get rid of the existing one
-    _.pull(this.targets, targetInfo.targetId);
+    const targets = this.targets[app];
+    for (const [page, targetId] of _.toPairs(targets)) {
+      if (targetId === targetInfo.targetId) {
+        delete targets[page];
+        return;
+      }
+    }
+    log.debug(`Target '${targetInfo.targetId}' deleted for app '${app}', but no such target exists`);
   }
 
   getTarget (appIdKey, pageIdKey) {


### PR DESCRIPTION
A little more tweaking of the target lifecycle. Handle provisional target addition, which could be tracked but as of now there is no need, since a target update event always gets fired before the old target is destroyed, and it contains all the information needed for its use.

Also better handle deleting targets, so we don't delete the wrong one.