### PR TITLE
docs: add an example for simulator in development notes

### DIFF
--- a/development-notes.md
+++ b/development-notes.md
@@ -33,3 +33,19 @@ to a file with the same name, but the added `.original` suffix.
 
 Running the utility again will use `socat` to catch the communication between
 the Safari Web Inspector and the simulator, and print it to standard output.
+
+## Example for a simulator
+
+```
+$ lsof -aUc launchd_sim # to find a path of com.apple.webinspectord_sim.socket.
+# e.g. "/private/tmp/com.apple.launchd.7J8c2aiVxG/com.apple.webinspectord_sim.socket" was found
+$ mv /private/tmp/com.apple.launchd.7J8c2aiVxG/com.apple.webinspectord_sim.socket /private/tmp/com.apple.launchd.7J8c2aiVxG/com.apple.webinspectord_sim.socket.original
+$ socat -t100 -x -v UNIX-LISTEN:/private/tmp/com.apple.launchd.7J8c2aiVxG/com.apple.webinspectord_sim.socket,mode=777,reuseaddr,fork UNIX-CONNECT:/private/tmp/com.apple.launchd.7J8c2aiVxG/com.apple.webinspectord_sim.socket.original
+# Open safari and its Web Inspector with a simulator's web page.
+# Then, the communication protocol appears
+```
+
+```
+$ npm run inspect-safari 8442C4CD-77B5-4764-A1F9-AABC7AD26209
+# Open Safari and its Web Inspector. Then, JSON formatted communication appeard.
+```

--- a/development-notes.md
+++ b/development-notes.md
@@ -41,11 +41,11 @@ $ lsof -aUc launchd_sim # to find a path of com.apple.webinspectord_sim.socket.
 # e.g. "/private/tmp/com.apple.launchd.7J8c2aiVxG/com.apple.webinspectord_sim.socket" was found
 $ mv /private/tmp/com.apple.launchd.7J8c2aiVxG/com.apple.webinspectord_sim.socket /private/tmp/com.apple.launchd.7J8c2aiVxG/com.apple.webinspectord_sim.socket.original
 $ socat -t100 -x -v UNIX-LISTEN:/private/tmp/com.apple.launchd.7J8c2aiVxG/com.apple.webinspectord_sim.socket,mode=777,reuseaddr,fork UNIX-CONNECT:/private/tmp/com.apple.launchd.7J8c2aiVxG/com.apple.webinspectord_sim.socket.original
-# Open safari and its Web Inspector with a simulator's web page.
+# Open Safari and its Web Inspector with a simulator's web page.
 # Then, the communication protocol appears
 ```
 
 ```
 $ npm run inspect-safari 8442C4CD-77B5-4764-A1F9-AABC7AD26209
-# Open Safari and its Web Inspector. Then, JSON formatted communication appeard.
+# Open Safari and its Web Inspector. Then, JSON formatted communication appears.
 ```


### PR DESCRIPTION
Related to https://github.com/appium/appium-remote-debugger/pull/274

Then, you can find Web Inspector's protocol like:

```
{
  "__argument": {
    "WIRApplicationIdentifierKey": "PID:2447",
    "WIRMessageDataTypeKey": "WIRMessageDataTypeFull",
    "WIRDestinationKey": "8B7C5766-E28E-478B-B62E-D2B2F6B0E16B",
    "WIRMessageDataKey": "{\"method\":\"Target.dispatchMessageFromTarget\",\"params\":{\"targetId\":\"page-11\",\"message\":\"{\\\"method\\\":\\\"Debugger.scriptParsed\\\",\\\"params\\\":{\\\"scriptId\\\":\\\"41\\\",\\\"url\\\":\\\"https://apis.google.com/_/scs/abc-static/_/js/k=gapi.gapi.en.PlpnwD4HYro.O/m=gapi_iframes,googleapis_client/rt=j/sv=1/d=1/ed=1/rs=AHpOoo-D4573md5GmdJHX15d0lc3SoObhA/cb=gapi.loaded_0\\\",\\\"startLine\\\":0,\\\"startColumn\\\":0,\\\"endLine\\\":353,\\\"endColumn\\\":0,\\\"isContentScript\\\":false,\\\"module\\\":false}}\"}}"
  },
  "__selector": "_rpc_applicationSentData:"
}
{
  "__argument": {
    "WIRApplicationIdentifierKey": "PID:2447",
    "WIRMessageDataTypeKey": "WIRMessageDataTypeFull",
    "WIRDestinationKey": "8B7C5766-E28E-478B-B62E-D2B2F6B0E16B",
    "WIRMessageDataKey": "{\"method\":\"Target.dispatchMessageFromTarget\",\"params\":{\"targetId\":\"page-11\",\"message\":\"{\\\"method\\\":\\\"Debugger.scriptParsed\\\",\\\"params\\\":{\\\"scriptId\\\":\\\"32\\\",\\\"url\\\":\\\"https://www.google.com/?client=safari&channel=iphone_bm\\\",\\\"startLine\\\":0,\\\"startColumn\\\":4514,\\\"endLine\\\":25,\\\"endColumn\\\":759,\\\"isContentScript\\\":false,\\\"module\\\":false}}\"}}"
  },
  "__selector": "_rpc_applicationSentData:"
}
```