### PR TITLE
fix: fix scripts for atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The steps to using the `RemoteDebugger` involve instantiating an object, then ru
 
 The remote debugger uses the standard [Selenium Atoms](https://github.com/SeleniumHQ/selenium/tree/master/javascript/atoms)
 to interact with web pages. These need to be manually updated when necessary. To
-do so, simply update the branch in the `gulpfile`, by modifying the `SELENIUM_BRANCH`
+do so, simply update the branch in the `scripts/common.js`, by modifying the `SELENIUM_BRANCH`
 constant at the top of the file. Then run `npm run build:atoms`, test and create
 a pull request with the resulting changed atoms directory.
 

--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
     "test": "mocha --exit --timeout 1m \"./test/unit/**/*-specs.js\"",
     "e2e-test": "mocha --exit --timeout 1m \"./test/functional/**/*-specs.js\"",
     "inspect-safari": "node build/bin/web_inspector_proxy.js",
-    "build:atoms": "babel --out-dir=build/scripts scripts && node build/scripts/build-atoms.js",
-    "build:atoms:import": "babel --out-dir=build/scripts scripts && node build/scripts/import-atoms.js",
-    "build:selenium": "babel --out-dir=build/scripts scripts && node build/scripts/build-selenium.js"
+    "build:atoms": "node scripts/build-atoms.js",
+    "build:atoms:import": "node scripts/import-atoms.js",
+    "build:selenium": "node scripts/build-selenium.js"
   },
   "pre-commit": [
     "precommit-msg",

--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
     "test": "mocha --exit --timeout 1m \"./test/unit/**/*-specs.js\"",
     "e2e-test": "mocha --exit --timeout 1m \"./test/functional/**/*-specs.js\"",
     "inspect-safari": "node build/bin/web_inspector_proxy.js",
-    "build:atoms": "node scripts/build-atoms.js",
-    "build:atoms:import": "node scripts/import-atoms.js",
-    "build:selenium": "node scripts/build-selenium.js"
+    "build:atoms": "babel --out-dir=build/scripts scripts && node build/scripts/build-atoms.js",
+    "build:atoms:import": "babel --out-dir=build/scripts scripts && node build/scripts/import-atoms.js",
+    "build:selenium": "babel --out-dir=build/scripts scripts && node build/scripts/build-selenium.js"
   },
   "pre-commit": [
     "precommit-msg",

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -8,7 +8,7 @@ const B = require('bluebird');
 const SELENIUM_BRANCH = 'selenium-3.141.59';
 const SELENIUM_GITHUB = 'https://github.com/SeleniumHQ/selenium.git';
 
-const WORKING_ROOT_DIR = path.resolve(__dirname, '..', '..');
+const WORKING_ROOT_DIR = path.resolve(__dirname, '..');
 const TMP_DIRECTORY = path.resolve(WORKING_ROOT_DIR, 'tmp');
 const SELENIUM_DIRECTORY = path.resolve(TMP_DIRECTORY, 'selenium');
 const ATOMS_DIRECTORY = path.resolve(WORKING_ROOT_DIR, 'atoms');
@@ -72,7 +72,7 @@ async function seleniumClean () {
   await rmDir(SELENIUM_DIRECTORY);
 }
 
-export async function seleniumClone () {
+module.exports.seleniumClone = async function seleniumClone () {
   await seleniumMkdir();
   await seleniumClean();
   log(`Cloning branch '${SELENIUM_BRANCH}' from '${SELENIUM_GITHUB}'`);
@@ -83,7 +83,7 @@ export async function seleniumClone () {
     SELENIUM_GITHUB,
     SELENIUM_DIRECTORY,
   ]);
-}
+};
 
 async function atomsCleanDir () {
   log(`Cleaning '${ATOMS_DIRECTORY}'`);
@@ -167,12 +167,11 @@ async function atomsCopy () {
     return true;
   };
 
-  const copyTarget = glob.sync('**/*.js', {
+  const filesToCopy = (await (B.promisify(glob)('**/*.js', {
     absolute: true,
     strict: false,
     cwd: SELENIUM_DIRECTORY,
-  });
-  const filesToCopy = copyTarget.filter(doesPathMatch);
+  }))).filter(doesPathMatch);
   if (filesToCopy.length) {
     await B.all(filesToCopy.map((p) => fs.promises.copyFile(
       p, path.join(ATOMS_DIRECTORY, path.basename(p))
@@ -185,7 +184,7 @@ async function atomsTimestamp () {
   await fs.promises.writeFile(LAST_UPDATE_FILE, Buffer.from(`${new Date()}\n\n${stdout}`));
 }
 
-export async function importAtoms() {
+module.exports.importAtoms = async function importAtoms() {
   await atomsCleanDir();
   await atomsClean();
   await atomsMkdir();
@@ -193,4 +192,4 @@ export async function importAtoms() {
   await atomsBuildFragments();
   await atomsCopy();
   await atomsTimestamp();
-}
+};

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -152,8 +152,6 @@ async function atomsBuildFragments () {
 
 async function atomsCopy () {
   const doesPathMatch = (p) => {
-    console.log(p);
-
     const dirname = path.dirname(p);
     if (![
       'build/javascript/atoms/fragments',

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -8,10 +8,11 @@ const B = require('bluebird');
 const SELENIUM_BRANCH = 'selenium-3.141.59';
 const SELENIUM_GITHUB = 'https://github.com/SeleniumHQ/selenium.git';
 
-const TMP_DIRECTORY = path.resolve(__dirname, 'tmp');
+const WORKING_ROOT_DIR = path.resolve(__dirname, '..', '..');
+const TMP_DIRECTORY = path.resolve(WORKING_ROOT_DIR, 'tmp');
 const SELENIUM_DIRECTORY = path.resolve(TMP_DIRECTORY, 'selenium');
-const ATOMS_DIRECTORY = path.resolve(__dirname, 'atoms');
-const ATOMS_BUILD_DIRECTORY = path.resolve(__dirname, 'atoms_build_dir');
+const ATOMS_DIRECTORY = path.resolve(WORKING_ROOT_DIR, 'atoms');
+const ATOMS_BUILD_DIRECTORY = path.resolve(WORKING_ROOT_DIR, 'atoms_build_dir');
 const LAST_UPDATE_FILE = path.resolve(ATOMS_DIRECTORY, 'lastupdate');
 
 const TEMP_BUILD_DIRECTORY_NAME = 'appium-atoms-driver';
@@ -151,6 +152,8 @@ async function atomsBuildFragments () {
 
 async function atomsCopy () {
   const doesPathMatch = (p) => {
+    console.log(p);
+
     const dirname = path.dirname(p);
     if (![
       'build/javascript/atoms/fragments',
@@ -166,11 +169,12 @@ async function atomsCopy () {
     return true;
   };
 
-  const filesToCopy = (await glob('**/*.js', {
+  const copyTarget = glob.sync('**/*.js', {
     absolute: true,
     strict: false,
     cwd: SELENIUM_DIRECTORY,
-  })).filter(doesPathMatch);
+  });
+  const filesToCopy = copyTarget.filter(doesPathMatch);
   if (filesToCopy.length) {
     await B.all(filesToCopy.map((p) => fs.promises.copyFile(
       p, path.join(ATOMS_DIRECTORY, path.basename(p))


### PR DESCRIPTION
Fixed scripts associated with atoms as minimal way so that `npm run build:atoms` can generate atoms as same as previously.

This won't include more changes in `scripts` for now to keep the change minimal.