### PR TITLE
fix: Tune page array retrieval

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -22,11 +22,13 @@ jobs:
       DEVICE_NAME: ${{ matrix.device }}
       CI: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: ${{ env.XCODE_VERSION }}
-    - run: xcrun simctl list
+    - run: |
+        xcrun simctl list
+        open -Fn "$(xcode-select -p)/Applications/Simulator.app"
     - name: Prepare iOS simulator
       uses: futureware-tech/simulator-action@v3
       with:

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -26,19 +26,17 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: ${{ env.XCODE_VERSION }}
-    - run: |
-        xcrun simctl list
-        open -Fn "$(xcode-select -p)/Applications/Simulator.app"
-    - name: Prepare iOS simulator
-      uses: futureware-tech/simulator-action@v3
-      with:
-        model: "${{ matrix.device }}"
-        os_version: "${{ matrix.ios }}"
-        shutdown_after_job: false
+    - run: xcrun simctl list
     - uses: actions/setup-node@v3
       with:
         node-version: lts/*
         check-latest: true
+    - name: Prepare iOS simulator
+      run: |
+        open -Fn "$(xcode-select -p)/Applications/Simulator.app"
+        udid=$(xcrun simctl list devices available -j | \
+          node -p "Object.entries(JSON.parse(fs.readFileSync(0)).devices).filter((x) => x[0].includes('$PLATFORM_VERSION'.replace('.', '-'))).reduce((acc, x) => [...acc, ...x[1]], []).filter(({name}) => name === '$DEVICE_NAME').map(({udid}) => udid)[0]")
+        xcrun simctl bootstatus $udid -b
     - run: npm install
     - run: |
         export PATH="${PATH}:$(python -c 'import site; print(site.USER_BASE)')/bin"

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         open -Fn "$(xcode-select -p)/Applications/Simulator.app"
         udid=$(xcrun simctl list devices available -j | \
-          node -p "Object.entries(JSON.parse(fs.readFileSync(0)).devices).filter((x) => x[0].includes('$PLATFORM_VERSION'.replace('.', '-'))).reduce((acc, x) => [...acc, ...x[1]], []).filter(({name}) => name === '$DEVICE_NAME').map(({udid}) => udid)[0]")
+          node -p "Object.entries(JSON.parse(fs.readFileSync(0)).devices).filter((x) => x[0].includes('$PLATFORM_VERSION'.replace('.', '-'))).reduce((acc, x) => [...acc, ...x[1]], []).find(({name}) => name === '$DEVICE_NAME').udid")
         xcrun simctl bootstatus $udid -b
     - run: npm install
     - run: |

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -32,6 +32,7 @@ jobs:
       with:
         model: "${{ matrix.device }}"
         os_version: "${{ matrix.ios }}"
+        shutdown_after_job: false
     - uses: actions/setup-node@v3
       with:
         node-version: lts/*

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -27,6 +27,11 @@ jobs:
       with:
         xcode-version: ${{ env.XCODE_VERSION }}
     - run: xcrun simctl list
+    - name: Prepare iOS simulator
+      uses: futureware-tech/simulator-action@v3
+      with:
+        model: "${{ matrix.device }}"
+        os_version: "${{ matrix.ios }}"
     - uses: actions/setup-node@v3
       with:
         node-version: lts/*

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -7,10 +7,10 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: macos-13
+        - os: macos-14
           xcode: '15.1'
           ios: '17.2'
-          device: iPhone 14
+          device: iPhone 15
         - os: macos-13
           xcode: '14.3.1'
           ios: '16.4'

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -37,6 +37,7 @@ jobs:
         udid=$(xcrun simctl list devices available -j | \
           node -p "Object.entries(JSON.parse(fs.readFileSync(0)).devices).filter((x) => x[0].includes('$PLATFORM_VERSION'.replace('.', '-'))).reduce((acc, x) => [...acc, ...x[1]], []).find(({name}) => name === '$DEVICE_NAME').udid")
         xcrun simctl bootstatus $udid -b
+        xcrun simctl openurl $udid "https://google.com"
     - run: npm install
     - run: |
         export PATH="${PATH}:$(python -c 'import site; print(site.USER_BASE)')/bin"

--- a/lib/mixins/connect.js
+++ b/lib/mixins/connect.js
@@ -1,7 +1,6 @@
 import {
   pageArrayFromDict,
   getPossibleDebuggerAppKeys,
-  simpleStringify,
 } from '../utils';
 import events from './events';
 import { timing } from '@appium/support';
@@ -111,19 +110,14 @@ export async function selectApp (currentUrl = null, maxTries = SELECT_APP_RETRIE
       return [];
     }
 
-    const {
-      appIdKey,
-      pageDict: pageArray,
-    } = await this.searchForApp(currentUrl, maxTries, ignoreAboutBlankUrl);
+    const { appIdKey } = await this.searchForApp(currentUrl, maxTries, ignoreAboutBlankUrl);
     if (this.appIdKey !== appIdKey) {
       this.log.debug(`Received altered app id, updating from '${this.appIdKey}' to '${appIdKey}'`);
       this.appIdKey = appIdKey;
     }
-
     logApplicationDictionary.bind(this)();
-
     // translate the dictionary into a useful form, and return to sender
-    this.log.debug(`Finally selecting app ${this.appIdKey}: ${simpleStringify(pageArray)}`);
+    this.log.debug(`Finally selecting app ${this.appIdKey}`);
 
     /** @type {Page[]} */
     const fullPageArray = [];

