### PR TITLE
fix: Select all available app ids for the given bundle name

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -145,23 +145,23 @@ function getDebuggerAppKey (bundleId, appDict) {
  *
  * @param {string} bundleId
  * @param {Record<string, any>} appDict
- * @returns {string|undefined}
+ * @returns {string[]}
  */
-function appIdForBundle (bundleId, appDict) {
-  let appId;
+function appIdsForBundle (bundleId, appDict) {
+  /** @type {Set<string>} */
+  const appIds = new Set();
   for (const [key, data] of _.toPairs(appDict)) {
     if (data.bundleId.endsWith(bundleId)) {
-      appId = key;
-      break;
+      appIds.add(key);
     }
   }
 
   // if nothing is found, try to get the generic app
-  if (!appId && bundleId !== WEB_CONTENT_BUNDLE_ID) {
-    return appIdForBundle(WEB_CONTENT_BUNDLE_ID, appDict);
+  if (appIds.size === 0 && bundleId !== WEB_CONTENT_BUNDLE_ID) {
+    return appIdsForBundle(WEB_CONTENT_BUNDLE_ID, appDict);
   }
 
-  return appId;
+  return Array.from(appIds);
 }
 
 /**
@@ -176,7 +176,6 @@ function getPossibleDebuggerAppKeys(bundleIds, appDict) {
     log.debug('Skip checking bundle identifiers because the bundleIds includes a wildcard');
     return _.uniq(Object.keys(appDict));
   }
-  let proxiedAppIds = [];
 
   // go through the possible bundle identifiers
   const possibleBundleIds = _.uniq([
@@ -188,24 +187,24 @@ function getPossibleDebuggerAppKeys(bundleIds, appDict) {
     ...bundleIds,
   ]);
   log.debug(`Checking for bundle identifiers: ${possibleBundleIds.join(', ')}`);
+  /** @type {Set<string>} */
+  const proxiedAppIds = new Set();
   for (const bundleId of possibleBundleIds) {
-    const appId = appIdForBundle(bundleId, appDict);
-
     // now we need to determine if we should pick a proxy for this instead
-    if (appId) {
-      proxiedAppIds.push(appId);
+    for (const appId of appIdsForBundle(bundleId, appDict)) {
+      proxiedAppIds.add(appId);
       log.debug(`Found app id key '${appId}' for bundle '${bundleId}'`);
       for (const [key, data] of _.toPairs(appDict)) {
         if (data.isProxy && data.hostId === appId) {
           log.debug(`Found separate bundleId '${data.bundleId}' ` +
                     `acting as proxy for '${bundleId}', with app id '${key}'`);
-          proxiedAppIds.push(key);
+          proxiedAppIds.add(key);
         }
       }
     }
   }
 
-  return _.uniq(proxiedAppIds);
+  return Array.from(proxiedAppIds);
 }
 
 function checkParams (params) {


### PR DESCRIPTION
```
dbug RemoteDebugger Current applications available:
dbug RemoteDebugger     Application: "PID:28725"
dbug RemoteDebugger         id: "PID:28725"
dbug RemoteDebugger         isProxy: false
dbug RemoteDebugger         name: "com.apple.WebKit.WebContent"
dbug RemoteDebugger         bundleId: "process-com.apple.WebKit.WebContent"
dbug RemoteDebugger         hostId: undefined
dbug RemoteDebugger         isActive: true
dbug RemoteDebugger         isAutomationEnabled: "Unknown"
dbug RemoteDebugger     Application: "PID:28685"
dbug RemoteDebugger         id: "PID:28685"
dbug RemoteDebugger         isProxy: false
dbug RemoteDebugger         name: "com.apple.WebKit.WebContent"
dbug RemoteDebugger         bundleId: "process-com.apple.WebKit.WebContent"
dbug RemoteDebugger         hostId: undefined
dbug RemoteDebugger         isActive: true
dbug RemoteDebugger         isAutomationEnabled: "Unknown"
dbug RemoteDebugger     Application: "PID:28677"
dbug RemoteDebugger         id: "PID:28677"
dbug RemoteDebugger         isProxy: false
dbug RemoteDebugger         name: "Safari"
dbug RemoteDebugger         bundleId: "com.apple.mobilesafari"
dbug RemoteDebugger         hostId: undefined
dbug RemoteDebugger         isActive: true
dbug RemoteDebugger         isAutomationEnabled: true
dbug RemoteDebugger     Application: "PID:28566"
dbug RemoteDebugger         id: "PID:28566"
dbug RemoteDebugger         isProxy: false
dbug RemoteDebugger         name: "amsengagementd"
dbug RemoteDebugger         bundleId: "com.apple.amsengagementd"
dbug RemoteDebugger         hostId: undefined
dbug RemoteDebugger         isActive: false
dbug RemoteDebugger         isAutomationEnabled: "Unknown"
```

As you could see in the above dict the `process-com.apple.WebKit.WebContent` bundle has two PIDs. The previous logic would only choose the first one