### PR TITLE
feat: add _rpc_reportCurrentState handler for iOS 14

### DIFF
--- a/lib/mixins/connect.js
+++ b/lib/mixins/connect.js
@@ -36,6 +36,7 @@ async function connect (timeout = APP_CONNECT_TIMEOUT_MS) {
   this.rpcClient.on('_rpc_applicationDisconnected:', this.onAppDisconnect.bind(this));
   this.rpcClient.on('_rpc_applicationUpdated:', this.onAppUpdate.bind(this));
   this.rpcClient.on('_rpc_reportConnectedDriverList:', this.onConnectedDriverList.bind(this));
+  this.rpcClient.on('_rpc_reportCurrentState:', this.onCurrentState.bind(this));
   this.rpcClient.on('Page.frameDetached', this.frameDetached.bind(this));
 
   await this.rpcClient.connect();

--- a/lib/mixins/message-handlers.js
+++ b/lib/mixins/message-handlers.js
@@ -104,6 +104,11 @@ function onConnectedDriverList (err, drivers) {
   log.debug(`Received connected driver list: ${JSON.stringify(this.connectedDrivers)}`);
 }
 
+function onCurrentState (err, drivers) {
+  this.connectedDrivers = drivers.WIRAutomationAvailabilityKey;
+  log.debug(`Received connected driver list with onCurrentState: ${JSON.stringify(this.connectedDrivers)}`);
+}
+
 async function onConnectedApplicationList (err, apps) {
   log.debug(`Received connected applications list: ${_.keys(apps).join(', ')}`);
 
@@ -133,6 +138,7 @@ const messageHandlers = {
   onAppDisconnect,
   onAppUpdate,
   onConnectedDriverList,
+  onCurrentState,
   onConnectedApplicationList,
 };
 

--- a/lib/mixins/message-handlers.js
+++ b/lib/mixins/message-handlers.js
@@ -106,7 +106,7 @@ function onConnectedDriverList (err, drivers) {
 
 function onCurrentState (err, state) {
   this.currentState = state.WIRAutomationAvailabilityKey;
-  log.debug(`Received connected current state: ${JSON.stringify(this.currentState)}`);
+  log.debug(`Received connected automation availability state: ${JSON.stringify(this.currentState)}`);
 }
 
 async function onConnectedApplicationList (err, apps) {

--- a/lib/mixins/message-handlers.js
+++ b/lib/mixins/message-handlers.js
@@ -104,9 +104,9 @@ function onConnectedDriverList (err, drivers) {
   log.debug(`Received connected driver list: ${JSON.stringify(this.connectedDrivers)}`);
 }
 
-function onCurrentState (err, drivers) {
-  this.connectedDrivers = drivers.WIRAutomationAvailabilityKey;
-  log.debug(`Received connected driver list with onCurrentState: ${JSON.stringify(this.connectedDrivers)}`);
+function onCurrentState (err, state) {
+  this.currentState = state.WIRAutomationAvailabilityKey;
+  log.debug(`Received connected current state: ${JSON.stringify(this.currentState)}`);
 }
 
 async function onConnectedApplicationList (err, apps) {

--- a/lib/mixins/message-handlers.js
+++ b/lib/mixins/message-handlers.js
@@ -106,6 +106,8 @@ function onConnectedDriverList (err, drivers) {
 
 function onCurrentState (err, state) {
   this.currentState = state.WIRAutomationAvailabilityKey;
+  // This state changes when 'Remote Automation' in 'Settings app' > 'Safari' > 'Advanced' > 'Remote Automation' changes
+  // WIRAutomationAvailabilityAvailable or WIRAutomationAvailabilityNotAvailable
   log.debug(`Received connected automation availability state: ${JSON.stringify(this.currentState)}`);
 }
 

--- a/lib/rpc/rpc-message-handler.js
+++ b/lib/rpc/rpc-message-handler.js
@@ -61,6 +61,9 @@ export default class RpcMessageHandler extends EventEmitters {
       case '_rpc_reportConnectedDriverList:':
         this.emit('_rpc_reportConnectedDriverList:', null, argument);
         break;
+      case '_rpc_reportCurrentState:':
+        this.emit('_rpc_reportCurrentState:', null, argument);
+        break;
       case '_rpc_applicationSentData:':
         await this.handleDataMessage(plist);
         break;


### PR DESCRIPTION
Before
```
[debug] [RemoteDebugger] Debugger got a message for '_rpc_reportCurrentState:' and have no handler, doing nothing.
```

After

```
[debug] [RemoteDebugger] Received connected current state: "WIRAutomationAvailabilityNotAvailable"
[debug] [RemoteDebugger] Received connected current state: "WIRAutomationAvailabilityAvailable"
```

This command seems to change when 'remote automation' state changes in settings app > safari > advanced > remote automation