--- a/lib/mixins/connect.js
+++ b/lib/mixins/connect.js
@@ -155,14 +155,14 @@ export async function selectApp (currentUrl = null, maxTries = SELECT_APP_RETRIE
  * @param {string?} currentUrl
  * @param {number} maxTries
  * @param {boolean} ignoreAboutBlankUrl
- * @returns {Promise<AppPages>}
+ * @returns {Promise<AppPage>}
  */
 export async function searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
   const bundleIds = this.includeSafari && !this.isSafari
     ? [this.bundleId, ...this.additionalBundleIds, SAFARI_BUNDLE_ID]
     : [this.bundleId, ...this.additionalBundleIds];
   let retryCount = 0;
-  return /** @type {AppPages} */ (await retryInterval(maxTries, SELECT_APP_RETRY_SLEEP_MS, async () => {
+  return /** @type {AppPage} */ (await retryInterval(maxTries, SELECT_APP_RETRY_SLEEP_MS, async () => {
     logApplicationDictionary.bind(this)();
     const possibleAppIds = getPossibleDebuggerAppKeys(/** @type {string[]} */ (bundleIds), this.appDict);
     this.log.debug(`Trying out the possible app ids: ${possibleAppIds.join(', ')} (try #${retryCount + 1} of ${maxTries})`);
@@ -220,7 +220,7 @@ export async function searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
  * @param {Record<string, import('../utils').AppInfo>} appsDict
  * @param {string?} currentUrl
  * @param {boolean} [ignoreAboutBlankUrl]
- * @returns {AppPages?}
+ * @returns {AppPage?}
  */
 export function searchForPage (appsDict, currentUrl = null, ignoreAboutBlankUrl = false) {
   for (const appDict of _.values(appsDict)) {
@@ -294,7 +294,7 @@ function logApplicationDictionary () {
 }
 
 /**
- * @typedef {Object} AppPages
+ * @typedef {Object} AppPage
  * @property {string} appIdKey
  * @property {Page} pageDict
  */

--- a/lib/mixins/connect.js
+++ b/lib/mixins/connect.js
@@ -166,17 +166,16 @@ export async function searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
           this.log.debug(`Skipping app '${attemptedAppIdKey}' because it is not active`);
           continue;
         }
-        if (_.isEmpty(this.appDict[attemptedAppIdKey]?.pageArray)) {
-          this.log.debug(`Skipping app '${attemptedAppIdKey}' because its pages are not ready yet`);
-          continue;
-        }
 
         this.log.debug(`Attempting app '${attemptedAppIdKey}'`);
-        const [appIdKey, pageDict] = await this.requireRpcClient().selectApp(attemptedAppIdKey);
-        // in iOS 8.2 the connect logic happens, but with an empty dictionary
-        // which leads to the remote debugger getting disconnected, and into a loop
-        if (_.isEmpty(pageDict)) {
-          this.log.debug('Empty page dictionary received. Trying again.');
+        /** @type {string} */
+        let appIdKey;
+        /** @type {import('@appium/types').StringRecord} */
+        let pageDict;
+        try {
+          [appIdKey, pageDict] = await this.requireRpcClient().selectApp(attemptedAppIdKey);
+        } catch (e) {
+          this.log.info(`Skipping app '${attemptedAppIdKey}'. Original error: ${e.message}`);
           continue;
         }
 
@@ -198,7 +197,7 @@ export async function searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
         }
       } catch (err) {
         this.log.debug(err.stack);
-        this.log.debug(`Error checking application ${attemptedAppIdKey}: '${err.message}'`);
+        this.log.warn(`Error checking application ${attemptedAppIdKey}: '${err.message}'`);
       }
     }
     retryCount++;

--- a/lib/mixins/connect.js
+++ b/lib/mixins/connect.js
@@ -8,26 +8,12 @@ import { timing } from '@appium/support';
 import { retryInterval, waitForCondition } from 'asyncbox';
 import _ from 'lodash';
 
-
 const APP_CONNECT_TIMEOUT_MS = 0;
 const APP_CONNECT_INTERVAL_MS = 100;
 const SELECT_APP_RETRIES = 20;
 const SELECT_APP_RETRY_SLEEP_MS = 500;
 const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
 const BLANK_PAGE_URL = 'about:blank';
-
-/**
- * @typedef {Object} AppPages
- * @property {string} appIdKey
- * @property {Record<string, any>} pageDict
- */
-
-/**
- * @typedef {Object} App
- * @property {string} id
- * @property {string} bundleId
- */
-
 
 /**
  *
@@ -105,20 +91,11 @@ export async function disconnect () {
 }
 
 /**
- * @typedef {Object} Page
- * @property {string} url
- * @property {string} title
- * @property {number} id
- * @property {boolean} isKey
- * @property {string} [bundleId]
- */
-
-/**
  *
  * @this {import('../remote-debugger').RemoteDebugger}
- * @param {string?} currentUrl
- * @param {number} [maxTries]
- * @param {boolean} [ignoreAboutBlankUrl]
+ * @param {string?} [currentUrl=null]
+ * @param {number} [maxTries=SELECT_APP_RETRIES]
+ * @param {boolean} [ignoreAboutBlankUrl=false]
  * @returns {Promise<Page[]>}
  */
 export async function selectApp (currentUrl = null, maxTries = SELECT_APP_RETRIES, ignoreAboutBlankUrl = false) {
@@ -134,24 +111,18 @@ export async function selectApp (currentUrl = null, maxTries = SELECT_APP_RETRIE
       return [];
     }
 
-    const {appIdKey, pageDict} = await this.searchForApp(currentUrl, maxTries, ignoreAboutBlankUrl) ?? {};
-
-    // if, after all this, we have no dictionary, we have failed
-    if (!appIdKey || !pageDict) {
-      throw this.log.errorWithException(`Could not connect to a valid app after ${maxTries} tries.`);
-    }
-
+    const {
+      appIdKey,
+      pageDict: pageArray,
+    } = await this.searchForApp(currentUrl, maxTries, ignoreAboutBlankUrl);
     if (this.appIdKey !== appIdKey) {
       this.log.debug(`Received altered app id, updating from '${this.appIdKey}' to '${appIdKey}'`);
       this.appIdKey = appIdKey;
     }
 
-    logApplicationDictionary.bind(this)(this.appDict);
+    logApplicationDictionary.bind(this)();
 
     // translate the dictionary into a useful form, and return to sender
-    const pageArray = _.isEmpty(this.appDict[appIdKey].pageArray)
-      ? pageArrayFromDict(pageDict)
-      : this.appDict[appIdKey].pageArray;
     this.log.debug(`Finally selecting app ${this.appIdKey}: ${simpleStringify(pageArray)}`);
 
     /** @type {Page[]} */
@@ -184,80 +155,86 @@ export async function selectApp (currentUrl = null, maxTries = SELECT_APP_RETRIE
  * @param {string?} currentUrl
  * @param {number} maxTries
  * @param {boolean} ignoreAboutBlankUrl
- * @returns {Promise<AppPages?>}
+ * @returns {Promise<AppPages>}
  */
 export async function searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
   const bundleIds = this.includeSafari && !this.isSafari
     ? [this.bundleId, ...this.additionalBundleIds, SAFARI_BUNDLE_ID]
     : [this.bundleId, ...this.additionalBundleIds];
   let retryCount = 0;
-  try {
-    return await retryInterval(maxTries, SELECT_APP_RETRY_SLEEP_MS, async () => {
-      logApplicationDictionary.bind(this)(this.appDict);
-      const possibleAppIds = getPossibleDebuggerAppKeys(/** @type {string[]} */ (bundleIds), this.appDict);
-      this.log.debug(`Trying out the possible app ids: ${possibleAppIds.join(', ')} (try #${retryCount + 1} of ${maxTries})`);
-      for (const attemptedAppIdKey of possibleAppIds) {
-        try {
-          if (!this.appDict[attemptedAppIdKey].isActive) {
-            this.log.debug(`Skipping app '${attemptedAppIdKey}' because it is not active`);
-            continue;
-          }
-          this.log.debug(`Attempting app '${attemptedAppIdKey}'`);
-          const [appIdKey, pageDict] = await this.requireRpcClient().selectApp(attemptedAppIdKey);
-          // in iOS 8.2 the connect logic happens, but with an empty dictionary
-          // which leads to the remote debugger getting disconnected, and into a loop
-          if (_.isEmpty(pageDict)) {
-            this.log.debug('Empty page dictionary received. Trying again.');
-            continue;
-          }
-
-          // save the page array for this app
-          this.appDict[appIdKey].pageArray = pageArrayFromDict(pageDict);
-
-          // if we are looking for a particular url, make sure we
-          // have the right page. Ignore empty or undefined urls.
-          // Ignore about:blank if requested.
-          const result = this.searchForPage(this.appDict, currentUrl, ignoreAboutBlankUrl);
-          if (result) {
-            return result;
-          }
-
-          if (currentUrl) {
-            this.log.debug(`Received app, but expected url ('${currentUrl}') was not found. Trying again.`);
-          } else {
-            this.log.debug('Received app, but no match was found. Trying again.');
-          }
-        } catch (err) {
-          this.log.debug(`Error checking application: '${err.message}'. Retrying connection`);
+  return /** @type {AppPages} */ (await retryInterval(maxTries, SELECT_APP_RETRY_SLEEP_MS, async () => {
+    logApplicationDictionary.bind(this)();
+    const possibleAppIds = getPossibleDebuggerAppKeys(/** @type {string[]} */ (bundleIds), this.appDict);
+    this.log.debug(`Trying out the possible app ids: ${possibleAppIds.join(', ')} (try #${retryCount + 1} of ${maxTries})`);
+    for (const attemptedAppIdKey of possibleAppIds) {
+      try {
+        if (!this.appDict[attemptedAppIdKey].isActive) {
+          this.log.debug(`Skipping app '${attemptedAppIdKey}' because it is not active`);
+          continue;
         }
+        if (_.isEmpty(this.appDict[attemptedAppIdKey]?.pageArray)) {
+          this.log.debug(`Skipping app '${attemptedAppIdKey}' because its pages are not ready yet`);
+          continue;
+        }
+
+        this.log.debug(`Attempting app '${attemptedAppIdKey}'`);
+        const [appIdKey, pageDict] = await this.requireRpcClient().selectApp(attemptedAppIdKey);
+        // in iOS 8.2 the connect logic happens, but with an empty dictionary
+        // which leads to the remote debugger getting disconnected, and into a loop
+        if (_.isEmpty(pageDict)) {
+          this.log.debug('Empty page dictionary received. Trying again.');
+          continue;
+        }
+
+        // save the page array for this app
+        this.appDict[appIdKey].pageArray = pageArrayFromDict(pageDict);
+
+        // if we are looking for a particular url, make sure we
+        // have the right page. Ignore empty or undefined urls.
+        // Ignore about:blank if requested.
+        const result = this.searchForPage(this.appDict, currentUrl, ignoreAboutBlankUrl);
+        if (result) {
+          return result;
+        }
+
+        if (currentUrl) {
+          this.log.debug(`Received app, but expected url ('${currentUrl}') was not found. Trying again.`);
+        } else {
+          this.log.debug('Received app, but no match was found. Trying again.');
+        }
+      } catch (err) {
+        this.log.debug(err.stack);
+        this.log.debug(`Error checking application ${attemptedAppIdKey}: '${err.message}'`);
       }
-      retryCount++;
-      throw new Error('Failed to find an app to select');
-    });
-  } catch (ign) {
-    this.log.errorAndThrow(`Could not connect to a valid app after ${maxTries} tries.`);
-  }
-  return null;
+    }
+    retryCount++;
+    throw new Error(
+      `Could not connect to a valid webapp. Make sure it is debuggable and has at least one active page.`
+    );
+  }));
 }
 
 /**
  *
  * @this {import('../remote-debugger').RemoteDebugger}
- * @param {Record<string, any>} appsDict
+ * @param {Record<string, import('../utils').AppInfo>} appsDict
  * @param {string?} currentUrl
  * @param {boolean} [ignoreAboutBlankUrl]
  * @returns {AppPages?}
  */
 export function searchForPage (appsDict, currentUrl = null, ignoreAboutBlankUrl = false) {
   for (const appDict of _.values(appsDict)) {
-    if (!appDict || !appDict.isActive || !appDict.pageArray || appDict.pageArray.promise) {
+    if (!appDict || !appDict.isActive || !appDict.pageArray || _.isEmpty(appDict.pageArray)) {
       continue;
     }
 
-    for (const dict of appDict.pageArray) {
-      if ((!ignoreAboutBlankUrl || dict.url !== BLANK_PAGE_URL) &&
-          (!currentUrl || dict.url === currentUrl || dict.url === `${currentUrl}/`)) {
-        return { appIdKey: appDict.id, pageDict: dict };
+    for (const page of appDict.pageArray) {
+      if ((!ignoreAboutBlankUrl || page.url !== BLANK_PAGE_URL) &&
+          (!currentUrl || page.url === currentUrl || page.url === `${currentUrl}/`)) {
+        return {
+          appIdKey: appDict.id,
+          pageDict: page
+        };
       }
     }
   }
@@ -292,23 +269,11 @@ export async function selectPage (appIdKey, pageIdKey, skipReadyCheck = false) {
 
 /**
  * @this {import('../remote-debugger').RemoteDebugger}
- * @param {Record<string, any>} apps
  * @returns {void}
  */
-function logApplicationDictionary (apps) {
-
-  function getValueString (key, value) {
-    if (_.isFunction(value)) {
-      return '[Function]';
-    }
-    if (key === 'pageArray' && !_.isArray(value)) {
-      return `"Waiting for data"`;
-    }
-    return JSON.stringify(value);
-  }
-
+function logApplicationDictionary () {
   this.log.debug('Current applications available:');
-  for (const [app, info] of _.toPairs(apps)) {
+  for (const [app, info] of _.toPairs(this.appDict)) {
     this.log.debug(`    Application: "${app}"`);
     for (const [key, value] of _.toPairs(info)) {
       if (key === 'pageArray' && Array.isArray(value) && value.length) {
@@ -321,9 +286,30 @@ function logApplicationDictionary (apps) {
           }
         }
       } else {
-        const valueString = getValueString(key, value);
+        const valueString = _.isFunction(value) ? '[Function]' : JSON.stringify(value);
         this.log.debug(`        ${key}: ${valueString}`);
       }
     }
   }
 }
+
+/**
+ * @typedef {Object} AppPages
+ * @property {string} appIdKey
+ * @property {Page} pageDict
+ */
+
+/**
+ * @typedef {Object} App
+ * @property {string} id
+ * @property {string} bundleId
+ */
+
+/**
+ * @typedef {Object} Page
+ * @property {string} url
+ * @property {string} title
+ * @property {number} id
+ * @property {boolean} isKey
+ * @property {string} [bundleId]
+ */

--- a/lib/mixins/message-handlers.js
+++ b/lib/mixins/message-handlers.js
@@ -2,9 +2,7 @@ import events from './events';
 import {
   pageArrayFromDict,
   getDebuggerAppKey,
-  simpleStringify,
   appInfoFromDict,
-  deferredPromise,
 } from '../utils';
 import _ from 'lodash';
 
@@ -21,48 +19,39 @@ import _ from 'lodash';
  * @param {Record<string, any>} pageDict
  * @returns {Promise<void>}
  */
+// eslint-disable-next-line require-await
 export async function onPageChange (err, appIdKey, pageDict) {
   if (_.isEmpty(pageDict)) {
     return;
   }
 
-  const pageArray = pageArrayFromDict(pageDict);
-
-  await useAppDictLock.bind(this)((/** @type {() => void} */ done) => {
-    try {
-      // save the page dict for this app
-      if (this.appDict[appIdKey]) {
-        if (this.appDict[appIdKey].pageArray) {
-          if (this.appDict[appIdKey].pageArray.resolve) {
-            // pageDict is a pending promise, so resolve
-            this.appDict[appIdKey].pageArray.resolve();
-          } else {
-            // we have a pre-existing pageDict
-            if (_.isEqual(this.appDict[appIdKey].pageArray, pageArray)) {
-              this.log.debug(`Received page change notice for app '${appIdKey}' ` +
-                        `but the listing has not changed. Ignoring.`);
-              return done();
-            }
-          }
-        }
-        // keep track of the page dictionary
-        this.appDict[appIdKey].pageArray = pageArray;
-      }
-    } finally {
-      done();
+  const currentPages = pageArrayFromDict(pageDict);
+  // save the page dict for this app
+  if (this.appDict[appIdKey]) {
+    const previousPages = this.appDict[appIdKey].pageArray;
+    // we have a pre-existing pageDict
+    if (previousPages && _.isEqual(previousPages, currentPages)) {
+      this.log.debug(
+        `Received page change notice for app '${appIdKey}' ` +
+        `but the listing has not changed. Ignoring.`
+      );
+      return;
     }
-  });
+    // keep track of the page dictionary
+    this.appDict[appIdKey].pageArray = currentPages;
+    this.log.debug(
+      `Pages changed for ${appIdKey}: ${JSON.stringify(previousPages)} -> ${JSON.stringify(currentPages)}`
+    );
+  }
 
   if (this._navigatingToPage) {
     // in the middle of navigating, so reporting a page change will cause problems
     return;
   }
 
-  this.log.debug(`Page changed: ${simpleStringify(pageDict, true)}`);
-
   this.emit(events.EVENT_PAGE_CHANGE, {
     appIdKey: appIdKey.replace('PID:', ''),
-    pageArray,
+    pageArray: currentPages,
   });
 }
 
@@ -72,28 +61,23 @@ export async function onPageChange (err, appIdKey, pageDict) {
  * @param {Record<string, any>} dict
  * @returns {Promise<void>}
  */
+// eslint-disable-next-line require-await
 export async function onAppConnect (err, dict) {
   const appIdKey = dict.WIRApplicationIdentifierKey;
   this.log.debug(`Notified that new application '${appIdKey}' has connected`);
-  await useAppDictLock.bind(this)((/** @type {() => void} */ done) => {
-    try {
-      updateAppsWithDict.bind(this)(dict);
-    } finally {
-      done();
-    }
-  });
+  updateAppsWithDict.bind(this)(dict);
 }
 
 /**
  * @this {import('../remote-debugger').RemoteDebugger}
  * @param {Error?} err
- * @param {Record<string, any>} dict
+ * @param {import('@appium/types').StringRecord} dict
  * @returns {void}
  */
 export function onAppDisconnect (err, dict) {
   const appIdKey = dict.WIRApplicationIdentifierKey;
   this.log.debug(`Application '${appIdKey}' disconnected. Removing from app dictionary.`);
- this.log.debug(`Current app is '${this.appIdKey}'`);
+  this.log.debug(`Current app is '${this.appIdKey}'`);
 
   // get rid of the entry in our app dictionary,
   // since it is no longer available
@@ -119,14 +103,10 @@ export function onAppDisconnect (err, dict) {
  * @param {Record<string, any>} dict
  * @returns {Promise<void>}
  */
+// eslint-disable-next-line require-await
 export async function onAppUpdate (err, dict) {
-  await useAppDictLock.bind(this)((/** @type {() => void} */ done) => {
-    try {
-      updateAppsWithDict.bind(this)(dict);
-    } finally {
-      done();
-    }
-  });
+  this.log.debug(`Notified that an application has been updated`);
+  updateAppsWithDict.bind(this)(dict);
 }
 
 /**
@@ -159,6 +139,7 @@ export function onCurrentState (err, state) {
  * @param {Record<string, any>} apps
  * @returns {Promise<void>}
  */
+// eslint-disable-next-line require-await
 export async function onConnectedApplicationList (err, apps) {
   this.log.debug(`Received connected applications list: ${_.keys(apps).join(', ')}`);
 
@@ -173,24 +154,8 @@ export async function onConnectedApplicationList (err, apps) {
     newDict[id] = entry;
   }
   // update the object's list of apps
-  await useAppDictLock.bind(this)((/** @type {() => void} */ done) => {
-    try {
-      _.defaults(this.appDict, newDict);
-    } finally {
-      done();
-    }
-  });
+  _.defaults(this.appDict, newDict);
 }
-
-/**
- * @this {import('../remote-debugger').RemoteDebugger}
- * @param {(done: () => any) => any} fn
- * @returns {Promise<any>}
- */
-async function useAppDictLock (fn) {
-  return await this._lock.acquire('appDict', fn);
-}
-
 
 /**
  *
@@ -201,18 +166,13 @@ async function useAppDictLock (fn) {
 function updateAppsWithDict (dict) {
   // get the dictionary entry into a nice form, and add it to the
   // application dictionary
-  this.appDict = this.appDict || {};
-  let [id, entry] = appInfoFromDict(dict);
+  this.appDict ??= {};
+  const [id, entry] = appInfoFromDict(dict);
   if (this.appDict[id]) {
     // preserve the page dictionary for this entry
     entry.pageArray = this.appDict[id].pageArray;
   }
   this.appDict[id] = entry;
-
-  // add a promise to get the page dictionary
-  if (_.isUndefined(entry.pageArray)) {
-    entry.pageArray = deferredPromise();
-  }
 
   // try to get the app id from our connected apps
   if (!this.appIdKey) {

--- a/lib/remote-debugger.js
+++ b/lib/remote-debugger.js
@@ -11,7 +11,7 @@ import * as screenshotMixins from './mixins/screenshot';
 import * as eventMixins from './mixins/events';
 import * as miscellaneousMixins from './mixins/misc';
 import _ from 'lodash';
-import AsyncLock from 'async-lock';
+
 
 export const REMOTE_DEBUGGER_PORT = 27753;
 /* How many milliseconds to wait for webkit to return a response before timing out */
@@ -160,8 +160,6 @@ export class RemoteDebugger extends EventEmitter {
     this.fullPageInitialization = fullPageInitialization;
 
     this.pageLoadStrategy = pageLoadStrategy;
-
-    this._lock = new AsyncLock();
   }
 
   /**

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -745,29 +745,24 @@ export class RpcClient {
 
         reject(new Error('New application has connected'));
       };
-      // @ts-ignore messageHandler must be defined
-      this.messageHandler.prependOnceListener('_rpc_applicationConnected:', onAppChange);
+      this.messageHandler?.prependOnceListener('_rpc_applicationConnected:', onAppChange);
 
       // do the actual connecting to the app
-      return (async () => {
-        let pageDict, connectedAppIdKey;
+      (async () => {
         try {
-          ([connectedAppIdKey, pageDict] = await this.send('connectToApp', {
-            appIdKey
-          }));
+          const [connectedAppIdKey, pageDict] = await this.send('connectToApp', {appIdKey});
+          // sometimes the connect logic happens, but with an empty dictionary
+          // which leads to the remote debugger getting disconnected, and into a loop
+          if (_.isEmpty(pageDict)) {
+            reject(new Error('Empty page dictionary received'));
+          } else {
+            resolve([connectedAppIdKey, pageDict]);
+          }
         } catch (err) {
-          log.warn(`Unable to connect to app: ${err.message}`);
+          log.warn(`Unable to connect to the app: ${err.message}`);
           reject(err);
-        }
-
-        // sometimes the connect logic happens, but with an empty dictionary
-        // which leads to the remote debugger getting disconnected, and into a loop
-        if (_.isEmpty(pageDict)) {
-          let msg = 'Empty page dictionary received';
-          log.debug(msg);
-          reject(new Error(msg));
-        } else {
-          resolve([connectedAppIdKey, pageDict]);
+        } finally {
+          this.messageHandler?.off('_rpc_applicationConnected:', onAppChange);
         }
       })();
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,10 +38,10 @@ export const RESPONSE_LOG_LENGTH = 100;
  * @property {boolean} isProxy
  * @property {string} name
  * @property {string} bundleId
- * @property {string} hostId
+ * @property {string} [hostId]
  * @property {boolean} isActive
  * @property {boolean|string} isAutomationEnabled
- * @property {any[]|undefined|DeferredPromise} [pageArray]
+ * @property {import('./mixins/connect').Page[]} [pageArray]
  */
 
 /**
@@ -83,28 +83,23 @@ export function appInfoFromDict (dict) {
   return [id, entry];
 }
 
-/*
+/**
  * Take a dictionary from the remote debugger and makes a more manageable
  * dictionary of pages available.
+ *
+ * @param {import('@appium/types').StringRecord} pageDict
+ * @returns {import('./mixins/connect').Page[]}
  */
 export function pageArrayFromDict (pageDict) {
-  if (pageDict.id) {
-    // the page is already translated, so wrap in an array and pass back
-    return [pageDict];
-  }
-  let newPageArray = [];
-  for (const dict of _.values(pageDict)) {
+  return _.values(pageDict)
     // count only WIRTypeWeb pages and ignore all others (WIRTypeJavaScript etc)
-    if (_.isUndefined(dict.WIRTypeKey) || ACCEPTED_PAGE_TYPES.includes(dict.WIRTypeKey)) {
-      newPageArray.push({
-        id: dict.WIRPageIdentifierKey,
-        title: dict.WIRTitleKey,
-        url: dict.WIRURLKey,
-        isKey: !_.isUndefined(dict.WIRConnectionIdentifierKey),
-      });
-    }
-  }
-  return newPageArray;
+    .filter((dict) => _.isUndefined(dict.WIRTypeKey) || ACCEPTED_PAGE_TYPES.includes(dict.WIRTypeKey))
+    .map((dict) => ({
+      id: dict.WIRPageIdentifierKey,
+      title: dict.WIRTitleKey,
+      url: dict.WIRURLKey,
+      isKey: !_.isUndefined(dict.WIRConnectionIdentifierKey),
+    }));
 }
 
 /**
@@ -147,7 +142,7 @@ export function getDebuggerAppKey (bundleId, appDict) {
  * Find app keys based on assigned bundleIds from appDict
  * When bundleIds includes a wildcard ('*'), returns all appKeys in appDict.
  * @param {string[]} bundleIds
- * @param {Record<string, any>} appDict
+ * @param {Record<string, AppInfo>} appDict
  * @returns {string[]}
  */
 export function getPossibleDebuggerAppKeys(bundleIds, appDict) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@appium/base-driver": "^9.0.0",
     "@appium/support": "^5.0.3",
     "appium-ios-device": "^2.0.0",
-    "async-lock": "^1.2.2",
     "asyncbox": "^3.0.0",
     "bluebird": "^3.4.7",
     "fancy-log": "^2.0.0",


### PR DESCRIPTION
It looks like sometimes after we receive a notification about a new app connection no followup pages update notification is delivered. This PR tries to streamline the flow and avoid performing any actions on the app until we actually have the list of pages. 

I've also updated/fixed some typedefs and removed the asynchronous lock as all operations on the `appDict` are synchronous and they don't need any locking