### PR TITLE
chore: add commands for Page

### DIFF
--- a/lib/protocol/index.js
+++ b/lib/protocol/index.js
@@ -132,12 +132,26 @@ const COMMANDS = {
   //#region PAGE DOMAIN
   'Page.enable': [],
   'Page.disable': [],
-  'Page.reload': [],
+  'Page.reload': ['ignoreCache', 'revalidateAllResources'],
   'Page.navigate': ['url'],
   'Page.overrideUserAgent': ['value'],
-  'Page.getCookies': ['urls'],
+  'Page.overrideSetting': ['setting', 'value'],
+  'Page.overrideUserPreference': ['name', 'value'],
+  'Page.getCookies': [],
+  'Page.setCookie': ['cookies'],
   'Page.deleteCookie': ['cookieName', 'url'],
   'Page.getResourceTree': [],
+  'Page.getResourceContent': ['frameId', 'url'],
+  'Page.searchInResource': ['frameId', 'url', 'query', 'caseSensitive', 'isRegex', 'requestId'],
+  'Page.searchInResources': ['text', 'caseSensitive', isRegex],
+  'Page.setShowRulers': ['result'],
+  'Page.setShowPaintRects': ['result'],
+  'Page.setEmulatedMedia': ['media'],
+  'Page.snapshotNode': ['nodeId'],
+  'Page.snapshotRect': ['x', 'y', 'with', 'height', 'coordinateSystem'],
+  'Page.archive': ['data'],
+  'Page.setScreenSizeOverride': ['width', 'height'],
+
   //#endregion
 
   // https://github.com/WebKit/WebKit/blob/main/Source/JavaScriptCore/inspector/protocol/Runtime.json

--- a/lib/protocol/index.js
+++ b/lib/protocol/index.js
@@ -138,7 +138,7 @@ const COMMANDS = {
   'Page.overrideSetting': ['setting', 'value'],
   'Page.overrideUserPreference': ['name', 'value'],
   'Page.getCookies': [],
-  'Page.setCookie': ['cookies'],
+  'Page.setCookie': ['cookie'],
   'Page.deleteCookie': ['cookieName', 'url'],
   'Page.getResourceTree': [],
   'Page.getResourceContent': ['frameId', 'url'],

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -208,6 +208,7 @@ class RemoteDebugger extends EventEmitter {
     return this._allowNavigationWithoutReload;
   }
 
+  // Potentially this does not work for mobile safari
   async overrideUserAgent (value) {
     log.debug('Setting overrideUserAgent');
     return await this.rpcClient.send('Page.overrideUserAgent', {
@@ -226,7 +227,7 @@ class RemoteDebugger extends EventEmitter {
   }
 
   async setCookie (cookie) {
-    log.debug('Setting cookies');
+    log.debug('Setting cookie');
     return await this.rpcClient.send('Page.setCookie', {
       appIdKey: this.appIdKey,
       pageIdKey: this.pageIdKey,

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -208,6 +208,15 @@ class RemoteDebugger extends EventEmitter {
     return this._allowNavigationWithoutReload;
   }
 
+  async overrideUserAgent (value) {
+    log.debug('Setting overrideUserAgent');
+    return await this.rpcClient.send('Page.overrideUserAgent', {
+      appIdKey: this.appIdKey,
+      pageIdKey: this.pageIdKey,
+      value
+    });
+  }
+
   async getCookies () {
     log.debug('Getting cookies');
     return await this.rpcClient.send('Page.getCookies', {

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -225,12 +225,12 @@ class RemoteDebugger extends EventEmitter {
     });
   }
 
-  async setCookies (cookies) {
+  async setCookie (cookie) {
     log.debug('Setting cookies');
     return await this.rpcClient.send('Page.setCookie', {
       appIdKey: this.appIdKey,
       pageIdKey: this.pageIdKey,
-      cookies
+      cookie
     });
   }
 

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -208,12 +208,20 @@ class RemoteDebugger extends EventEmitter {
     return this._allowNavigationWithoutReload;
   }
 
-  async getCookies (urls) {
+  async getCookies () {
     log.debug('Getting cookies');
     return await this.rpcClient.send('Page.getCookies', {
       appIdKey: this.appIdKey,
+      pageIdKey: this.pageIdKey
+    });
+  }
+
+  async setCookies (cookies) {
+    log.debug('Setting cookies');
+    return await this.rpcClient.send('Page.setCookie', {
+      appIdKey: this.appIdKey,
       pageIdKey: this.pageIdKey,
-      urls,
+      cookies
     });
   }
 


### PR DESCRIPTION
Added all available commands in `Page` from https://github.com/WebKit/WebKit/blob/main/Source/JavaScriptCore/inspector/protocol/Page.json

Current getCookies does not have any input in xcuitest https://github.com/appium/appium-xcuitest-driver/blob/85833718a898c46c3dc2c96769dfd18608bb37bc/lib/commands/cookies.js. Tge Page definition as well, so maybe current remote debgger was wrongly sent null (but it does not matter), maybe.


`overrideUserAgent` probably can be used.

I haven't tested these yet.


Maybe we should move commands related to Page into another file for Page for readability, but this does not include such things.

---


https://github.com/appium/appium-xcuitest-driver/compare/add-some-remotedebugger?expand=1 is an example in the xcuitest driver repository