### PR TITLE
fix: Improve page load detection logic

### DIFF
--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -102,14 +102,16 @@ async function waitForDom (startPageLoadTimer) {
 
 /**
  * @this {import('../remote-debugger').RemoteDebugger}
+ * @param {number} [timeoutMs]
  * @returns {Promise<boolean>}
  */
-async function checkPageIsReady () {
+async function checkPageIsReady (timeoutMs) {
   checkParams({appIdKey: this.appIdKey});
 
   const readyCmd = 'document.readyState;';
   try {
-    const readyState = await B.resolve(this.execute(readyCmd, true)).timeout(this.pageReadyTimeout);
+    const readyState = await B.resolve(this.execute(readyCmd, true))
+      .timeout(timeoutMs ?? this.pageReadyTimeout);
     log.debug(`Document readyState is '${readyState}'`);
     return readyState === 'complete';
   } catch (err) {
@@ -187,7 +189,7 @@ async function navToUrl (url) {
       do {
         const pageReadyCheckStart = new timing.Timer().start();
         try {
-          const isReady = await this.checkPageIsReady();
+          const isReady = await this.checkPageIsReady(PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS);
           if (isReady && isPageLoading && onPageLoaded) {
             return onPageLoaded();
           }

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -186,7 +186,7 @@ async function navToUrl (url) {
     // and start sending `document.readyState` requests until we either succeed or
     // another event/timeout happens
     onDefaultUserPreferencesDidChange = async () => {
-      do {
+      while (isPageLoading) {
         const pageReadyCheckStart = new timing.Timer().start();
         try {
           const isReady = await this.checkPageIsReady(PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS);
@@ -194,11 +194,11 @@ async function navToUrl (url) {
             return onPageLoaded();
           }
         } catch (ign) {}
-        const msLeft = PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS - pageReadyCheckStart.getDuration().asSeconds;
+        const msLeft = PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS - pageReadyCheckStart.getDuration().asMilliSeconds;
         if (msLeft > 0 && isPageLoading) {
           await B.delay(msLeft);
         }
-      } while (isPageLoading);
+      }
     };
     this.rpcClient?.once('Page.defaultUserPreferencesDidChange', onDefaultUserPreferencesDidChange);
 

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -8,6 +8,7 @@ import { errors } from '@appium/base-driver';
 
 const DEFAULT_PAGE_READINESS_TIMEOUT_MS = 20 * 1000;
 const PAGE_READINESS_CHECK_INTERVAL_MS = 50;
+const PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS = 1000;
 const CONSOLE_ENABLEMENT_TIMEOUT_MS = 20 * 1000;
 
 /**
@@ -141,6 +142,8 @@ async function navToUrl (url) {
   const readinessTimeoutMs = this.pageLoadMs || DEFAULT_PAGE_READINESS_TIMEOUT_MS;
   /** @type {(() => void)|undefined} */
   let onPageLoaded;
+  /** @type {(() => void)|undefined} */
+  let onDefaultUserPreferencesDidChange;
   /** @type {NodeJS.Timeout|undefined|null} */
   let onPageLoadedTimeout;
   this.pageLoadDelay = util.cancellableDelay(readinessTimeoutMs);
@@ -176,6 +179,26 @@ async function navToUrl (url) {
     };
     // https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-loadEventFired
     this.rpcClient?.once('Page.loadEventFired', onPageLoaded);
+    // Pages that have no proper DOM structure do not fire the Page.loadEventFired event
+    // so we rely on the very first event after target change, which is Page.defaultUserPreferencesDidChange
+    // and start sending `document.readyState` requests until we either succeed or
+    // another event/timeout happens
+    onDefaultUserPreferencesDidChange = async () => {
+      do {
+        const pageReadyCheckStart = new timing.Timer().start();
+        try {
+          const isReady = await this.checkPageIsReady();
+          if (isReady && isPageLoading && onPageLoaded) {
+            return onPageLoaded();
+          }
+        } catch (ign) {}
+        const msLeft = PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS - pageReadyCheckStart.getDuration().asSeconds;
+        if (msLeft > 0 && isPageLoading) {
+          await B.delay(msLeft);
+        }
+      } while (isPageLoading);
+    };
+    this.rpcClient?.once('Page.defaultUserPreferencesDidChange', onDefaultUserPreferencesDidChange);
 
     this.rpcClient?.send('Page.navigate', {
       url,
@@ -200,6 +223,9 @@ async function navToUrl (url) {
     if (onPageLoadedTimeout && pageReadinessPromise.isFulfilled()) {
       clearTimeout(onPageLoadedTimeout);
       onPageLoadedTimeout = null;
+    }
+    if (onDefaultUserPreferencesDidChange) {
+      this.rpcClient.off('Page.defaultUserPreferencesDidChange', onDefaultUserPreferencesDidChange);
     }
     if (onPageLoaded) {
       this.rpcClient.off('Page.loadEventFired', onPageLoaded);

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -228,7 +228,7 @@ async function navToUrl (url) {
       onPageLoadedTimeout = null;
     }
     if (onTargetProvisioned) {
-      this.rpcClient.targetSubscriptions.off('Page.defaultUserPreferencesDidChange', onTargetProvisioned);
+      this.rpcClient.targetSubscriptions.off(rpcConstants.ON_TARGET_PROVISIONED_EVENT, onTargetProvisioned);
     }
     if (onPageLoaded) {
       this.rpcClient.off('Page.loadEventFired', onPageLoaded);

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -5,6 +5,7 @@ import { timing, util } from '@appium/support';
 import _ from 'lodash';
 import B from 'bluebird';
 import { errors } from '@appium/base-driver';
+import { rpcConstants } from '../rpc';
 
 const DEFAULT_PAGE_READINESS_TIMEOUT_MS = 20 * 1000;
 const PAGE_READINESS_CHECK_INTERVAL_MS = 50;
@@ -145,7 +146,7 @@ async function navToUrl (url) {
   /** @type {(() => void)|undefined} */
   let onPageLoaded;
   /** @type {(() => void)|undefined} */
-  let onDefaultUserPreferencesDidChange;
+  let onTargetProvisioned;
   /** @type {NodeJS.Timeout|undefined|null} */
   let onPageLoadedTimeout;
   this.pageLoadDelay = util.cancellableDelay(readinessTimeoutMs);
@@ -181,11 +182,11 @@ async function navToUrl (url) {
     };
     // https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-loadEventFired
     this.rpcClient?.once('Page.loadEventFired', onPageLoaded);
-    // Pages that have no proper DOM structure do not fire the Page.loadEventFired event
-    // so we rely on the very first event after target change, which is Page.defaultUserPreferencesDidChange
+    // Pages that have no proper DOM structure do not fire the `Page.loadEventFired` event
+    // so we rely on the very first event after target change, which is `onTargetProvisioned`
     // and start sending `document.readyState` requests until we either succeed or
     // another event/timeout happens
-    onDefaultUserPreferencesDidChange = async () => {
+    onTargetProvisioned = async () => {
       while (isPageLoading) {
         const pageReadyCheckStart = new timing.Timer().start();
         try {
@@ -200,7 +201,7 @@ async function navToUrl (url) {
         }
       }
     };
-    this.rpcClient?.once('Page.defaultUserPreferencesDidChange', onDefaultUserPreferencesDidChange);
+    this.rpcClient?.targetSubscriptions.once(rpcConstants.ON_TARGET_PROVISIONED_EVENT, onTargetProvisioned);
 
     this.rpcClient?.send('Page.navigate', {
       url,
@@ -226,8 +227,8 @@ async function navToUrl (url) {
       clearTimeout(onPageLoadedTimeout);
       onPageLoadedTimeout = null;
     }
-    if (onDefaultUserPreferencesDidChange) {
-      this.rpcClient.off('Page.defaultUserPreferencesDidChange', onDefaultUserPreferencesDidChange);
+    if (onTargetProvisioned) {
+      this.rpcClient.targetSubscriptions.off('Page.defaultUserPreferencesDidChange', onTargetProvisioned);
     }
     if (onPageLoaded) {
       this.rpcClient.off('Page.loadEventFired', onPageLoaded);

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -55,7 +55,7 @@ class RemoteDebugger extends EventEmitter {
   searchForApp;
   /** @type {(appsDict:Record<string, any>, currentUrl: string?, ignoreAboutBlankUrl: boolean) => import('./mixins/connect').AppPages?} */
   searchForPage;
-  /** @type {() => Promise<boolean>} */
+  /** @type {(timeoutMs?: number) => Promise<boolean>} */
   checkPageIsReady;
   /** @type {(dict: Record<string, any>) => void} */
   updateAppsWithDict;

--- a/lib/rpc/constants.js
+++ b/lib/rpc/constants.js
@@ -1,0 +1,1 @@
+export const ON_TARGET_PROVISIONED_EVENT = 'onTargetProvisioned';

--- a/lib/rpc/index.js
+++ b/lib/rpc/index.js
@@ -1,5 +1,6 @@
 import RpcClientSimulator from './rpc-client-simulator';
 import RpcClientRealDevice from './rpc-client-real-device';
+import * as rpcConstants from './constants';
 
 
-export { RpcClientSimulator, RpcClientRealDevice };
+export { RpcClientSimulator, RpcClientRealDevice, rpcConstants };

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -5,6 +5,8 @@ import _ from 'lodash';
 import B from 'bluebird';
 import RpcMessageHandler from './rpc-message-handler';
 import { util, timing } from '@appium/support';
+import { EventEmitter } from 'node:events';
+import { ON_TARGET_PROVISIONED_EVENT } from './constants';
 
 
 const DATA_LOG_LENGTH = {length: 200};
@@ -74,6 +76,7 @@ export default class RpcClient {
 
     this._contexts = [];
     this._targets = {};
+    this._targetSubscriptions = new EventEmitter();
 
     // start with a best guess for the protocol
     this.isTargetBased = isTargetBased(isSafari, this.platformVersion);
@@ -105,6 +108,10 @@ export default class RpcClient {
 
   set isConnected (connected) {
     this.connected = !!connected;
+  }
+
+  get targetSubscriptions() {
+    return this._targetSubscriptions;
   }
 
   on (event, listener) {
@@ -430,8 +437,20 @@ export default class RpcClient {
         if (targetId === oldTargetId) {
           log.debug(`Found provisional target for app '${app}'. Old target: '${oldTargetId}', new target: '${newTargetId}'. Updating`);
           targets[page] = newTargetId;
-          // This is needed to enable the broadcast of page lifecycle events
-          this.sendToDevice('Page.enable', {appIdKey: app, pageIdKey: parseInt(page, 10)}, false);
+          const opts = {appIdKey: app, pageIdKey: parseInt(page, 10)};
+          (async () => {
+            try {
+              // This is needed to enable the broadcast of page lifecycle events
+              await this.sendToDevice('Page.enable', opts, true);
+            } catch (err) {
+              log.warn(err.message);
+            }
+            this._targetSubscriptions.emit(ON_TARGET_PROVISIONED_EVENT, {
+              ...opts,
+              oldTargetId,
+              targetId: newTargetId,
+            });
+          })();
           return;
         }
       }


### PR DESCRIPTION
I've noticed we always experience page load timeouts for web pages like WDA's /health one. The reason for it is it's actually not a real page, but just a text, so it does not trigger the `Page.loadEventFired` event  like other "normal" pages.