### PR TITLE
fix: Properly log retries count

### DIFF
--- a/lib/mixins/connect.js
+++ b/lib/mixins/connect.js
@@ -184,8 +184,9 @@ async function searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
   const bundleIds = this.includeSafari && !this.isSafari
     ? [this.bundleId, ...this.additionalBundleIds, SAFARI_BUNDLE_ID]
     : [this.bundleId, ...this.additionalBundleIds];
+  let retryCount = 0;
   try {
-    return await retryInterval(maxTries, SELECT_APP_RETRY_SLEEP_MS, async (retryCount) => {
+    return await retryInterval(maxTries, SELECT_APP_RETRY_SLEEP_MS, async () => {
       if (!this.rpcClient) {
         throw new Error('rpcClient is undefined. Is the debugger connected?');
       }
@@ -230,7 +231,7 @@ async function searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
       }
       retryCount++;
       throw new Error('Failed to find an app to select');
-    }, 0);
+    });
   } catch (ign) {
     log.errorAndThrow(`Could not connect to a valid app after ${maxTries} tries.`);
   }


### PR DESCRIPTION
Currently the value of retryCount is always 0