### PR TITLE
refactor: move protocol out of rpc generation

### DIFF
--- a/lib/mixins/execute.js
+++ b/lib/mixins/execute.js
@@ -42,7 +42,9 @@ async function executeAtomAsync (atom, args, frames) {
     window.${promiseName}.resolve = res;
     window.${promiseName}.reject = rej;
     window.${promiseName};`;
-  const obj = await evaluate('Runtime.evaluate', {command: script});
+  const obj = await evaluate('Runtime.evaluate', {
+    expression: script,
+  });
   const promiseObjectId = obj.result.objectId;
 
   // execute the atom, calling back to the resolve function
@@ -57,7 +59,12 @@ async function executeAtomAsync (atom, args, frames) {
   let res;
   const subcommandTimeout = 1000; // timeout on individual commands
   try {
-    res = await evaluate('Runtime.awaitPromise', {promiseObjectId});
+    res = await evaluate('Runtime.awaitPromise', {
+      promiseObjectId,
+      returnByValue: true,
+      generatePreview: true,
+      saveResult: true,
+    });
   } catch (err) {
     if (!err.message.includes(`'Runtime.awaitPromise' was not found`)) {
       throw err;
@@ -73,13 +80,15 @@ async function executeAtomAsync (atom, args, frames) {
       // the atom _will_ return, either because it finished or an error
       // including a timeout error
       const hasValue = await evaluate('Runtime.evaluate', {
-        command: `window.hasOwnProperty('${promiseName}Value');`,
+        expression: `window.hasOwnProperty('${promiseName}Value');`,
+        returnByValue: true,
       });
       if (hasValue) {
         // we only put the property on `window` when the callback is called,
         // so if it is there, everything is done
         return await evaluate('Runtime.evaluate', {
-          command: `window.${promiseName}Value;`,
+          expression: `window.${promiseName}Value;`,
+          returnByValue: true,
         });
       }
       // throw a TimeoutError, or else it needs to be caught and re-thrown
@@ -110,7 +119,8 @@ async function execute (command, override) {
 
   log.debug(`Sending javascript command: '${_.truncate(command, {length: 50})}'`);
   const res = await this.rpcClient.send('Runtime.evaluate', {
-    command,
+    expression: command,
+    returnByValue: true,
     appIdKey: this.appIdKey,
     pageIdKey: this.pageIdKey,
   });
@@ -118,7 +128,7 @@ async function execute (command, override) {
   return convertResult(res);
 }
 
-async function callFunction (objId, fn, args) {
+async function callFunction (objectId, fn, args) {
   checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
 
   if (this.garbageCollectOnExecute) {
@@ -127,9 +137,10 @@ async function callFunction (objId, fn, args) {
 
   log.debug('Calling javascript function');
   const res = await this.rpcClient.send('Runtime.callFunctionOn', {
-    objId,
-    fn,
-    args,
+    objectId,
+    functionDeclaration: fn,
+    arguments: args,
+    returnByValue: true,
     appIdKey: this.appIdKey,
     pageIdKey: this.pageIdKey,
   });

--- a/lib/protocol/index.js
+++ b/lib/protocol/index.js
@@ -123,8 +123,8 @@ function getProtocolCommand (id, method, opts = {}) {
     throw new Error(`Unknown command: '${method}'`);
   }
 
-  const params = paramNames.reduce(function (params, param) {
-    params[param] = opts[param];
+  const params = paramNames.reduce(function (params, name) {
+    params[name] = opts[name];
     return params;
   }, {});
   return getCommand(id, method, params);

--- a/lib/protocol/index.js
+++ b/lib/protocol/index.js
@@ -1,5 +1,6 @@
 const OBJECT_GROUP = 'console';
 
+// See https://github.com/WebKit/webkit/tree/master/Source/JavaScriptCore/inspector/protocol
 const COMMANDS = {
   //#region APPLICATIONCACHE DOMAIN
   'ApplicationCache.enable': [],

--- a/lib/protocol/index.js
+++ b/lib/protocol/index.js
@@ -1,0 +1,114 @@
+const OBJECT_GROUP = 'console';
+
+const COMMANDS = {
+  /* APPLICATIONCACHE DOMAIN */
+  'ApplicationCache.enable': [],
+  'ApplicationCache.getFramesWithManifests': [],
+
+  /* CANVAS DOMAIN */
+  'Canvas.enable': [],
+
+  /* CONSOLE DOMAIN */
+  'Console.disable': [],
+  'Console.enable': [],
+  'Console.getLoggingChannels': [],
+  'Console.setLoggingChannelLevel': ['source', 'level'],
+
+  /* CSS DOMAIN */
+  'CSS.enable': [],
+
+  /* DATABASE DOMAIN */
+  'Database.enable': [],
+
+  /* DEBUGGER DOMAIN */
+  'Debugger.enable': [],
+  'Debugger.setAsyncStackTraceDepth': ['depth'],
+  'Debugger.setBreakpointsActive': ['active'],
+  'Debugger.setPauseForInternalScripts': ['shouldPause'],
+  'Debugger.setPauseOnAssertions': ['enabled'],
+  'Debugger.setPauseOnExceptions': ['state'],
+
+  /* DOM DOMAIN */
+  'DOM.getDocument': [],
+
+  /* DOMSTORAGE DOMAIN */
+  'DOMStorage.enable': [],
+
+  /* HEAP DOMAIN */
+  'Heap.enable': [],
+  'Heap.gc': [],
+
+  /* INDEXEDDB DOMAIN */
+  'IndexedDB.enable': [],
+
+  /* INSPECTOR DOMAIN */
+  'Inspector.enable': [],
+  'Inspector.initialized': [],
+
+  /* LAYERTREE DOMAIN */
+  'LayerTree.enable': [],
+
+  /* MEMORY DOMAIN */
+  'Memory.enable': [],
+
+  /* NETWORK DOMAIN */
+  'Network.disable': [],
+  'Network.enable': [],
+  'Network.setResourceCachingDisabled': ['disabled'],
+
+  /* PAGE DOMAIN */
+  'Page.deleteCookie': ['cookieName', 'url'],
+  'Page.enable': [],
+  'Page.getCookies': ['urls'],
+  'Page.getResourceTree': [],
+  'Page.navigate': ['url'],
+
+  /* RUNTIME DOMAIN */
+  'Runtime.awaitPromise': ['promiseObjectId', 'returnByValue', 'generatePreview', 'saveResult'],
+  'Runtime.callFunctionOn': ['objectId', 'functionDeclaration', 'arguments', 'returnByValue'],
+  'Runtime.enable': [],
+  'Runtime.evaluate': ['expression', 'returnByValue', 'contextId'],
+
+  /* TARGET DOMAIN */
+  'Target.exists': [],
+
+  /* TIMELINE DOMAIN */
+  'Timeline.setAutoCaptureEnabled': ['enabled'],
+  'Timeline.setInstruments': ['instruments'],
+  'Timeline.start': [],
+  'Timeline.stop': [],
+
+  /* WORKER DOMAIN */
+  'Worker.enable': [],
+};
+
+function getCommand (id, method, params = {}) {
+  return {
+    id,
+    method,
+    params: Object.assign({
+      objectGroup: OBJECT_GROUP,
+      includeCommandLineAPI: true,
+      doNotPauseOnExceptionsAndMuteConsole: false,
+      emulateUserGesture: false,
+      generatePreview: false,
+      saveResult: false,
+    }, params),
+  };
+}
+
+function getProtocolCommand (id, method, opts = {}) {
+  const paramNames = COMMANDS[method];
+  if (!paramNames) {
+    throw new Error(`Unknown command: '${method}'`);
+  }
+
+  const params = paramNames.reduce(function (params, param) {
+    params[param] = opts[param];
+    return params;
+  }, {});
+  return getCommand(id, method, params);
+}
+
+export { getProtocolCommand };
+export default getProtocolCommand;

--- a/lib/protocol/index.js
+++ b/lib/protocol/index.js
@@ -1,85 +1,104 @@
 const OBJECT_GROUP = 'console';
 
 const COMMANDS = {
-  /* APPLICATIONCACHE DOMAIN */
+  //#region APPLICATIONCACHE DOMAIN
   'ApplicationCache.enable': [],
   'ApplicationCache.getFramesWithManifests': [],
+  //#endregion
 
-  /* CANVAS DOMAIN */
+  //#region CANVAS DOMAIN
   'Canvas.enable': [],
+  //#endregion
 
-  /* CONSOLE DOMAIN */
+  //#region CONSOLE DOMAIN
   'Console.disable': [],
   'Console.enable': [],
   'Console.getLoggingChannels': [],
   'Console.setLoggingChannelLevel': ['source', 'level'],
+  //#endregion
 
-  /* CSS DOMAIN */
+  //#region CSS DOMAIN
   'CSS.enable': [],
+  //#endregion
 
-  /* DATABASE DOMAIN */
+  //#region DATABASE DOMAIN
   'Database.enable': [],
+  //#endregion
 
-  /* DEBUGGER DOMAIN */
+  //#region DEBUGGER DOMAIN
   'Debugger.enable': [],
   'Debugger.setAsyncStackTraceDepth': ['depth'],
   'Debugger.setBreakpointsActive': ['active'],
   'Debugger.setPauseForInternalScripts': ['shouldPause'],
   'Debugger.setPauseOnAssertions': ['enabled'],
   'Debugger.setPauseOnExceptions': ['state'],
+  //#endregion
 
-  /* DOM DOMAIN */
+  //#region DOM DOMAIN
   'DOM.getDocument': [],
+  //#endregion
 
-  /* DOMSTORAGE DOMAIN */
+  //#region DOMSTORAGE DOMAIN
   'DOMStorage.enable': [],
+  //#endregion
 
-  /* HEAP DOMAIN */
+  //#region HEAP DOMAIN
   'Heap.enable': [],
   'Heap.gc': [],
+  //#endregion
 
-  /* INDEXEDDB DOMAIN */
+  //#region INDEXEDDB DOMAIN
   'IndexedDB.enable': [],
+  //#endregion
 
-  /* INSPECTOR DOMAIN */
+  //#region INSPECTOR DOMAIN
   'Inspector.enable': [],
   'Inspector.initialized': [],
+  //#endregion
 
-  /* LAYERTREE DOMAIN */
+  //#region LAYERTREE DOMAIN
   'LayerTree.enable': [],
+  //#endregion
 
-  /* MEMORY DOMAIN */
+  //#region MEMORY DOMAIN
   'Memory.enable': [],
+  //#endregion
 
-  /* NETWORK DOMAIN */
+  //#region NETWORK DOMAIN
   'Network.disable': [],
   'Network.enable': [],
   'Network.setResourceCachingDisabled': ['disabled'],
+  //#endregion
 
-  /* PAGE DOMAIN */
+  //#region PAGE DOMAIN
   'Page.deleteCookie': ['cookieName', 'url'],
   'Page.enable': [],
   'Page.getCookies': ['urls'],
   'Page.getResourceTree': [],
   'Page.navigate': ['url'],
+  //#endregion
 
-  /* RUNTIME DOMAIN */
+  //#region RUNTIME DOMAIN
   'Runtime.awaitPromise': ['promiseObjectId', 'returnByValue', 'generatePreview', 'saveResult'],
   'Runtime.callFunctionOn': ['objectId', 'functionDeclaration', 'arguments', 'returnByValue'],
   'Runtime.enable': [],
   'Runtime.evaluate': ['expression', 'returnByValue', 'contextId'],
+  //#endregion
 
-  /* TARGET DOMAIN */
+  //#region TARGET DOMAIN
   'Target.exists': [],
+  //#endregion
 
-  /* TIMELINE DOMAIN */
+  //#region TIMELINE DOMAIN
   'Timeline.setAutoCaptureEnabled': ['enabled'],
   'Timeline.setInstruments': ['instruments'],
   'Timeline.start': [],
   'Timeline.stop': [],
+  //#endregion
 
-  /* WORKER DOMAIN */
+  //#region WORKER DOMAIN
   'Worker.enable': [],
+  //#endregion
 };
 
 function getCommand (id, method, params = {}) {

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -209,7 +209,7 @@ class RemoteDebugger extends EventEmitter {
   }
 
   async getCookies (urls) {
-    log.debug('Getting network cookies');
+    log.debug('Getting cookies');
     return await this.rpcClient.send('Page.getCookies', {
       appIdKey: this.appIdKey,
       pageIdKey: this.pageIdKey,

--- a/lib/rpc/remote-messages.js
+++ b/lib/rpc/remote-messages.js
@@ -1,7 +1,28 @@
 import _ from 'lodash';
+import getProtocolCommand from '../protocol';
 
 
 const OBJECT_GROUP = 'console';
+
+const MINIMAL_COMMAND = 'getMinimalCommand';
+const FUll_COMMAND = 'getFullCommand';
+const DIRECT_COMMAND = 'getDirectCommand';
+
+// mapping of commands to the function for getting the command
+// defaults to `getMinimalCommand`, so no need to have those listed here
+const COMMANDS = {
+  'Page.getCookies': FUll_COMMAND,
+  'Page.navigate': FUll_COMMAND,
+
+  'Runtime.awaitPromise': FUll_COMMAND,
+  'Runtime.callFunctionOn': FUll_COMMAND,
+  'Runtime.evaluate': FUll_COMMAND,
+
+  'Target.exists': DIRECT_COMMAND,
+
+  'Timeline.start': FUll_COMMAND,
+  'Timeline.stop': FUll_COMMAND,
+};
 
 class RemoteMessages {
   constructor (isTargetBased = false) {
@@ -20,8 +41,7 @@ class RemoteMessages {
    * Connection functions
    */
 
-  setConnectionKey (opts = {}) {
-    const {connId} = opts;
+  setConnectionKey (connId) {
     return {
       __argument: {
         WIRConnectionIdentifierKey: connId
@@ -30,8 +50,7 @@ class RemoteMessages {
     };
   }
 
-  connectToApp (opts = {}) {
-    const {connId, appIdKey} = opts;
+  connectToApp (connId, appIdKey) {
     return {
       __argument: {
         WIRConnectionIdentifierKey: connId,
@@ -41,8 +60,7 @@ class RemoteMessages {
     };
   }
 
-  setSenderKey (opts = {}) {
-    const {connId, senderId, appIdKey, pageIdKey} = opts;
+  setSenderKey (connId, senderId, appIdKey, pageIdKey) {
     return {
       __argument: {
         WIRApplicationIdentifierKey: appIdKey,
@@ -55,13 +73,7 @@ class RemoteMessages {
     };
   }
 
-  indicateWebView (opts = {}) {
-    const {
-      connId,
-      appIdKey,
-      pageIdKey,
-      enabled,
-    } = opts;
+  indicateWebView (connId, appIdKey, pageIdKey, enabled) {
     return {
       __argument: {
         WIRApplicationIdentifierKey: appIdKey,
@@ -73,8 +85,7 @@ class RemoteMessages {
     };
   }
 
-  launchApplication (opts = {}) {
-    const {bundleId} = opts;
+  launchApplication (bundleId) {
     return {
       __argument: {
         WIRApplicationBundleIdentifierKey: bundleId
@@ -211,263 +222,30 @@ class RemoteMessages {
       targetId,
     } = opts;
 
-    let method, params;
-
+    // deal with Safari Web Inspector commands
     switch (command) {
-      /* BASIC COMMANDS */
       case 'setConnectionKey':
-        return this.setConnectionKey({connId});
+        return this.setConnectionKey(connId);
       case 'indicateWebView':
-        return this.indicateWebView({connId, appIdKey, pageIdKey, enabled: opts.enabled});
+        return this.indicateWebView(connId, appIdKey, pageIdKey, opts.enabled);
       case 'connectToApp':
-        return this.connectToApp({connId, appIdKey});
+        return this.connectToApp(connId, appIdKey);
       case 'setSenderKey':
-        return this.setSenderKey({connId, senderId, appIdKey, pageIdKey});
+        return this.setSenderKey(connId, senderId, appIdKey, pageIdKey);
       case 'launchApplication':
-        return this.launchApplication(opts);
-
-
-      /* APPLICATIONCACHE DOMAIN */
-      case 'ApplicationCache.enable':
-        method = 'ApplicationCache.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'ApplicationCache.getFramesWithManifests':
-        method = 'ApplicationCache.getFramesWithManifests';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* CANVAS DOMAIN */
-      case 'Canvas.enable':
-        method = 'Canvas.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* CONSOLE DOMAIN */
-      case 'Console.disable':
-        method = 'Console.disable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Console.enable':
-        method = 'Console.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Console.getLoggingChannels':
-        method = 'Console.getLoggingChannels';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Console.setLoggingChannelLevel':
-        method = 'Console.setLoggingChannelLevel';
-        params = {
-          source: opts.source,
-          level: opts.level,
-        };
-        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* CSS DOMAIN */
-      case 'CSS.enable':
-        method = 'CSS.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* DATABASE DOMAIN */
-      case 'Database.enable':
-        method = 'Database.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* DEBUGGER DOMAIN */
-      case 'Debugger.enable':
-        method = 'Debugger.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Debugger.setAsyncStackTraceDepth':
-        method = 'Debugger.setAsyncStackTraceDepth';
-        params = {
-          depth: opts.depth,
-        };
-        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Debugger.setBreakpointsActive':
-        method = 'Debugger.setBreakpointsActive';
-        params = {
-          active: opts.active,
-        };
-        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Debugger.setPauseForInternalScripts':
-        method = 'Debugger.setPauseForInternalScripts';
-        params = {
-          shouldPause: opts.shouldPause,
-        };
-        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Debugger.setPauseOnAssertions':
-        method = 'Debugger.setPauseOnAssertions';
-        params = {
-          enabled: opts.enabled,
-        };
-        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Debugger.setPauseOnExceptions':
-        method = 'Debugger.setPauseOnExceptions';
-        params = {
-          state: opts.state,
-        };
-        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* DOM DOMAIN */
-      case 'DOM.getDocument':
-        method = 'DOM.getDocument';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* DOMSTORAGE DOMAIN */
-      case 'DOMStorage.enable':
-        method = 'DOMStorage.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* HEAP DOMAIN */
-      case 'Heap.enable':
-        method = 'Heap.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Heap.gc':
-        method = 'Heap.gc';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* INDEXEDDB DOMAIN */
-      case 'IndexedDB.enable':
-        method = 'IndexedDB.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* INSPECTOR DOMAIN */
-      case 'Inspector.enable':
-        method = 'Inspector.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Inspector.initialized':
-        method = 'Inspector.initialized';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* LAYERTREE DOMAIN */
-      case 'LayerTree.enable':
-        method = 'LayerTree.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* MEMORY DOMAIN */
-      case 'Memory.enable':
-        method = 'Memory.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* NETWORK DOMAIN */
-      case 'Network.disable':
-        method = 'Network.disable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Network.enable':
-        method = 'Network.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Network.setResourceCachingDisabled':
-        method = 'Network.setResourceCachingDisabled';
-        params = {
-          disabled: opts.disabled,
-        };
-        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-      /* PAGE DOMAIN */
-      case 'Page.deleteCookie':
-        method = 'Page.deleteCookie';
-        params = {
-          cookieName: opts.cookieName,
-          url: opts.url,
-        };
-        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Page.enable':
-        method = 'Page.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Page.getCookies':
-        method = 'Page.getCookies';
-        return this.getFullCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Page.getResourceTree':
-        method = 'Page.getResourceTree';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Page.navigate':
-        method = 'Page.navigate';
-        params = {
-          url: opts.url,
-        };
-        return this.getFullCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* RUNTIME DOMAIN */
-      case 'Runtime.awaitPromise':
-        method = 'Runtime.awaitPromise';
-        params = {
-          promiseObjectId: opts.promiseObjectId,
-          returnByValue: true,
-          generatePreview: true,
-          saveResult: true,
-        };
-        return this.getFullCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Runtime.callFunctionOn':
-        method = 'Runtime.callFunctionOn';
-        params = {
-          objectId: opts.objId,
-          functionDeclaration: opts.fn,
-          arguments: opts.args,
-          returnByValue: true,
-        };
-        return this.getFullCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Runtime.enable':
-        method = 'Runtime.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Runtime.evaluate':
-        method = 'Runtime.evaluate';
-        params = {
-          expression: opts.command,
-          returnByValue: _.isBoolean(opts.returnByValue) ? opts.returnByValue : true,
-          contextId: opts.contextId,
-        };
-        return this.getFullCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* TARGET DOMAIN */
-      case 'Target.exists':
-        method = 'Target.exists';
-        return this.getDirectCommand({method, connId, senderId, appIdKey, pageIdKey, id});
-
-
-      /* TIMELINE DOMAIN */
-      case 'Timeline.setAutoCaptureEnabled':
-        method = 'Timeline.setAutoCaptureEnabled';
-        params = {
-          enabled: opts.enabled,
-        };
-        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Timeline.setInstruments':
-        method = 'Timeline.setInstruments';
-        params = {
-          instruments: [
-            'Timeline',
-            'ScriptProfiler',
-            'CPU',
-          ],
-        };
-        return this.getMinimalCommand({method, params, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Timeline.start':
-        method = 'Timeline.start';
-        return this.getFullCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-      case 'Timeline.stop':
-        method = 'Timeline.stop';
-        return this.getFullCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      /* WORKER DOMAIN */
-      case 'Worker.enable':
-        method = 'Worker.enable';
-        return this.getMinimalCommand({method, connId, senderId, targetId, appIdKey, pageIdKey, id});
-
-
-      default:
-        throw new Error(`Unknown command: '${command}'`);
+        return this.launchApplication(opts.bundleId);
     }
+
+    // deal with WebKit commands
+    const builderFunction = COMMANDS[command] || MINIMAL_COMMAND;
+    return this[builderFunction]({
+      ...getProtocolCommand(id, command, opts),
+      connId,
+      appIdKey,
+      senderId,
+      pageIdKey,
+      targetId,
+    });
   }
 }
 

--- a/lib/rpc/remote-messages.js
+++ b/lib/rpc/remote-messages.js
@@ -5,23 +5,23 @@ import getProtocolCommand from '../protocol';
 const OBJECT_GROUP = 'console';
 
 const MINIMAL_COMMAND = 'getMinimalCommand';
-const FUll_COMMAND = 'getFullCommand';
+const FULL_COMMAND = 'getFullCommand';
 const DIRECT_COMMAND = 'getDirectCommand';
 
 // mapping of commands to the function for getting the command
 // defaults to `getMinimalCommand`, so no need to have those listed here
 const COMMANDS = {
-  'Page.getCookies': FUll_COMMAND,
-  'Page.navigate': FUll_COMMAND,
+  'Page.getCookies': FULL_COMMAND,
+  'Page.navigate': FULL_COMMAND,
 
-  'Runtime.awaitPromise': FUll_COMMAND,
-  'Runtime.callFunctionOn': FUll_COMMAND,
-  'Runtime.evaluate': FUll_COMMAND,
+  'Runtime.awaitPromise': FULL_COMMAND,
+  'Runtime.callFunctionOn': FULL_COMMAND,
+  'Runtime.evaluate': FULL_COMMAND,
 
   'Target.exists': DIRECT_COMMAND,
 
-  'Timeline.start': FUll_COMMAND,
-  'Timeline.stop': FUll_COMMAND,
+  'Timeline.start': FULL_COMMAND,
+  'Timeline.stop': FULL_COMMAND,
 };
 
 class RemoteMessages {

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -460,7 +460,9 @@ export default class RpcClient {
     await this.send('Memory.enable', sendOpts, false);
     await this.send('ApplicationCache.enable', sendOpts, false);
     await this.send('ApplicationCache.getFramesWithManifests', sendOpts, false);
-    await this.send('Timeline.setInstruments', sendOpts, false);
+    await this.send('Timeline.setInstruments', Object.assign({
+      instruments: ['Timeline', 'ScriptProfiler', 'CPU'],
+    }, sendOpts), false);
     await this.send('Timeline.setAutoCaptureEnabled', Object.assign({
       enabled: false,
     }, sendOpts), false);


### PR DESCRIPTION
Separate the protocol messages from the RPC generation, which is iOS specific. I've been working on integrating Chrome and this is a first step. Also makes the protocol easier to handle.