### PR TITLE
chore: return timeout error

### DIFF
--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -213,8 +213,7 @@ async function navToUrl (url) {
         `within ${CONSOLE_ENABLEMENT_TIMEOUT_MS}ms. This might be an Inspector bug.`
       );
       throw new errors.TimeoutError(`Could not enable console events after the page load within ` +
-        `${CONSOLE_ENABLEMENT_TIMEOUT_MS}ms. The Web Inspector/Safari may need to be restarted. ` +
-        `Original error: ${err.message}`);
+        `${CONSOLE_ENABLEMENT_TIMEOUT_MS}ms. The Web Inspector/Safari may need to be restarted.`);
     } else {
       throw err;
     }

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -4,6 +4,7 @@ import events from './events';
 import { timing, util } from '@appium/support';
 import _ from 'lodash';
 import B from 'bluebird';
+import { errors } from '@appium/base-driver';
 
 const DEFAULT_PAGE_READINESS_TIMEOUT_MS = 20 * 1000;
 const PAGE_READINESS_CHECK_INTERVAL_MS = 50;
@@ -211,6 +212,8 @@ async function navToUrl (url) {
         `Could not enable console events on the page '${this.pageIdKey}' (app '${this.appIdKey}') ` +
         `within ${CONSOLE_ENABLEMENT_TIMEOUT_MS}ms. This might be an Inspector bug.`
       );
+      throw new errors.TimeoutError('Could not enable console event after the page load. ' +
+        'The Web Inspector/Safari may need to be restarted.');
     } else {
       throw err;
     }

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -8,7 +8,7 @@ import { errors } from '@appium/base-driver';
 
 const DEFAULT_PAGE_READINESS_TIMEOUT_MS = 20 * 1000;
 const PAGE_READINESS_CHECK_INTERVAL_MS = 50;
-const CONSOLE_ENABLEMENT_TIMEOUT_MS = 1000;
+const CONSOLE_ENABLEMENT_TIMEOUT_MS = 20 * 1000;
 
 /**
  * @this {import('../remote-debugger').RemoteDebugger}
@@ -212,8 +212,9 @@ async function navToUrl (url) {
         `Could not enable console events on the page '${this.pageIdKey}' (app '${this.appIdKey}') ` +
         `within ${CONSOLE_ENABLEMENT_TIMEOUT_MS}ms. This might be an Inspector bug.`
       );
-      throw new errors.TimeoutError('Could not enable console event after the page load. ' +
-        'The Web Inspector/Safari may need to be restarted.');
+      throw new errors.TimeoutError(`Could not enable console events after the page load within ` +
+        `${CONSOLE_ENABLEMENT_TIMEOUT_MS}ms. The Web Inspector/Safari may need to be restarted. ` +
+        `Original error: ${err.message}`);
     } else {
       throw err;
     }


### PR DESCRIPTION
It did a few more tests.
Then, once this timeout occurs, `driver.title` etc also no longer gets a response. So, maybe it would be helpful to notify if an error occurred explicitly as the response for users so that they can end the session or restart the Safari process rather than silently fail and wait for long response time without any response (and eventually should kill the session or appium process)