### PR TITLE
refactor: clean up parameter error handling

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -161,12 +161,10 @@ function getPossibleDebuggerAppKeys (bundleIds, appDict) {
 }
 
 function checkParams (params) {
-  let errors = [];
-  for (const [param, value] of _.toPairs(params)) {
-    if (_.isNil(value)) {
-      errors.push(param);
-    }
-  }
+  // check if all parameters have a value
+  const errors = _.toPairs(params)
+    .filter(([, value]) => _.isNil(value))
+    .map(([param]) => param);
   if (errors.length) {
     throw new Error(`Missing ${util.pluralize('parameter', errors.length)}: ${errors.join(', ')}`);
   }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,9 +1,9 @@
 import log from './logger';
 import getAtom from './atoms';
 import _ from 'lodash';
-import assert from 'assert';
 import B from 'bluebird';
 import { errorFromMJSONWPStatusCode } from 'appium-base-driver';
+import { util } from 'appium-support';
 
 
 const WEB_CONTENT_BUNDLE_ID = 'com.apple.WebKit.WebContent';
@@ -163,14 +163,12 @@ function getPossibleDebuggerAppKeys (bundleIds, appDict) {
 function checkParams (params) {
   let errors = [];
   for (const [param, value] of _.toPairs(params)) {
-    try {
-      assert.ok(value);
-    } catch (err) {
+    if (_.isNil(value)) {
       errors.push(param);
     }
   }
   if (errors.length) {
-    return errors;
+    throw new Error(`Missing ${util.pluralize('parameter', errors.length)}: ${errors.join(', ')}`);
   }
 }
 

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -554,8 +554,7 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   async checkPageIsReady () {
-    const errors = checkParams({appIdKey: this.appIdKey});
-    if (errors) throw new Error(errors); // eslint-disable-line curly
+    checkParams({appIdKey: this.appIdKey});
 
     log.debug('Checking document readyState');
     const readyCmd = 'document.readyState;';
@@ -581,10 +580,7 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   async navToUrl (url, pageLoadVerifyHook) {
-    const errors = checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
-    if (errors) {
-      throw new Error(errors);
-    }
+    checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
 
     this._navigatingToPage = true;
 
@@ -728,10 +724,7 @@ class RemoteDebugger extends events.EventEmitter {
       await this.waitForDom();
     }
 
-    const errors = checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
-    if (errors) {
-      throw new Error(errors);
-    }
+    checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
 
     if (this.garbageCollectOnExecute) {
       await this.garbageCollect();
@@ -748,8 +741,7 @@ class RemoteDebugger extends events.EventEmitter {
   }
 
   async callFunction (objId, fn, args) {
-    let errors = checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
-    if (errors) throw new Error(errors); // eslint-disable-line curly
+    checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
 
     if (this.garbageCollectOnExecute) {
       await this.garbageCollect();
@@ -796,11 +788,9 @@ class RemoteDebugger extends events.EventEmitter {
 
   async garbageCollect (timeoutMs = GARBAGE_COLLECT_TIMEOUT) {
     log.debug(`Garbage collecting with ${timeoutMs}ms timeout`);
-    const errors = checkParams({
-      appIdKey: this.appIdKey,
-      pageIdKey: this.pageIdKey,
-    });
-    if (errors) {
+    try {
+      checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
+    } catch (err) {
       log.debug(`Unable to collect garbage at this time`);
       return;
     }

--- a/test/unit/helpers-specs.js
+++ b/test/unit/helpers-specs.js
@@ -91,13 +91,11 @@ describe('helpers', function () {
     });
   });
   describe('checkParams', function () {
-    it('should not return error when not missing parameters', function () {
-      expect(checkParams({one: 'first', two: 'second', three: 'third'})).to.not.exist;
+    it('should not throw error when not missing parameters', function () {
+      checkParams({one: 'first', two: 'second', three: 'third'});
     });
-    it('should return error when parameter is missing', function () {
-      let errors = checkParams({one: 'first', two: null, three: 'third'});
-      errors.should.have.length(1);
-      errors[0].should.equal('two');
+    it('should throw error when parameter is missing', function () {
+      expect(() => checkParams({one: 'first', two: null, three: 'third'})).to.throw('Missing parameter: two');
     });
   });
 });


### PR DESCRIPTION
Easier to just throw.

Plus, a simple benchmark shows that `try`/`catch` for control flow is very inefficient
```
[12:51:44] assert/catch x 36,599 ops/sec ±8.25% (60 runs sampled)
[12:51:51] if/then x 164,072,843 ops/sec ±1.51% (82 runs sampled)
[12:51:51] Fastest is if/then
```