### PR TITLE
ci: bump up ios versions, device, xcode and macos version under test

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -7,14 +7,14 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: macos-11
-          xcode: '13.2'
-          ios: '15.2'
-          device: iPhone 11
-        - os: macos-11
-          xcode: '12.5'
-          ios: '14.5'
-          device: iPhone 11
+        - os: macos-13
+          xcode: '15.0.1'
+          ios: '17.0'
+          device: iPhone 14
+        - os: macos-13
+          xcode: '14.3.1'
+          ios: '16.4'
+          device: iPhone 14
     runs-on: ${{ matrix.os }}
     env:
       PLATFORM_VERSION: ${{ matrix.ios }}

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         include:
         - os: macos-13
-          xcode: '15.0.1'
+          xcode: '15.1'
           ios: '17.2'
           device: iPhone 14
         - os: macos-13

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -9,7 +9,7 @@ jobs:
         include:
         - os: macos-13
           xcode: '15.0.1'
-          ios: '17.0'
+          ios: '17.2'
           device: iPhone 14
         - os: macos-13
           xcode: '14.3.1'

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -7,11 +7,11 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: macos-13
+        - os: macos-13-arm64
           xcode: '15.0.1'
           ios: '17.0'
           device: iPhone 14
-        - os: macos-13
+        - os: macos-13-arm64
           xcode: '14.3.1'
           ios: '16.4'
           device: iPhone 14

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -7,11 +7,11 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: macos-13-arm64
+        - os: macos-13
           xcode: '15.0.1'
           ios: '17.0'
           device: iPhone 14
-        - os: macos-13-arm64
+        - os: macos-13
           xcode: '14.3.1'
           ios: '16.4'
           device: iPhone 14


### PR DESCRIPTION
although I'm not familiar with GitHub actions, updated based on https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode


<!--
## memo
- macos images seem to have 14 GB of RAM
    - https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-->