### PR TITLE
chore: Perform URL validation

### DIFF
--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -130,6 +130,11 @@ async function navToUrl (url) {
   if (!this.rpcClient) {
     throw new Error('rpcClient is undefined. Is the debugger connected?');
   }
+  try {
+    new URL(url);
+  } catch (e) {
+    throw new TypeError(`'${url}' is not a valid URL`);
+  }
 
   this._navigatingToPage = true;
   log.debug(`Navigating to new URL: '${url}'`);


### PR DESCRIPTION
Currently no URL validation is performed, which makes the remote debugger to wait for a page until timeout happens if the given URL is invalid. This PR fixes that