### PR TITLE
feat: support pageLoadStrategy in readState check

### DIFF
--- a/lib/mixins/connect.js
+++ b/lib/mixins/connect.js
@@ -192,7 +192,7 @@ async function searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
       }
 
       logApplicationDictionary(this.appDict);
-      const possibleAppIds = getPossibleDebuggerAppKeys(bundleIds, this.appDict);
+      const possibleAppIds = getPossibleDebuggerAppKeys(/** @type {string[]} */ (bundleIds), this.appDict);
       log.debug(`Trying out the possible app ids: ${possibleAppIds.join(', ')} (try #${retryCount + 1} of ${maxTries})`);
       for (const attemptedAppIdKey of possibleAppIds) {
         try {
@@ -353,7 +353,7 @@ function updateAppsWithDict (dict) {
 
   // try to get the app id from our connected apps
   if (!this.appIdKey) {
-    this.appIdKey = getDebuggerAppKey(this.bundleId, this.appDict);
+    this.appIdKey = getDebuggerAppKey(/** @type {string} */ (this.bundleId), this.appDict);
   }
 }
 

--- a/lib/mixins/message-handlers.js
+++ b/lib/mixins/message-handlers.js
@@ -97,7 +97,7 @@ function onAppDisconnect (err, dict) {
   // if the disconnected app is the one we are connected to, try to find another
   if (this.appIdKey === appIdKey) {
     log.debug(`No longer have app id. Attempting to find new one.`);
-    this.appIdKey = getDebuggerAppKey(this.bundleId, this.appDict);
+    this.appIdKey = getDebuggerAppKey(/** @type {string} */ (this.bundleId), this.appDict);
   }
 
   if (!this.appDict) {

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -16,7 +16,7 @@ const PAGE_LOAD_STRATEGY = {
   EAGER: 'eager',
   NONE: 'none',
   NORMAL: 'normal'
-}
+};
 
 /**
  * @this {import('../remote-debugger').RemoteDebugger}

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -12,6 +12,10 @@ const PAGE_READINESS_CHECK_INTERVAL_MS = 50;
 const PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS = 1000;
 const CONSOLE_ENABLEMENT_TIMEOUT_MS = 20 * 1000;
 
+const PAGE_LOAD_EAGER = 'eager';
+const PAGE_LOAD_NONE = 'none';
+export const PAGE_LOAD_NORMAL = 'normal';
+
 /**
  * @this {import('../remote-debugger').RemoteDebugger}
  * @returns {void}
@@ -40,10 +44,15 @@ function cancelPageLoad () {
  * @returns string
  */
 function completeToLoadPage (pageLoadStrategy, readyState) {
-  if (pageLoadStrategy === 'eager') {
+  if (pageLoadStrategy === PAGE_LOAD_NONE) {
+    return true;
+  }
+
+  if (pageLoadStrategy === PAGE_LOAD_EAGER) {
     // this could include 'interactive', or 'complete'
     return readyState !== 'loading';
   }
+
   return readyState === 'complete';
 }
 
@@ -202,11 +211,6 @@ async function navToUrl (url) {
     // and start sending `document.readyState` requests until we either succeed or
     // another event/timeout happens
     onTargetProvisioned = async () => {
-      if (this.pageLoadStrategy === 'none') {
-        log.debug("none page load strategy");
-        return
-      };
-
       while (isPageLoading) {
         const pageReadyCheckStart = new timing.Timer().start();
         try {

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -41,7 +41,7 @@ function cancelPageLoad () {
  * for the given page load strategy,
  * @param {string?} pageLoadStrategy
  * @param {string} readyState
- * @returns string
+ * @returns {boolean}
  */
 function completeToLoadPage (pageLoadStrategy, readyState) {
   if (pageLoadStrategy === PAGE_LOAD_NONE) {

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -44,11 +44,12 @@ function cancelPageLoad () {
  * @returns {boolean}
  */
 function isPageLoadingCompleted (pageLoadStrategy, readyState) {
-  if (pageLoadStrategy === PAGE_LOAD_NONE) {
+  const _pageLoadStrategy = _.lowerCase(pageLoadStrategy);
+  if (_pageLoadStrategy === PAGE_LOAD_NONE) {
     return true;
   }
 
-  if (pageLoadStrategy === PAGE_LOAD_EAGER) {
+  if (_pageLoadStrategy === PAGE_LOAD_EAGER) {
     // This could include 'interactive' or 'complete'
     return readyState !== 'loading';
   }

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -14,7 +14,7 @@ const CONSOLE_ENABLEMENT_TIMEOUT_MS = 20 * 1000;
 
 const PAGE_LOAD_EAGER = 'eager';
 const PAGE_LOAD_NONE = 'none';
-export const PAGE_LOAD_NORMAL = 'normal';
+const PAGE_LOAD_NORMAL = 'normal';
 
 /**
  * @this {import('../remote-debugger').RemoteDebugger}
@@ -39,7 +39,7 @@ function cancelPageLoad () {
 /**
  * Return if current readState can be handles as page load completes
  * for the given page load strategy,
- * @param {string} pageLoadStrategy
+ * @param {string?} pageLoadStrategy
  * @param {string} readyState
  * @returns string
  */
@@ -53,6 +53,7 @@ function completeToLoadPage (pageLoadStrategy, readyState) {
     return readyState !== 'loading';
   }
 
+  // default behavior. It includes pageLoadStrategy is 'normal' as well.
   return readyState === 'complete';
 }
 
@@ -137,7 +138,8 @@ async function checkPageIsReady (timeoutMs) {
   try {
     const readyState = await B.resolve(this.execute(readyCmd, true))
       .timeout(timeoutMs ?? this.pageReadyTimeout);
-    log.debug(`Document readyState is '${readyState}'`);
+    log.debug(`Document readyState is '${readyState}'. ` +
+      `The pageLoadStrategy is '${this.pageLoadStrategy || PAGE_LOAD_NORMAL}'`);
     return completeToLoadPage(this.pageLoadStrategy, readyState);
   } catch (err) {
     if (!(err instanceof B.TimeoutError)) {

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -38,22 +38,22 @@ function cancelPageLoad () {
 
 /**
  * Return if current readState can be handles as page load completes
- * for the given page load strategy,
+ * for the given page load strategy.
  * @param {string?} pageLoadStrategy
  * @param {string} readyState
  * @returns {boolean}
  */
-function completeToLoadPage (pageLoadStrategy, readyState) {
+function isPageLoadingCompleted (pageLoadStrategy, readyState) {
   if (pageLoadStrategy === PAGE_LOAD_NONE) {
     return true;
   }
 
   if (pageLoadStrategy === PAGE_LOAD_EAGER) {
-    // this could include 'interactive', or 'complete'
+    // This could include 'interactive' or 'complete'
     return readyState !== 'loading';
   }
 
-  // default behavior. It includes pageLoadStrategy is 'normal' as well.
+  // dDefault behavior. It includes pageLoadStrategy is 'normal' as well.
   return readyState === 'complete';
 }
 
@@ -140,7 +140,7 @@ async function checkPageIsReady (timeoutMs) {
       .timeout(timeoutMs ?? this.pageReadyTimeout);
     log.debug(`Document readyState is '${readyState}'. ` +
       `The pageLoadStrategy is '${this.pageLoadStrategy || PAGE_LOAD_NORMAL}'`);
-    return completeToLoadPage(this.pageLoadStrategy, readyState);
+    return isPageLoadingCompleted(this.pageLoadStrategy, readyState);
   } catch (err) {
     if (!(err instanceof B.TimeoutError)) {
       throw err;

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -12,9 +12,11 @@ const PAGE_READINESS_CHECK_INTERVAL_MS = 50;
 const PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS = 1000;
 const CONSOLE_ENABLEMENT_TIMEOUT_MS = 20 * 1000;
 
-const PAGE_LOAD_EAGER = 'eager';
-const PAGE_LOAD_NONE = 'none';
-const PAGE_LOAD_NORMAL = 'normal';
+const PAGE_LOAD_STRATEGY = {
+  EAGER: 'eager',
+  NONE: 'none',
+  NORMAL: 'normal'
+}
 
 /**
  * @this {import('../remote-debugger').RemoteDebugger}
@@ -39,22 +41,22 @@ function cancelPageLoad () {
 /**
  * Return if current readState can be handles as page load completes
  * for the given page load strategy.
- * @param {string?} pageLoadStrategy
+ * @this {import('../remote-debugger').RemoteDebugger}
  * @param {string} readyState
  * @returns {boolean}
  */
-function isPageLoadingCompleted (pageLoadStrategy, readyState) {
-  const _pageLoadStrategy = _.lowerCase(pageLoadStrategy || PAGE_LOAD_NORMAL);
-  if (_pageLoadStrategy === PAGE_LOAD_NONE) {
+function isPageLoadingCompleted (readyState) {
+  const _pageLoadStrategy = _.toLower(this.pageLoadStrategy);
+  if (_pageLoadStrategy === PAGE_LOAD_STRATEGY.NONE) {
     return true;
   }
 
-  if (_pageLoadStrategy === PAGE_LOAD_EAGER) {
+  if (_pageLoadStrategy === PAGE_LOAD_STRATEGY.EAGER) {
     // This could include 'interactive' or 'complete'
     return readyState !== 'loading';
   }
 
-  // dDefault behavior. It includes pageLoadStrategy is 'normal' as well.
+  // Default behavior. It includes pageLoadStrategy is 'normal' as well.
   return readyState === 'complete';
 }
 
@@ -140,8 +142,8 @@ async function checkPageIsReady (timeoutMs) {
     const readyState = await B.resolve(this.execute(readyCmd, true))
       .timeout(timeoutMs ?? this.pageReadyTimeout);
     log.debug(`Document readyState is '${readyState}'. ` +
-      `The pageLoadStrategy is '${this.pageLoadStrategy || PAGE_LOAD_NORMAL}'`);
-    return isPageLoadingCompleted(this.pageLoadStrategy, readyState);
+      `The pageLoadStrategy is '${this.pageLoadStrategy || PAGE_LOAD_STRATEGY.NORMAL}'`);
+    return this.isPageLoadingCompleted(readyState);
   } catch (err) {
     if (!(err instanceof B.TimeoutError)) {
       throw err;
@@ -278,4 +280,4 @@ async function navToUrl (url) {
   }
 }
 
-export default {frameDetached, cancelPageLoad, waitForDom, checkPageIsReady, navToUrl};
+export default {frameDetached, cancelPageLoad, waitForDom, checkPageIsReady, navToUrl, isPageLoadingCompleted};

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -12,6 +12,9 @@ const PAGE_READINESS_CHECK_INTERVAL_MS = 50;
 const PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS = 1000;
 const CONSOLE_ENABLEMENT_TIMEOUT_MS = 20 * 1000;
 
+/**
+ * pageLoadStrategy in WebDriver definitions.
+ */
 const PAGE_LOAD_STRATEGY = {
   EAGER: 'eager',
   NONE: 'none',

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -44,7 +44,7 @@ function cancelPageLoad () {
  * @returns {boolean}
  */
 function isPageLoadingCompleted (pageLoadStrategy, readyState) {
-  const _pageLoadStrategy = _.lowerCase(pageLoadStrategy);
+  const _pageLoadStrategy = _.lowerCase(pageLoadStrategy || PAGE_LOAD_NORMAL);
   if (_pageLoadStrategy === PAGE_LOAD_NONE) {
     return true;
   }

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -33,6 +33,21 @@ function cancelPageLoad () {
 }
 
 /**
+ * Return if current readState can be handles as page load completes
+ * for the given page load strategy,
+ * @param {string} pageLoadStrategy
+ * @param {string} readyState
+ * @returns string
+ */
+function completeToLoadPage (pageLoadStrategy, readyState) {
+  if (pageLoadStrategy === 'eager') {
+    // this could include 'interactive', or 'complete'
+    return readyState !== 'loading';
+  }
+  return readyState === 'complete';
+}
+
+/**
  * @this {import('../remote-debugger').RemoteDebugger}
  * @param {timing.Timer|null|undefined} startPageLoadTimer
  * @returns {Promise<void>}
@@ -114,7 +129,7 @@ async function checkPageIsReady (timeoutMs) {
     const readyState = await B.resolve(this.execute(readyCmd, true))
       .timeout(timeoutMs ?? this.pageReadyTimeout);
     log.debug(`Document readyState is '${readyState}'`);
-    return readyState === 'complete';
+    return completeToLoadPage(this.pageLoadStrategy, readyState);
   } catch (err) {
     if (!(err instanceof B.TimeoutError)) {
       throw err;
@@ -187,6 +202,11 @@ async function navToUrl (url) {
     // and start sending `document.readyState` requests until we either succeed or
     // another event/timeout happens
     onTargetProvisioned = async () => {
+      if (this.pageLoadStrategy === 'none') {
+        log.debug("none page load strategy");
+        return
+      };
+
       while (isPageLoading) {
         const pageReadyCheckStart = new timing.Timer().start();
         try {

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -90,19 +90,6 @@ class RemoteDebugger extends EventEmitter {
   /** @type {(err: Error?, state: Record<string, any>) => void} */
   frameDetached;
 
-  /*
-   * The constructor takes an opts hash with the following properties:
-   *   - platformVersion -
-   *   - useNewSafari -
-   *   - pageLoadMs -
-   *   - host -
-   *   - port -
-   *   - logAllCommunication -
-   *   - logAllCommunicationHexDump -
-   *   - socketChunkSize -
-   *   - webInspectorMaxFrameLength -
-   */
-
   /**
    * @typedef {Object} RemoteDebuggerOptions
    * @property {string} [bundleId] id of the app being connected to

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -39,12 +39,16 @@ class RemoteDebugger extends EventEmitter {
   navigationDelay;
   /** @type {import('./rpc/rpc-client').default?} */
   rpcClient;
+  /** @type {string} */
+  pageLoadStrategy;
 
   // events
   /** @type {string} */
   static EVENT_PAGE_CHANGE;
   /** @type {string} */
   static EVENT_DISCONNECT;
+  /** @type {string} */
+  static EVENT_FRAMES_DETACHED;
 
   // methods
   /** @type {() => Promise<void>} */
@@ -126,6 +130,7 @@ class RemoteDebugger extends EventEmitter {
       webInspectorMaxFrameLength,
       socketChunkSize,
       fullPageInitialization,
+      pageLoadStrategy = 'normal'
     } = opts;
 
     this.bundleId = bundleId;
@@ -154,6 +159,8 @@ class RemoteDebugger extends EventEmitter {
     }
 
     this.fullPageInitialization = fullPageInitialization;
+
+    this.pageLoadStrategy = pageLoadStrategy;
 
     this._lock = new AsyncLock();
   }

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -70,6 +70,9 @@ class RemoteDebugger extends EventEmitter {
   /** @type {(command: string, args?: any[], frames?: string[]) => Promise<any>} */
   executeAtom;
 
+  /** @type {(command: string, args?: any[], frames?: string[]) => Promise<any>} */
+  completeToLoadPage;
+
   // Callbacks
   /** @type {(err: Error?, appIdKey: string, pageDict: Record<string, any>) => Promise<void>} */
   onPageChange;
@@ -130,7 +133,7 @@ class RemoteDebugger extends EventEmitter {
       webInspectorMaxFrameLength,
       socketChunkSize,
       fullPageInitialization,
-      pageLoadStrategy = 'normal'
+      pageLoadStrategy = mixins.navigate.PAGE_LOAD_NORMAL
     } = opts;
 
     this.bundleId = bundleId;

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -69,8 +69,7 @@ class RemoteDebugger extends EventEmitter {
   execute;
   /** @type {(command: string, args?: any[], frames?: string[]) => Promise<any>} */
   executeAtom;
-
-  /** @type {(pageLoadStrategy: string?, readyState: string) => boolean} */
+  /** @type {(readyState: string) => boolean} */
   isPageLoadingCompleted;
 
   // Callbacks

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -133,7 +133,7 @@ class RemoteDebugger extends EventEmitter {
       webInspectorMaxFrameLength,
       socketChunkSize,
       fullPageInitialization,
-      pageLoadStrategy = mixins.navigate.PAGE_LOAD_NORMAL
+      pageLoadStrategy
     } = opts;
 
     this.bundleId = bundleId;

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -39,7 +39,7 @@ class RemoteDebugger extends EventEmitter {
   navigationDelay;
   /** @type {import('./rpc/rpc-client').default?} */
   rpcClient;
-  /** @type {string} */
+  /** @type {string|undefined} */
   pageLoadStrategy;
 
   // events
@@ -92,19 +92,46 @@ class RemoteDebugger extends EventEmitter {
 
   /*
    * The constructor takes an opts hash with the following properties:
-   *   - bundleId - id of the app being connected to
-   *   - additionalBundleIds - array of possible bundle ids that the inspector
-   *                           could return
-   *   - platformVersion - version of iOS
-   *   - useNewSafari - for web inspector, whether this is a new Safari instance
-   *   - pageLoadMs - the time, in ms, that should be waited for page loading
-   *   - host - the remote debugger's host address
-   *   - port - the remote debugger port through which to communicate
-   *   - logAllCommunication - log plists sent and received from Web Inspector
-   *   - logAllCommunicationHexDump - log communication from Web Inspector as hex dump
-   *   - socketChunkSize - size, in bytes, of chunks of data sent to Web Inspector (real device only)
-   *   - webInspectorMaxFrameLength - The maximum size in bytes of a single data frame
-   *                                  in the device communication protocol
+   *   - platformVersion -
+   *   - useNewSafari -
+   *   - pageLoadMs -
+   *   - host -
+   *   - port -
+   *   - logAllCommunication -
+   *   - logAllCommunicationHexDump -
+   *   - socketChunkSize -
+   *   - webInspectorMaxFrameLength -
+   */
+
+  /**
+   * @typedef {Object} RemoteDebuggerOptions
+   * @property {string} [bundleId] id of the app being connected to
+   * @property {string[]} [additionalBundleIds=[]] array of possible bundle
+   *                      ids that the inspector could return
+   * @property {string} [platformVersion] version of iOS
+   * @property {boolean} [isSafari=true]
+   * @property {boolean} [includeSafari=false]
+   * @property {boolean} [useNewSafari=false] for web inspector, whether this is a new Safari instance
+   * @property {number} [pageLoadMs] the time, in ms, that should be waited for page loading
+   * @property {string} [host] the remote debugger's host address
+   * @property {number} [port=REMOTE_DEBUGGER_PORT] the remote debugger port through which to communicate
+   * @property {string} [socketPath]
+   * @property {number} [pageReadyTimeout=PAGE_READY_TIMEOUT]
+   * @property {string} [remoteDebugProxy]
+   * @property {boolean} [garbageCollectOnExecute=false]
+   * @property {boolean} [logFullResponse=false]
+   * @property {boolean} [logAllCommunication=false] log plists sent and received from Web Inspector
+   * @property {boolean} [logAllCommunicationHexDump=false] log communication from Web Inspector as hex dump
+   * @property {number} [webInspectorMaxFrameLength] The maximum size in bytes of a single data
+   *                    frame in the device communication protocol
+   * @property {number} [socketChunkSize] size, in bytes, of chunks of data sent to
+   *                    Web Inspector (real device only)
+   * @property {boolean} [fullPageInitialization]
+   * @property {string} [pageLoadStrategy]
+   */
+
+  /**
+   * @param {RemoteDebuggerOptions} opts
    */
   constructor (opts = {}) {
     super();

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -70,8 +70,8 @@ class RemoteDebugger extends EventEmitter {
   /** @type {(command: string, args?: any[], frames?: string[]) => Promise<any>} */
   executeAtom;
 
-  /** @type {(command: string, args?: any[], frames?: string[]) => Promise<any>} */
-  completeToLoadPage;
+  /** @type {(pageLoadStrategy: string?, readyState: string) => boolean} */
+  isPageLoadingCompleted;
 
   // Callbacks
   /** @type {(err: Error?, appIdKey: string, pageDict: Record<string, any>) => Promise<void>} */

--- a/test/unit/mixins/navigate-specs.js
+++ b/test/unit/mixins/navigate-specs.js
@@ -7,7 +7,7 @@ chai.use(chaiAsPromised);
 
 describe('navigate', function () {
   describe('isPageLoadingCompleted', function () {
-    const BUNDLE_ID = 'com.apple.mobilesafari'
+    const BUNDLE_ID = 'com.apple.mobilesafari';
 
     describe('default pageLoadStrategy', function () {
       it('with complete readyState', function () {

--- a/test/unit/mixins/navigate-specs.js
+++ b/test/unit/mixins/navigate-specs.js
@@ -1,0 +1,70 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import RemoteDebugger from '../../../lib/remote-debugger';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('navigate', function () {
+  describe('isPageLoadingCompleted', function () {
+    describe('default pageLoadStrategy', function () {
+      it('with complete readyState', async function () {
+        const remoteDebugger = new RemoteDebugger();
+        remoteDebugger.isPageLoadingCompleted('complete').should.eql(true);
+      });
+      it('with interactive readyState', async function () {
+        const remoteDebugger = new RemoteDebugger();
+        remoteDebugger.isPageLoadingCompleted('interactive').should.eql(false);
+      });
+      it('with loading readyState', async function () {
+        const remoteDebugger = new RemoteDebugger();
+        remoteDebugger.isPageLoadingCompleted('loading').should.eql(false);
+      });
+    });
+
+    describe('eager pageLoadStrategy', function () {
+      it('with complete readyState', async function () {
+        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'eager'});
+        remoteDebugger.isPageLoadingCompleted('complete').should.eql(true);
+      });
+      it('with interactive readyState', async function () {
+        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'Eager'});
+        remoteDebugger.isPageLoadingCompleted('interactive').should.eql(true);
+      });
+      it('with loading readyState', async function () {
+        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'eager'});
+        remoteDebugger.isPageLoadingCompleted('loading').should.eql(false);
+      });
+    });
+
+    describe('normal pageLoadStrategy', function () {
+      it('with complete readyState', async function () {
+        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'NorMal'});
+        remoteDebugger.isPageLoadingCompleted('complete').should.eql(true);
+      });
+      it('with interactive readyState', async function () {
+        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'normaL'});
+        remoteDebugger.isPageLoadingCompleted('interactive').should.eql(false);
+      });
+      it('with loading readyState', async function () {
+        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'normal'});
+        remoteDebugger.isPageLoadingCompleted('loading').should.eql(false);
+      });
+    });
+
+    describe('none pageLoadStrategy', function () {
+      it('with complete readyState', async function () {
+        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'none'});
+        remoteDebugger.isPageLoadingCompleted('complete').should.eql(true);
+      });
+      it('with interactive readyState', async function () {
+        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'noNe'});
+        remoteDebugger.isPageLoadingCompleted('interactive').should.eql(true);
+      });
+      it('with loading readyState', async function () {
+        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'NONE'});
+        remoteDebugger.isPageLoadingCompleted('loading').should.eql(true);
+      });
+    });
+  });
+});

--- a/test/unit/mixins/navigate-specs.js
+++ b/test/unit/mixins/navigate-specs.js
@@ -7,62 +7,64 @@ chai.use(chaiAsPromised);
 
 describe('navigate', function () {
   describe('isPageLoadingCompleted', function () {
+    const BUNDLE_ID = 'com.apple.mobilesafari'
+
     describe('default pageLoadStrategy', function () {
       it('with complete readyState', function () {
-        const remoteDebugger = new RemoteDebugger();
+        const remoteDebugger = new RemoteDebugger({bundleId: BUNDLE_ID});
         remoteDebugger.isPageLoadingCompleted('complete').should.eql(true);
       });
       it('with interactive readyState', function () {
-        const remoteDebugger = new RemoteDebugger();
+        const remoteDebugger = new RemoteDebugger({bundleId: BUNDLE_ID});
         remoteDebugger.isPageLoadingCompleted('interactive').should.eql(false);
       });
       it('with loading readyState', function () {
-        const remoteDebugger = new RemoteDebugger();
+        const remoteDebugger = new RemoteDebugger({bundleId: BUNDLE_ID});
         remoteDebugger.isPageLoadingCompleted('loading').should.eql(false);
       });
     });
 
     describe('eager pageLoadStrategy', function () {
       it('with complete readyState', function () {
-        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'eager'});
+        const remoteDebugger = new RemoteDebugger({bundleId: BUNDLE_ID, pageLoadStrategy: 'eager'});
         remoteDebugger.isPageLoadingCompleted('complete').should.eql(true);
       });
       it('with interactive readyState', function () {
-        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'Eager'});
+        const remoteDebugger = new RemoteDebugger({bundleId: BUNDLE_ID, pageLoadStrategy: 'Eager'});
         remoteDebugger.isPageLoadingCompleted('interactive').should.eql(true);
       });
       it('with loading readyState', function () {
-        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'eager'});
+        const remoteDebugger = new RemoteDebugger({bundleId: BUNDLE_ID, pageLoadStrategy: 'eager'});
         remoteDebugger.isPageLoadingCompleted('loading').should.eql(false);
       });
     });
 
     describe('normal pageLoadStrategy', function () {
       it('with complete readyState', function () {
-        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'NorMal'});
+        const remoteDebugger = new RemoteDebugger({bundleId: BUNDLE_ID, pageLoadStrategy: 'NorMal'});
         remoteDebugger.isPageLoadingCompleted('complete').should.eql(true);
       });
       it('with interactive readyState', function () {
-        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'normaL'});
+        const remoteDebugger = new RemoteDebugger({bundleId: BUNDLE_ID, pageLoadStrategy: 'normaL'});
         remoteDebugger.isPageLoadingCompleted('interactive').should.eql(false);
       });
       it('with loading readyState', function () {
-        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'normal'});
+        const remoteDebugger = new RemoteDebugger({bundleId: BUNDLE_ID, pageLoadStrategy: 'normal'});
         remoteDebugger.isPageLoadingCompleted('loading').should.eql(false);
       });
     });
 
     describe('none pageLoadStrategy', function () {
       it('with complete readyState', function () {
-        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'none'});
+        const remoteDebugger = new RemoteDebugger({bundleId: BUNDLE_ID, pageLoadStrategy: 'none'});
         remoteDebugger.isPageLoadingCompleted('complete').should.eql(true);
       });
       it('with interactive readyState', function () {
-        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'noNe'});
+        const remoteDebugger = new RemoteDebugger({bundleId: BUNDLE_ID, pageLoadStrategy: 'noNe'});
         remoteDebugger.isPageLoadingCompleted('interactive').should.eql(true);
       });
       it('with loading readyState', function () {
-        const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'NONE'});
+        const remoteDebugger = new RemoteDebugger({bundleId: BUNDLE_ID, pageLoadStrategy: 'NONE'});
         remoteDebugger.isPageLoadingCompleted('loading').should.eql(true);
       });
     });

--- a/test/unit/mixins/navigate-specs.js
+++ b/test/unit/mixins/navigate-specs.js
@@ -8,60 +8,60 @@ chai.use(chaiAsPromised);
 describe('navigate', function () {
   describe('isPageLoadingCompleted', function () {
     describe('default pageLoadStrategy', function () {
-      it('with complete readyState', async function () {
+      it('with complete readyState', function () {
         const remoteDebugger = new RemoteDebugger();
         remoteDebugger.isPageLoadingCompleted('complete').should.eql(true);
       });
-      it('with interactive readyState', async function () {
+      it('with interactive readyState', function () {
         const remoteDebugger = new RemoteDebugger();
         remoteDebugger.isPageLoadingCompleted('interactive').should.eql(false);
       });
-      it('with loading readyState', async function () {
+      it('with loading readyState', function () {
         const remoteDebugger = new RemoteDebugger();
         remoteDebugger.isPageLoadingCompleted('loading').should.eql(false);
       });
     });
 
     describe('eager pageLoadStrategy', function () {
-      it('with complete readyState', async function () {
+      it('with complete readyState', function () {
         const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'eager'});
         remoteDebugger.isPageLoadingCompleted('complete').should.eql(true);
       });
-      it('with interactive readyState', async function () {
+      it('with interactive readyState', function () {
         const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'Eager'});
         remoteDebugger.isPageLoadingCompleted('interactive').should.eql(true);
       });
-      it('with loading readyState', async function () {
+      it('with loading readyState', function () {
         const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'eager'});
         remoteDebugger.isPageLoadingCompleted('loading').should.eql(false);
       });
     });
 
     describe('normal pageLoadStrategy', function () {
-      it('with complete readyState', async function () {
+      it('with complete readyState', function () {
         const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'NorMal'});
         remoteDebugger.isPageLoadingCompleted('complete').should.eql(true);
       });
-      it('with interactive readyState', async function () {
+      it('with interactive readyState', function () {
         const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'normaL'});
         remoteDebugger.isPageLoadingCompleted('interactive').should.eql(false);
       });
-      it('with loading readyState', async function () {
+      it('with loading readyState', function () {
         const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'normal'});
         remoteDebugger.isPageLoadingCompleted('loading').should.eql(false);
       });
     });
 
     describe('none pageLoadStrategy', function () {
-      it('with complete readyState', async function () {
+      it('with complete readyState', function () {
         const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'none'});
         remoteDebugger.isPageLoadingCompleted('complete').should.eql(true);
       });
-      it('with interactive readyState', async function () {
+      it('with interactive readyState', function () {
         const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'noNe'});
         remoteDebugger.isPageLoadingCompleted('interactive').should.eql(true);
       });
-      it('with loading readyState', async function () {
+      it('with loading readyState', function () {
         const remoteDebugger = new RemoteDebugger({pageLoadStrategy: 'NONE'});
         remoteDebugger.isPageLoadingCompleted('loading').should.eql(true);
       });


### PR DESCRIPTION
closes https://github.com/appium/appium-remote-debugger/issues/315

We could support pageLoadStrategy in `document.readyState` step case. In case a webpage issues `Page.loadEventFire` properly, this will not change the behavior so much.


Keyword | Page load strategy state | Document readiness state
-- | -- | --
"none" | none |  
"eager" | eager | "interactive"
"normal" | normal | "complete"



The input variation will be handled by https://github.com/appium/appium-xcuitest-driver/pull/2411