### PR TITLE
chore: add a debug value message when waiting for data

### DIFF
--- a/lib/mixins/connect.js
+++ b/lib/mixins/connect.js
@@ -216,7 +216,7 @@ function logApplicationDictionary (apps) {
       return '[Function]';
     }
     if (key === 'pageArray' && !_.isArray(value)) {
-      return `"Waiting for data"`;
+      return `"Waiting for data: ${JSON.stringify(value)}"`;
     }
     return JSON.stringify(value);
   }


### PR DESCRIPTION
I'd like to leave `value` as a debug message when 'waiting for data' when `safariLogAllCommunication: true` ( since I'm not sure the value has other cases.) 

before

```
[debug] [RemoteDebugger]     Application: "PID:16527"
[debug] [RemoteDebugger]         id: "PID:16527"
[debug] [RemoteDebugger]         isProxy: false
[debug] [RemoteDebugger]         name: "com.apple.WebKit.WebContent"
[debug] [RemoteDebugger]         bundleId: "process-com.apple.WebKit.WebContent"
[debug] [RemoteDebugger]         hostId: undefined
[debug] [RemoteDebugger]         isActive: false
[debug] [RemoteDebugger]         isAutomationEnabled: "Unknown"
[debug] [RemoteDebugger]         pageArray: "Waiting for data."
```

after
```
[debug] [RemoteDebugger]     Application: "PID:16527"
[debug] [RemoteDebugger]         id: "PID:16527"
[debug] [RemoteDebugger]         isProxy: false
[debug] [RemoteDebugger]         name: "com.apple.WebKit.WebContent"
[debug] [RemoteDebugger]         bundleId: "process-com.apple.WebKit.WebContent"
[debug] [RemoteDebugger]         hostId: undefined
[debug] [RemoteDebugger]         isActive: false
[debug] [RemoteDebugger]         isAutomationEnabled: "Unknown"
[debug] [RemoteDebugger]         pageArray: "Waiting for data: {"promise":{"isFulfilled":false,"isRejected":false}}"
```