### PR TITLE
feat: make isTargetBased true by default

### DIFF
--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -401,7 +401,10 @@ export default class RpcClient {
     log.debug('Sender key set');
 
     if (this.isTargetBased && util.compareVersions(this.platformVersion, '<', MIN_PLATFORM_NO_TARGET_EXISTS)) {
-      await this.send('Target.exists', sendOpts, false);
+      try {
+        // Wait for the response since this result affects following communication protocol
+        await this.send('Target.exists', sendOpts, true);
+      } catch (ign) { }
     }
 
     this.shouldCheckForTarget = true;

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -403,10 +403,7 @@ export default class RpcClient {
     log.debug('Sender key set');
 
     if (this.isTargetBased && util.compareVersions(this.platformVersion, '<', MIN_PLATFORM_NO_TARGET_EXISTS)) {
-      try {
-        // Wait for the response since this result affects following communication protocol
-        await this.send('Target.exists', sendOpts, true);
-      } catch (ign) { }
+      await this.send('Target.exists', sendOpts, false);
     }
 
     this.shouldCheckForTarget = true;

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -18,7 +18,9 @@ const MIN_PLATFORM_FOR_TARGET_BASED = '12.2';
 const MIN_PLATFORM_NO_TARGET_EXISTS = '13.4';
 
 function isTargetBased (isSafari, platformVersion) {
-  // on iOS 12.2 the messages get sent through the Target domain
+  // On iOS 12.2 the messages get sent through the Target domain
+  // On iOS 13.0, WKWebKit also needs to follow the Target domain,
+  // so here only check the target OS version as the default behaviour.
   const isHighVersion = util.compareVersions(platformVersion, '>=', MIN_PLATFORM_FOR_TARGET_BASED);
   log.debug(`Checking which communication style to use (${isSafari ? '' : 'non-'}Safari on platform version '${platformVersion}')`);
   log.debug(`Platform version equal or higher than '${MIN_PLATFORM_FOR_TARGET_BASED}': ${isHighVersion}`);
@@ -171,8 +173,8 @@ export default class RpcClient {
       return await this.sendToDevice(command, opts, waitForResponse);
     } catch (err) {
       if (err.message.includes(`'Target' domain was not found`)) {
-        log.info('The target device does not support Target based communication. ' +
-          'Following non-target based communication.');
+        log.info('The target device does not support Target basde communication. ' +
+          'Will follow non-target based communication.');
         this.isTargetBased = false;
         return await this.sendToDevice(command, opts, waitForResponse);
       } else if (err.message.includes(`domain was not found`) || err.message.includes(`Some arguments of method`)) {

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -22,7 +22,7 @@ function isTargetBased (isSafari, platformVersion) {
   const isHighVersion = util.compareVersions(platformVersion, '>=', MIN_PLATFORM_FOR_TARGET_BASED);
   log.debug(`Checking which communication style to use (${isSafari ? '' : 'non-'}Safari on platform version '${platformVersion}')`);
   log.debug(`Platform version equal or higher than '${MIN_PLATFORM_FOR_TARGET_BASED}': ${isHighVersion}`);
-  return isSafari && isHighVersion;
+  return isHighVersion;
 }
 
 export default class RpcClient {
@@ -171,6 +171,8 @@ export default class RpcClient {
       return await this.sendToDevice(command, opts, waitForResponse);
     } catch (err) {
       if (err.message.includes(`'Target' domain was not found`)) {
+        log.info('The target device does not support Target basde communication. ' +
+          'Will follow non-target based communication.');
         this.isTargetBased = false;
         return await this.sendToDevice(command, opts, waitForResponse);
       } else if (err.message.includes(`domain was not found`) || err.message.includes(`Some arguments of method`)) {


### PR DESCRIPTION
For now, the `Target` domain communication is only when safari &&  12.2+, but according to https://github.com/appium/appium/issues/14604 `WKwebview` also requires the Target domain communication.

We have logic to make `this.isTargetBased` `false` to disable the Target communication style, so I think we can simply make `this.isTargetBased` `true` for iOS 12.2+.

I tested below steps with iOS 12.0, 12.4, iOS 13.0 and 13.6 simulators. iOS 12.0 raised `'Target' domain was not found` error once, but made `this.isTargetBased` false

1. Launch te ui-catalog app
2. Open the WebView section
3. Switch to WebView context
4. Back
5. Select the WebView section again
    - Then, below logs appear

I'll test for a real device later