### PR TITLE
build: move to iOS 13.3 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ jobs:
         - TEST=e2e-test
 
     - stage:
-      osx_image: xcode11
+      osx_image: xcode11.3
       env:
-        - PLATFORM_VERSION=13.0
+        - PLATFORM_VERSION=13.3
         - DEVICE_NAME="iPhone X"
         - TEST=e2e-test
 


### PR DESCRIPTION
Once Travis supports Xcode 11.4 we will add that, since there were changes between it and 11.3.