### PR TITLE
chore: Improve error messages on missing params

### DIFF
--- a/lib/mixins/execute.js
+++ b/lib/mixins/execute.js
@@ -118,7 +118,12 @@ async function execute (command, override) {
     await this.waitForDom();
   }
 
-  checkParams({appIdKey: this.appIdKey, pageIdKey: this.pageIdKey});
+  if (_.isNil(this.appIdKey)) {
+    throw new Error('Missing parameter: appIdKey. Is the target web application still alive?');
+  }
+  if (_.isNil(this.pageIdKey)) {
+    throw new Error('Missing parameter: pageIdKey. Is the target web page still alive?');
+  }
 
   if (this.garbageCollectOnExecute) {
     await this.garbageCollect();


### PR DESCRIPTION
I can observe these param values are reset if the target web app/page crashes or is closed unexpectedly. Updated error messages might help one to find the cause. See https://dev.azure.com/AppiumCI/7a2a2919-d2b4-4720-a6c3-3a639f9bb2e0/_apis/build/builds/24988/logs/142 for an example of such crash