### PR TITLE
chore: Remove deprecated dependencies

### DIFF
--- a/lib/webkit-remote-debugger.js
+++ b/lib/webkit-remote-debugger.js
@@ -5,8 +5,7 @@ import { errors } from 'appium-base-driver';
 import { RemoteDebugger, DEBUGGER_TYPES, RPC_RESPONSE_TIMEOUT_MS } from './remote-debugger';
 import WebKitRpcClient from './webkit-rpc-client';
 import _ from 'lodash';
-import url from 'url';
-import request from 'request-promise';
+import axios from 'axios';
 import { simpleStringify } from './helpers';
 
 
@@ -67,9 +66,9 @@ export default class WebKitRemoteDebugger extends RemoteDebugger {
     log.debug(`Page element JSON: ${simpleStringify(pageElementJSON)}`);
 
     // Add elements to an array
-    const newPageArray = pageElementJSON.filter((pageObject) => {
-      return pageObject.url && (!ignoreAboutBlankUrl || pageObject.url !== 'about:blank');
-    }).map((pageObject) => {
+    const newPageArray = pageElementJSON.filter((pageObject) =>
+      pageObject.url && (!ignoreAboutBlankUrl || pageObject.url !== 'about:blank')
+    ).map((pageObject) => {
       const urlArray = pageObject.webSocketDebuggerUrl.split('/').reverse();
       const id = urlArray[0];
       return {
@@ -84,15 +83,10 @@ export default class WebKitRemoteDebugger extends RemoteDebugger {
   }
 
   async getJsonFromUrl (hostname, port, pathname) {
-    const uri = url.format({
-      protocol: 'http',
-      hostname,
-      port,
-      pathname,
-      json: true,
-    });
-    log.debug(`Sending request to: ${uri}`);
-    return JSON.parse(await request({uri, method: 'GET'}));
+    const portStr = _.isFinite(port) ? `:${port}` : '';
+    const url = `http://${hostname}${portStr}${pathname}`;
+    log.debug(`Sending request to: ${url}`);
+    return (await axios.get(url)).data;
   }
 
   convertResult (res) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "atoms"
   ],
   "dependencies": {
+    "axios": "^0.20.0",
     "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^7.0.0",
     "appium-support": "^2.28.0",
@@ -38,8 +39,6 @@
     "bufferpack": "0.0.6",
     "es6-error": "^4.1.1",
     "lodash": "^4.17.11",
-    "request": "^2.79.0",
-    "request-promise": "^4.1.1",
     "source-map-support": "^0.5.5",
     "ws": "^7.0.0"
   },
@@ -63,7 +62,6 @@
     "precommit-test"
   ],
   "devDependencies": {
-    "ajv": "^6.5.3",
     "appium-gulp-plugins": "^5.1.1",
     "appium-ios-simulator": "^3.10.0",
     "chai": "^4.1.2",


### PR DESCRIPTION
We still need to use version 4 of this module until appium-ios-driver is fully deprecated, so it makes sense to get rid of the deprecated modules that it is using