### PR TITLE
[wip] feat: calls Target.setPauseOnStart to initialise the web inspector

### DIFF
--- a/lib/protocol/index.js
+++ b/lib/protocol/index.js
@@ -88,6 +88,7 @@ const COMMANDS = {
 
   //#region TARGET DOMAIN
   'Target.exists': [],
+  'Target.setPauseOnStart': [],
   //#endregion
 
   //#region TIMELINE DOMAIN

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -400,6 +400,9 @@ export default class RpcClient {
 
     if (this.isTargetBased && util.compareVersions(this.platformVersion, '<', MIN_PLATFORM_NO_TARGET_EXISTS)) {
       await this.send('Target.exists', sendOpts, false);
+    } else if (this.isTargetBased) {
+      // https://github.com/WebKit/webkit/commit/aadf3178085edc85d8252f104702e412df908846#diff-f471073e2a8e77a7695cb03bb15eee89R40-R45
+      await this.send('Target.setPauseOnStart', {'pauseOnStart': true}, false);
     }
 
     this.shouldCheckForTarget = true;

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -403,6 +403,8 @@ export default class RpcClient {
     }
 
     if (this.isTargetBased) {
+      // Use to initialise the target
+      // https://github.com/WebKit/webkit/blob/950143da027e80924b4bb86defa8a3f21fd3fb1e/Source/WebInspectorUI/UserInterface/Controllers/TargetManager.js#L40-L45
       await this.send('Target.setPauseOnStart', {'pauseOnStart': true}, false);
     }
 

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -14,7 +14,7 @@ const WAIT_FOR_TARGET_INTERVAL = 1000;
 
 const MIN_PLATFORM_FOR_TARGET_BASED = '12.2';
 
-// `Target.exists` protocol method was removed from WebKitin 13.4
+// `Target.exists` protocol method was removed from WebKit in 13.4
 const MIN_PLATFORM_NO_TARGET_EXISTS = '13.4';
 
 function isTargetBased (isSafari, platformVersion) {
@@ -400,8 +400,9 @@ export default class RpcClient {
 
     if (this.isTargetBased && util.compareVersions(this.platformVersion, '<', MIN_PLATFORM_NO_TARGET_EXISTS)) {
       await this.send('Target.exists', sendOpts, false);
-    } else if (this.isTargetBased) {
-      // https://github.com/WebKit/webkit/commit/aadf3178085edc85d8252f104702e412df908846#diff-f471073e2a8e77a7695cb03bb15eee89R40-R45
+    }
+
+    if (this.isTargetBased) {
       await this.send('Target.setPauseOnStart', {'pauseOnStart': true}, false);
     }
 


### PR DESCRIPTION
For https://github.com/appium/appium/issues/14604

In my investigation, 13.6 inspector called `{"id":1,"method":"Target.setPauseOnStart","params":{"pauseOnStart":true}}`.
13.3 called `{"id":1,"method":"Target.exists"}`. So, we should call `Target.setPauseOnStart` once.

The command seemed to work over iOS 13.0+. I tested with Xcode 10.3 and Xcode 11.6 based environment.
So, we can only check the `Target` domain availability.

I tested our ui-catalog app's webview section.

1. Launch te ui-catalog app
2. Open the WebView section
3. Switch to WebView context
4. Back
5. Select the WebView section again
    - Then, below logs appear

After

```
[debug] [RemoteDebugger] Sender key set
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message (id: 36): 'Target.setPauseOnStart'
[debug] [RemoteDebugger] Sending to Web Inspector took 0ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '3', target 'page-25' (id: 38): 'Inspector.enable'
[debug] [RemoteDebugger] Sending to Web Inspector took 0ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '3', target 'page-25' (id: 40): 'Page.enable'
[debug] [RemoteDebugger] Sending to Web Inspector took 0ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '3', target 'page-25' (id: 42): 'Network.enable'
[debug] [RemoteDebugger] Sending to Web Inspector took 0ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '3', target 'page-25' (id: 44): 'Runtime.enable'
[debug] [RemoteDebugger] Sending to Web Inspector took 0ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '3', target 'page-25' (id: 46): 'Heap.enable'
[debug] [RemoteDebugger] Sending to Web Inspector took 0ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '3', target 'page-25' (id: 48): 'Debugger.enable'
[debug] [RemoteDebugger] Sending to Web Inspector took 0ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '3', target 'page-25' (id: 50): 'Console.enable'
[debug] [RemoteDebugger] Sending to Web Inspector took 0ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '3', target 'page-25' (id: 52): 'Inspector.initialized'
[debug] [RemoteDebugger] Sending to Web Inspector took 0ms
[debug] [RemoteDebugger] Checking document readyState
[debug] [RemoteDebugger] Sending javascript command: 'document.readyState;'
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '3', target 'page-25' (id: 54): 'Runtime.evaluate'
[debug] [RemoteDebugger] Page readiness check timed out after 5000ms
[debug] [RemoteDebugger] Page unloading
```

Before

```
[debug] [XCUITest] Attempting to set context to 'WEBVIEW_522.2' from 'NATIVE_APP'
[debug] [RemoteDebugger] Selecting page '2' on app 'PID:522' and forwarding socket setup
[debug] [RemoteDebugger] Sending '_rpc_forwardIndicateWebView:' message to app 'PID:522', page '2' (id: 4): 'indicateWebView'
[debug] [RemoteDebugger] Sending to Web Inspector took 7ms
[debug] [RemoteDebugger] Sending '_rpc_forwardIndicateWebView:' message to app 'PID:522', page '2' (id: 5): 'indicateWebView'
[debug] [RemoteDebugger] Sending to Web Inspector took 14ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketSetup:' message to app 'PID:522', page '2' (id: 6): 'setSenderKey'
[debug] [RemoteDebugger] Sending to Web Inspector took 6ms
[debug] [RemoteDebugger] Sender key set
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '2' (id: 7): 'Inspector.enable'
[debug] [RemoteDebugger] Target created for app 'PID:522' and page '2': {"targetId":"page-16","type":"page"}
[debug] [RemoteDebugger] Sending to Web Inspector took 7ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '2' (id: 8): 'Page.enable'
[debug] [RemoteDebugger] Handling message (id: '7')
[RemoteDebugger] Received error from send that is not being waited for (id: 7): '{"code":-32601,"message":"'Inspector' domain was not found","data":[{"code":-32601,"message":"'Inspector' domain was not found"}]}'
[debug] [RemoteDebugger] Sending to Web Inspector took 10ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '2' (id: 9): 'Network.enable'
[debug] [RemoteDebugger] Handling message (id: '8')
[RemoteDebugger] Received error from send that is not being waited for (id: 8): '{"code":-32601,"message":"'Page' domain was not found","data":[{"code":-32601,"message":"'Page' domain was not found"}]}'
[debug] [RemoteDebugger] Sending to Web Inspector took 7ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '2' (id: 10): 'Runtime.enable'
[debug] [RemoteDebugger] Handling message (id: '9')
[RemoteDebugger] Received error from send that is not being waited for (id: 9): '{"code":-32601,"message":"'Network' domain was not found","data":[{"code":-32601,"message":"'Network' domain was not found"}]}'
[debug] [RemoteDebugger] Sending to Web Inspector took 5ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '2' (id: 11): 'Heap.enable'
[debug] [RemoteDebugger] Handling message (id: '10')
[RemoteDebugger] Received error from send that is not being waited for (id: 10): '{"code":-32601,"message":"'Runtime' domain was not found","data":[{"code":-32601,"message":"'Runtime' domain was not found"}]}'
[debug] [RemoteDebugger] Sending to Web Inspector took 6ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '2' (id: 12): 'Debugger.enable'
[debug] [RemoteDebugger] Handling message (id: '11')
[RemoteDebugger] Received error from send that is not being waited for (id: 11): '{"code":-32601,"message":"'Heap' domain was not found","data":[{"code":-32601,"message":"'Heap' domain was not found"}]}'
[debug] [RemoteDebugger] Sending to Web Inspector took 6ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '2' (id: 13): 'Console.enable'
[debug] [RemoteDebugger] Handling message (id: '12')
[RemoteDebugger] Received error from send that is not being waited for (id: 12): '{"code":-32601,"message":"'Debugger' domain was not found","data":[{"code":-32601,"message":"'Debugger' domain was not found"}]}'
[debug] [RemoteDebugger] Sending to Web Inspector took 7ms
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '2' (id: 14): 'Inspector.initialized'
[debug] [RemoteDebugger] Handling message (id: '13')
[RemoteDebugger] Received error from send that is not being waited for (id: 13): '{"code":-32601,"message":"'Console' domain was not found","data":[{"code":-32601,"message":"'Console' domain was not found"}]}'
[debug] [RemoteDebugger] Sending to Web Inspector took 6ms
[debug] [RemoteDebugger] Checking document readyState
[debug] [RemoteDebugger] Sending javascript command: 'document.readyState;'
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '2' (id: 15): 'Runtime.evaluate'
[debug] [RemoteDebugger] Handling message (id: '14')
[RemoteDebugger] Received error from send that is not being waited for (id: 14): '{"code":-32601,"message":"'Inspector' domain was not found","data":[{"code":-32601,"message":"'Inspector' domain was not found"}]}'
[debug] [RemoteDebugger] Handling message (id: '15')
[RemoteDebugger] Setting communication protocol: using Target-based communication
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:522', page '2', target 'page-16' (id: 16): 'Runtime.evaluate'
[debug] [RemoteDebugger] Received data response from send (id: 16): '"complete"'
[debug] [RemoteDebugger] Sending to Web Inspector took 52ms
[debug] [RemoteDebugger] Document readyState is 'complete'
[debug] [RemoteDebugger] Selected page after 139ms
[debug] [RemoteDebugger] Starting to listen for JavaScript console
[debug] [RemoteDebugger] Starting to listen for network events
```
