### PR TITLE
fix: do not send Target.exists on iOS 13.4

### DIFF
--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -14,6 +14,9 @@ const WAIT_FOR_TARGET_INTERVAL = 1000;
 
 const MIN_PLATFORM_FOR_TARGET_BASED = '12.2';
 
+// `Target.exists` protocol method was removed from WebKitin 13.4
+const MIN_PLATFORM_NO_TARGET_EXISTS = '13.4';
+
 function isTargetBased (isSafari, platformVersion) {
   // on iOS 12.2 the messages get sent through the Target domain
   const isHighVersion = util.compareVersions(platformVersion, '>=', MIN_PLATFORM_FOR_TARGET_BASED);
@@ -229,6 +232,12 @@ export default class RpcClient {
         // do not log receipts
         this.messageHandler.once(msgId.toString(), function (err) {
           if (err) {
+            // we are not waiting for this, and if it errors it is most likely
+            // a protocol change. Log and check during testing
+            log.error(`Received error from send that is not being waited for (id: ${msgId}): '${_.truncate(JSON.stringify(err), DATA_LOG_LENGTH)}'`);
+            // reject, though it is very rare that this will be triggered, since
+            // the promise is resolved directlty after send. On the off chance,
+            // though, it will alert of a protocol change.
             reject(err);
           }
         });
@@ -389,7 +398,7 @@ export default class RpcClient {
     await this.send('setSenderKey', sendOpts);
     log.debug('Sender key set');
 
-    if (this.isTargetBased) {
+    if (this.isTargetBased && util.compareVersions(this.platformVersion, '<', MIN_PLATFORM_NO_TARGET_EXISTS)) {
       await this.send('Target.exists', sendOpts, false);
     }
 


### PR DESCRIPTION
`Target.exists` was removed from WebKit ([rev](https://trac.webkit.org/browser/webkit/trunk/Source/JavaScriptCore/inspector/protocol/Target.json?rev=251227), [diff](https://trac.webkit.org/changeset?reponame=webkit&new=251227%40trunk%2FSource%2FJavaScriptCore%2Finspector%2Fprotocol%2FTarget.json&old=238192%40trunk%2FSource%2FJavaScriptCore%2Finspector%2Fprotocol%2FTarget.json)) in 13.4.