### PR TITLE
fix: Properly handle protected accessors from mixin methods

### DIFF
--- a/lib/mixins/connect.js
+++ b/lib/mixins/connect.js
@@ -47,7 +47,7 @@ export async function setConnectionKey () {
  *
  * @this {RemoteDebugger}
  * @param {number} [timeout=APP_CONNECT_TIMEOUT_MS]
- * @returns {Promise<import('@appium/types').StringRecord>}
+ * @returns {Promise<import('../types').AppDict>}
  */
 export async function connect (timeout = APP_CONNECT_TIMEOUT_MS) {
   this.setup();
@@ -89,8 +89,7 @@ export async function connect (timeout = APP_CONNECT_TIMEOUT_MS) {
         this.log.debug(`Timed out waiting for applications to be reported`);
       }
     }
-    const appDict = getAppDict(this);
-    return _.isNil(appDict) ? {} : _.cloneDeep(appDict);
+    return _.cloneDeep(getAppDict(this));
   } catch (err) {
     this.log.error(`Error setting connection key: ${err.message}`);
     await this.disconnect();

--- a/lib/mixins/connect.js
+++ b/lib/mixins/connect.js
@@ -7,6 +7,17 @@ import events from './events';
 import { timing, util } from '@appium/support';
 import { retryInterval, waitForCondition } from 'asyncbox';
 import _ from 'lodash';
+import {
+  setAppIdKey,
+  getAppDict,
+  getAppIdKey,
+  setPageIdKey,
+  getRcpClient,
+  getIsSafari,
+  getIncludeSafari,
+  getBundleId,
+  getAdditionalBundleIds,
+} from './property-accessors';
 
 const APP_CONNECT_TIMEOUT_MS = 0;
 const APP_CONNECT_INTERVAL_MS = 100;
@@ -66,19 +77,20 @@ export async function connect (timeout = APP_CONNECT_TIMEOUT_MS) {
       const timer = new timing.Timer().start();
       this.log.debug(`Waiting up to ${timeout}ms for applications to be reported`);
       try {
-        await waitForCondition(() => !_.isEmpty(this._appDict), {
+        await waitForCondition(() => !_.isEmpty(getAppDict(this)), {
           waitMs: timeout,
           intervalMs: APP_CONNECT_INTERVAL_MS,
         });
         this.log.debug(
-          `Retrieved ${util.pluralize('application', _.size(this._appDict), true)} ` +
+          `Retrieved ${util.pluralize('application', _.size(getAppDict(this)), true)} ` +
           `within ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`
         );
       } catch (err) {
         this.log.debug(`Timed out waiting for applications to be reported`);
       }
     }
-    return this._appDict || {};
+    const appDict = getAppDict(this);
+    return _.isNil(appDict) ? {} : _.cloneDeep(appDict);
   } catch (err) {
     this.log.error(`Error setting connection key: ${err.message}`);
     await this.disconnect();
@@ -92,9 +104,7 @@ export async function connect (timeout = APP_CONNECT_TIMEOUT_MS) {
  * @returns {Promise<void>}
  */
 export async function disconnect () {
-  if (this._rpcClient) {
-    await this._rpcClient.disconnect();
-  }
+  await getRcpClient(this)?.disconnect();
   this.emit(events.EVENT_DISCONNECT, true);
   this.teardown();
 }
@@ -115,23 +125,23 @@ export async function selectApp (currentUrl = null, maxTries = SELECT_APP_RETRIE
   rpcClient.shouldCheckForTarget = false;
   try {
     const timer = new timing.Timer().start();
-    if (!this._appDict || _.isEmpty(this._appDict)) {
+    if (_.isEmpty(getAppDict(this))) {
       this.log.debug('No applications currently connected.');
       return [];
     }
 
     const { appIdKey } = await searchForApp.bind(this)(currentUrl, maxTries, ignoreAboutBlankUrl);
-    if (this._appIdKey !== appIdKey) {
-      this.log.debug(`Received altered app id, updating from '${this._appIdKey}' to '${appIdKey}'`);
-      this._appIdKey = appIdKey;
+    if (getAppIdKey(this) !== appIdKey) {
+      this.log.debug(`Received altered app id, updating from '${getAppIdKey(this)}' to '${appIdKey}'`);
+      setAppIdKey(this, appIdKey);
     }
     logApplicationDictionary.bind(this)();
     // translate the dictionary into a useful form, and return to sender
-    this.log.debug(`Finally selecting app ${this._appIdKey}`);
+    this.log.debug(`Finally selecting app ${getAppIdKey(this)}`);
 
     /** @type {import('../types').Page[]} */
     const fullPageArray = [];
-    for (const [app, info] of _.toPairs(this._appDict)) {
+    for (const [app, info] of _.toPairs(getAppDict(this))) {
       if (!_.isArray(info.pageArray) || !info.isActive) {
         continue;
       }
@@ -162,14 +172,15 @@ export async function selectApp (currentUrl = null, maxTries = SELECT_APP_RETRIE
  * @returns {Promise<void>}
  */
 export async function selectPage (appIdKey, pageIdKey, skipReadyCheck = false) {
-  this._appIdKey = _.startsWith(`${appIdKey}`, 'PID:') ? `${appIdKey}` : `PID:${appIdKey}`;
-  this._pageIdKey = pageIdKey;
+  const fullAppIdKey = _.startsWith(`${appIdKey}`, 'PID:') ? `${appIdKey}` : `PID:${appIdKey}`;
+  setAppIdKey(this, fullAppIdKey);
+  setPageIdKey(this, pageIdKey);
 
-  this.log.debug(`Selecting page '${pageIdKey}' on app '${this._appIdKey}' and forwarding socket setup`);
+  this.log.debug(`Selecting page '${pageIdKey}' on app '${fullAppIdKey}' and forwarding socket setup`);
 
   const timer = new timing.Timer().start();
 
-  await this.requireRpcClient().selectPage(this._appIdKey, pageIdKey);
+  await this.requireRpcClient().selectPage(fullAppIdKey, pageIdKey);
 
   if (!skipReadyCheck && !await this.checkPageIsReady()) {
     await this.waitForDom();
@@ -177,7 +188,6 @@ export async function selectPage (appIdKey, pageIdKey, skipReadyCheck = false) {
 
   this.log.debug(`Selected page after ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
 }
-
 
 /**
  *
@@ -188,9 +198,14 @@ export async function selectPage (appIdKey, pageIdKey, skipReadyCheck = false) {
  * @returns {Promise<import('../types').AppPage>}
  */
 async function searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
-  const bundleIds = this._includeSafari && !this._isSafari
-    ? [this._bundleId, ...this._additionalBundleIds, SAFARI_BUNDLE_ID]
-    : [this._bundleId, ...this._additionalBundleIds];
+  /** @type {string[]} */
+  const bundleIds = _.compact(
+    [
+      getBundleId(this),
+      ...(getAdditionalBundleIds(this) ?? []),
+      ...(getIncludeSafari(this) && !getIsSafari(this) ? [SAFARI_BUNDLE_ID] : []),
+    ]
+  );
   let retryCount = 0;
   return /** @type {import('../types').AppPage} */ (await retryInterval(maxTries, SELECT_APP_RETRY_SLEEP_MS, async () => {
     logApplicationDictionary.bind(this)();
@@ -198,7 +213,7 @@ async function searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
     this.log.debug(`Trying out the possible app ids: ${possibleAppIds.join(', ')} (try #${retryCount + 1} of ${maxTries})`);
     for (const attemptedAppIdKey of possibleAppIds) {
       try {
-        if (!this._appDict[attemptedAppIdKey].isActive) {
+        if (!getAppDict(this)[attemptedAppIdKey].isActive) {
           this.log.debug(`Skipping app '${attemptedAppIdKey}' because it is not active`);
           continue;
         }
@@ -216,12 +231,12 @@ async function searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
         }
 
         // save the page array for this app
-        this._appDict[appIdKey].pageArray = pageArrayFromDict(pageDict);
+        getAppDict(this)[appIdKey].pageArray = pageArrayFromDict(pageDict);
 
         // if we are looking for a particular url, make sure we
         // have the right page. Ignore empty or undefined urls.
         // Ignore about:blank if requested.
-        const result = searchForPage.bind(this)(this._appDict, currentUrl, ignoreAboutBlankUrl);
+        const result = searchForPage.bind(this)(getAppDict(this), currentUrl, ignoreAboutBlankUrl);
         if (result) {
           return result;
         }
@@ -276,7 +291,7 @@ function searchForPage (appsDict, currentUrl = null, ignoreAboutBlankUrl = false
  */
 function logApplicationDictionary () {
   this.log.debug('Current applications available:');
-  for (const [app, info] of _.toPairs(this._appDict)) {
+  for (const [app, info] of _.toPairs(getAppDict(this))) {
     this.log.debug(`    Application: "${app}"`);
     for (const [key, value] of _.toPairs(info)) {
       if (key === 'pageArray' && Array.isArray(value) && value.length) {
@@ -307,7 +322,7 @@ function logApplicationDictionary () {
 export function getPossibleDebuggerAppKeys(bundleIds) {
   if (bundleIds.includes(WILDCARD_BUNDLE_ID)) {
     this.log.debug('Skip checking bundle identifiers because the bundleIds includes a wildcard');
-    return _.uniq(Object.keys(this._appDict));
+    return _.uniq(Object.keys(getAppDict(this)));
   }
 
   // go through the possible bundle identifiers
@@ -324,10 +339,10 @@ export function getPossibleDebuggerAppKeys(bundleIds) {
   const proxiedAppIds = new Set();
   for (const bundleId of possibleBundleIds) {
     // now we need to determine if we should pick a proxy for this instead
-    for (const appId of appIdsForBundle(bundleId, this._appDict)) {
+    for (const appId of appIdsForBundle(bundleId, getAppDict(this))) {
       proxiedAppIds.add(appId);
       this.log.debug(`Found app id key '${appId}' for bundle '${bundleId}'`);
-      for (const [key, data] of _.toPairs(this._appDict)) {
+      for (const [key, data] of _.toPairs(getAppDict(this))) {
         if (data.isProxy && data.hostId === appId) {
           this.log.debug(
             `Found separate bundleId '${data.bundleId}' ` +
@@ -343,19 +358,5 @@ export function getPossibleDebuggerAppKeys(bundleIds) {
 }
 
 /**
- * @typedef {Object} HasConnectionRelatedProperties
- * @property {string | null | undefined} _appIdKey
- * @property {string | number | null | undefined} _pageIdKey
- * @property {import('../types').AppDict} _appDict
- * @property {string | undefined} _bundleId
- * @property {import('../rpc/rpc-client').RpcClient | undefined} _rpcClient
- * @property {boolean} _includeSafari
- * @property {boolean} _isSafari
- * @property {string[]} _additionalBundleIds
- * @property {(this: RemoteDebugger, timeoutMs?: number | undefined) => Promise<boolean>} checkPageIsReady:
- * @property {(this: RemoteDebugger, startPageLoadTimer?: timing.Timer | null | undefined) => Promise<void>} waitForDom:
- */
-
-/**
- * @typedef {import('../remote-debugger').RemoteDebugger & HasConnectionRelatedProperties} RemoteDebugger
+ * @typedef {import('../remote-debugger').RemoteDebugger} RemoteDebugger
  */

--- a/lib/mixins/cookies.js
+++ b/lib/mixins/cookies.js
@@ -1,3 +1,7 @@
+import {
+  getAppIdKey,
+  getPageIdKey,
+} from './property-accessors';
 
 /**
  *
@@ -7,8 +11,8 @@
 export async function getCookies () {
   this.log.debug('Getting cookies');
   return await this.requireRpcClient().send('Page.getCookies', {
-    appIdKey: this._appIdKey,
-    pageIdKey: this._pageIdKey
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
   });
 }
 
@@ -21,9 +25,9 @@ export async function getCookies () {
 export async function setCookie (cookie) {
   this.log.debug('Setting cookie');
   return await this.requireRpcClient().send('Page.setCookie', {
-    appIdKey: this._appIdKey,
-    pageIdKey: this._pageIdKey,
-    cookie
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
+    cookie,
   });
 }
 
@@ -37,19 +41,13 @@ export async function setCookie (cookie) {
 export async function deleteCookie (cookieName, url) {
   this.log.debug(`Deleting cookie '${cookieName}' on '${url}'`);
   return await this.requireRpcClient().send('Page.deleteCookie', {
-    appIdKey: this._appIdKey,
-    pageIdKey: this._pageIdKey,
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
     cookieName,
     url,
   });
 }
 
 /**
- * @typedef {Object} HasCookiesRelatedProperties
- * @property {string | null | undefined} _appIdKey
- * @property {string | number | null | undefined} _pageIdKey
- */
-
-/**
- * @typedef {import('../remote-debugger').RemoteDebugger & HasCookiesRelatedProperties} RemoteDebugger
+ * @typedef {import('../remote-debugger').RemoteDebugger} RemoteDebugger
  */

--- a/lib/mixins/events.js
+++ b/lib/mixins/events.js
@@ -1,9 +1,13 @@
+import {
+  getClientEventListeners,
+} from './property-accessors';
+
 // event emitted publically
-export const events = {
+export const events = /** @type {const} */ ({
   EVENT_PAGE_CHANGE: 'remote_debugger_page_change',
   EVENT_FRAMES_DETACHED: 'remote_debugger_frames_detached',
   EVENT_DISCONNECT: 'remote_debugger_disconnect',
-};
+});
 
 /**
  * Keep track of the client event listeners so they can be removed
@@ -14,8 +18,8 @@ export const events = {
  * @returns {void}
  */
 export function addClientEventListener (eventName, listener) {
-  this._clientEventListeners[eventName] ??= [];
-  this._clientEventListeners[eventName].push(listener);
+  getClientEventListeners(this)[eventName] ??= [];
+  getClientEventListeners(this)[eventName].push(listener);
   this.requireRpcClient().on(eventName, listener);
 }
 
@@ -25,7 +29,7 @@ export function addClientEventListener (eventName, listener) {
  * @returns {void}
  */
 export function removeClientEventListener (eventName) {
-  for (const listener of (this._clientEventListeners[eventName] || [])) {
+  for (const listener of (getClientEventListeners(this)[eventName] || [])) {
     this.requireRpcClient().off(eventName, listener);
   }
 }
@@ -73,10 +77,5 @@ export function stopNetwork () {
 export default events;
 
 /**
- * @typedef {Object} HasEventsRelatedProperties
- * @property {import('@appium/types').StringRecord<import('../types').EventListener[]>} _clientEventListeners:
- */
-
-/**
- * @typedef {import('../remote-debugger').RemoteDebugger & HasEventsRelatedProperties} RemoteDebugger
+ * @typedef {import('../remote-debugger').RemoteDebugger} RemoteDebugger
  */

--- a/lib/mixins/execute.js
+++ b/lib/mixins/execute.js
@@ -1,10 +1,20 @@
 import { errors } from '@appium/base-driver';
-import { checkParams, simpleStringify, convertResult, RESPONSE_LOG_LENGTH } from '../utils';
+import {
+  checkParams,
+  simpleStringify,
+  convertResult,
+  RESPONSE_LOG_LENGTH,
+} from '../utils';
 import { getScriptForAtom } from '../atoms';
 import { util, timing } from '@appium/support';
 import { retryInterval } from 'asyncbox';
 import _ from 'lodash';
-
+import {
+  getAppIdKey,
+  getPageIdKey,
+  getPageLoading,
+  getGarbageCollectOnExecute,
+} from './property-accessors';
 
 /* How many milliseconds to wait for webkit to return a response before timing out */
 const RPC_RESPONSE_TIMEOUT_MS = 5000;
@@ -36,8 +46,8 @@ export async function executeAtom (atom, args = [], frames = []) {
 export async function executeAtomAsync (atom, args = [], frames = []) {
   // helper to send directly to the web inspector
   const evaluate = async (method, opts) => await this.requireRpcClient(true).send(method, Object.assign({
-    appIdKey: this._appIdKey,
-    pageIdKey: this._pageIdKey,
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
     returnByValue: false,
   }, opts));
 
@@ -125,19 +135,19 @@ export async function executeAtomAsync (atom, args = [], frames = []) {
  */
 export async function execute (command, override) {
   // if the page is not loaded yet, wait for it
-  if (this._pageLoading && !override) {
+  if (getPageLoading(this) && !override) {
     this.log.debug('Trying to execute but page is not loaded.');
     await this.waitForDom();
   }
 
-  if (_.isNil(this._appIdKey)) {
+  if (_.isNil(getAppIdKey(this))) {
     throw new Error('Missing parameter: appIdKey. Is the target web application still alive?');
   }
-  if (_.isNil(this._pageIdKey)) {
+  if (_.isNil(getPageIdKey(this))) {
     throw new Error('Missing parameter: pageIdKey. Is the target web page still alive?');
   }
 
-  if (this._garbageCollectOnExecute) {
+  if (getGarbageCollectOnExecute(this)) {
     await this.garbageCollect();
   }
 
@@ -145,8 +155,8 @@ export async function execute (command, override) {
   const res = await this.requireRpcClient(true).send('Runtime.evaluate', {
     expression: command,
     returnByValue: true,
-    appIdKey: this._appIdKey,
-    pageIdKey: this._pageIdKey,
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
   });
   return convertResult(res);
 }
@@ -158,9 +168,12 @@ export async function execute (command, override) {
  * @param {any[]} [args]
  */
 export async function callFunction (objectId, fn, args) {
-  checkParams({appIdKey: this._appIdKey, pageIdKey: this._pageIdKey});
+  checkParams({
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
+  });
 
-  if (this._garbageCollectOnExecute) {
+  if (getGarbageCollectOnExecute(this)) {
     await this.garbageCollect();
   }
 
@@ -170,22 +183,13 @@ export async function callFunction (objectId, fn, args) {
     functionDeclaration: fn,
     arguments: args,
     returnByValue: true,
-    appIdKey: this._appIdKey,
-    pageIdKey: this._pageIdKey,
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
   });
 
   return convertResult(res);
 }
 
 /**
- * @typedef {Object} HasExecutionRelatedProperties
- * @property {string | null | undefined} _appIdKey
- * @property {string | number | null | undefined} _pageIdKey
- * @property {boolean} _pageLoading
- * @property {boolean} _garbageCollectOnExecute
- * @property {(this: RemoteDebugger, startPageLoadTimer?: timing.Timer | null | undefined) => Promise<void>} waitForDom:
- */
-
-/**
- * @typedef {import('../remote-debugger').RemoteDebugger & HasExecutionRelatedProperties} RemoteDebugger
+ * @typedef {import('../remote-debugger').RemoteDebugger} RemoteDebugger
  */

--- a/lib/mixins/message-handlers.js
+++ b/lib/mixins/message-handlers.js
@@ -15,7 +15,6 @@ import {
   getSkippedApps,
 } from './property-accessors';
 
-
 /*
  * Generic callbacks used throughout the lifecycle of the Remote Debugger.
  * These will be added to the prototype.

--- a/lib/mixins/message-handlers.js
+++ b/lib/mixins/message-handlers.js
@@ -4,6 +4,16 @@ import {
   appInfoFromDict,
 } from '../utils';
 import _ from 'lodash';
+import {
+  setAppIdKey,
+  getAppDict,
+  getAppIdKey,
+  getBundleId,
+  getNavigatingToPage,
+  setCurrentState,
+  setConnectedDrivers,
+  getSkippedApps,
+} from './property-accessors';
 
 
 /*
@@ -26,8 +36,8 @@ export async function onPageChange (err, appIdKey, pageDict) {
 
   const currentPages = pageArrayFromDict(pageDict);
   // save the page dict for this app
-  if (this._appDict[appIdKey]) {
-    const previousPages = this._appDict[appIdKey].pageArray;
+  if (getAppDict(this)[appIdKey]) {
+    const previousPages = getAppDict(this)[appIdKey].pageArray;
     // we have a pre-existing pageDict
     if (previousPages && _.isEqual(previousPages, currentPages)) {
       this.log.debug(
@@ -37,13 +47,13 @@ export async function onPageChange (err, appIdKey, pageDict) {
       return;
     }
     // keep track of the page dictionary
-    this._appDict[appIdKey].pageArray = currentPages;
+    getAppDict(this)[appIdKey].pageArray = currentPages;
     this.log.debug(
       `Pages changed for ${appIdKey}: ${JSON.stringify(previousPages)} -> ${JSON.stringify(currentPages)}`
     );
   }
 
-  if (this._navigatingToPage) {
+  if (getNavigatingToPage(this)) {
     // in the middle of navigating, so reporting a page change will cause problems
     return;
   }
@@ -76,19 +86,19 @@ export async function onAppConnect (err, dict) {
 export function onAppDisconnect (err, dict) {
   const appIdKey = dict.WIRApplicationIdentifierKey;
   this.log.debug(`Application '${appIdKey}' disconnected. Removing from app dictionary.`);
-  this.log.debug(`Current app is '${this._appIdKey}'`);
+  this.log.debug(`Current app is '${getAppIdKey(this)}'`);
 
   // get rid of the entry in our app dictionary,
   // since it is no longer available
-  delete this._appDict[appIdKey];
+  delete getAppDict(this)[appIdKey];
 
   // if the disconnected app is the one we are connected to, try to find another
-  if (this._appIdKey === appIdKey) {
+  if (getAppIdKey(this) === appIdKey) {
     this.log.debug(`No longer have app id. Attempting to find new one.`);
-    this._appIdKey = getDebuggerAppKey.bind(this)(/** @type {string} */ (this._bundleId));
+    setAppIdKey(this, getDebuggerAppKey.bind(this)(/** @type {string} */ (getBundleId(this))));
   }
 
-  if (!this._appDict) {
+  if (_.isEmpty(getAppDict(this))) {
     // this means we no longer have any apps. what the what?
     this.log.debug('Main app disconnected. Disconnecting altogether.');
     this.emit(events.EVENT_DISCONNECT, true);
@@ -114,8 +124,8 @@ export async function onAppUpdate (err, dict) {
  * @returns {void}
  */
 export function onConnectedDriverList (err, drivers) {
-  this._connectedDrivers = drivers.WIRDriverDictionaryKey;
-  this.log.debug(`Received connected driver list: ${JSON.stringify(this._connectedDrivers)}`);
+  setConnectedDrivers(this, drivers.WIRDriverDictionaryKey);
+  this.log.debug(`Received connected driver list: ${JSON.stringify(this.connectedDrivers)}`);
 }
 
 /**
@@ -125,10 +135,10 @@ export function onConnectedDriverList (err, drivers) {
  * @returns {void}
  */
 export function onCurrentState (err, state) {
-  this._currentState = state.WIRAutomationAvailabilityKey;
+  setCurrentState(this, state.WIRAutomationAvailabilityKey);
   // This state changes when 'Remote Automation' in 'Settings app' > 'Safari' > 'Advanced' > 'Remote Automation' changes
   // WIRAutomationAvailabilityAvailable or WIRAutomationAvailabilityNotAvailable
-  this.log.debug(`Received connected automation availability state: ${JSON.stringify(this._currentState)}`);
+  this.log.debug(`Received connected automation availability state: ${JSON.stringify(this.currentState)}`);
 }
 
 /**
@@ -146,13 +156,13 @@ export async function onConnectedApplicationList (err, apps) {
   let newDict = {};
   for (const dict of _.values(apps)) {
     const [id, entry] = appInfoFromDict(dict);
-    if (this._skippedApps.includes(entry.name)) {
+    if (getSkippedApps(this).includes(entry.name)) {
       continue;
     }
     newDict[id] = entry;
   }
   // update the object's list of apps
-  _.defaults(this._appDict, newDict);
+  _.defaults(getAppDict(this), newDict);
 }
 
 /**
@@ -164,17 +174,16 @@ export async function onConnectedApplicationList (err, apps) {
 function updateAppsWithDict (dict) {
   // get the dictionary entry into a nice form, and add it to the
   // application dictionary
-  this._appDict ??= {};
   const [id, entry] = appInfoFromDict(dict);
-  if (this._appDict[id]) {
+  if (getAppDict(this)[id]) {
     // preserve the page dictionary for this entry
-    entry.pageArray = this._appDict[id].pageArray;
+    entry.pageArray = getAppDict(this)[id].pageArray;
   }
-  this._appDict[id] = entry;
+  getAppDict(this)[id] = entry;
 
   // try to get the app id from our connected apps
-  if (!this._appIdKey) {
-    this._appIdKey = getDebuggerAppKey.bind(this)(/** @type {string} */ (this._bundleId));
+  if (!getAppIdKey(this)) {
+    setAppIdKey(this, getDebuggerAppKey.bind(this)(/** @type {string} */ (getBundleId(this))));
   }
 }
 
@@ -188,7 +197,7 @@ function updateAppsWithDict (dict) {
  */
 export function getDebuggerAppKey (bundleId) {
   let appId;
-  for (const [key, data] of _.toPairs(this._appDict)) {
+  for (const [key, data] of _.toPairs(getAppDict(this))) {
     if (data.bundleId === bundleId) {
       appId = key;
       break;
@@ -198,7 +207,7 @@ export function getDebuggerAppKey (bundleId) {
   if (appId) {
     this.log.debug(`Found app id key '${appId}' for bundle '${bundleId}'`);
     let proxyAppId;
-    for (const [key, data] of _.toPairs(this._appDict)) {
+    for (const [key, data] of _.toPairs(getAppDict(this))) {
       if (data.isProxy && data.hostId === appId) {
         this.log.debug(`Found separate bundleId '${data.bundleId}' ` +
                   `acting as proxy for '${bundleId}', with app id '${key}'`);
@@ -216,17 +225,5 @@ export function getDebuggerAppKey (bundleId) {
 }
 
 /**
- * @typedef {Object} HasMessageHandlersRelatedProperties
- * @property {string | null | undefined} _appIdKey
- * @property {string | number | null | undefined} _pageIdKey
- * @property {import('../types').AppDict} _appDict
- * @property {boolean} _navigatingToPage
- * @property {string | undefined} _currentState
- * @property {string | undefined} _bundleId
- * @property {string[] | undefined} _connectedDrivers
- * @property {string[]} _skippedApps
- */
-
-/**
- * @typedef {import('../remote-debugger').RemoteDebugger & HasMessageHandlersRelatedProperties} RemoteDebugger
+ * @typedef {import('../remote-debugger').RemoteDebugger} RemoteDebugger
  */

--- a/lib/mixins/misc.js
+++ b/lib/mixins/misc.js
@@ -1,5 +1,9 @@
 import { checkParams } from '../utils';
 import B from 'bluebird';
+import {
+  getAppIdKey,
+  getPageIdKey,
+} from './property-accessors';
 
 const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
 const GARBAGE_COLLECT_TIMEOUT_MS = 5000;
@@ -23,8 +27,8 @@ export async function startTimeline (fn) {
   this.log.debug('Starting to record the timeline');
   this.requireRpcClient().on('Timeline.eventRecorded', fn);
   return await this.requireRpcClient().send('Timeline.start', {
-    appIdKey: this._appIdKey,
-    pageIdKey: this._pageIdKey,
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
   });
 }
 
@@ -35,8 +39,8 @@ export async function startTimeline (fn) {
 export async function stopTimeline () {
   this.log.debug('Stopping to record the timeline');
   await this.requireRpcClient().send('Timeline.stop', {
-    appIdKey: this._appIdKey,
-    pageIdKey: this._pageIdKey,
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
   });
 }
 
@@ -49,9 +53,9 @@ export async function stopTimeline () {
 export async function overrideUserAgent (value) {
   this.log.debug('Setting overrideUserAgent');
   return await this.requireRpcClient().send('Page.overrideUserAgent', {
-    appIdKey: this._appIdKey,
-    pageIdKey: this._pageIdKey,
-    value
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
+    value,
   });
 }
 
@@ -64,7 +68,10 @@ export async function garbageCollect (timeoutMs = GARBAGE_COLLECT_TIMEOUT_MS) {
   this.log.debug(`Garbage collecting with ${timeoutMs}ms timeout`);
 
   try {
-    checkParams({appIdKey: this._appIdKey, pageIdKey: this._pageIdKey});
+    checkParams({
+      appIdKey: getAppIdKey(this),
+      pageIdKey: getPageIdKey(this),
+    });
   } catch (err) {
     this.log.debug(`Unable to collect garbage at this time`);
     return;
@@ -73,8 +80,8 @@ export async function garbageCollect (timeoutMs = GARBAGE_COLLECT_TIMEOUT_MS) {
   try {
     await B.resolve(this.requireRpcClient().send(
       'Heap.gc', {
-        appIdKey: this._appIdKey,
-        pageIdKey: this._pageIdKey,
+        appIdKey: getAppIdKey(this),
+        pageIdKey: getPageIdKey(this),
       })
     ).timeout(timeoutMs);
     this.log.debug(`Garbage collection successful`);
@@ -88,11 +95,5 @@ export async function garbageCollect (timeoutMs = GARBAGE_COLLECT_TIMEOUT_MS) {
 }
 
 /**
- * @typedef {Object} HasMiscRelatedProperties
- * @property {string | null | undefined} _appIdKey
- * @property {string | number | null | undefined} _pageIdKey
- */
-
-/**
- * @typedef {import('../remote-debugger').RemoteDebugger & HasMiscRelatedProperties} RemoteDebugger
+ * @typedef {import('../remote-debugger').RemoteDebugger} RemoteDebugger
  */

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -5,8 +5,18 @@ import _ from 'lodash';
 import B from 'bluebird';
 import { errors } from '@appium/base-driver';
 import { rpcConstants } from '../rpc';
+import {
+  getAppIdKey,
+  setPageLoading,
+  getPageLoadDelay,
+  getPageLoadStartegy,
+  setPageLoadDelay,
+  getPageReadyTimeout,
+  getPageIdKey,
+  setNavigatingToPage,
+} from './property-accessors';
 
-const DEFAULT_PAGE_READINESS_TIMEOUT_MS = 20 * 1000;
+export const DEFAULT_PAGE_READINESS_TIMEOUT_MS = 20 * 1000;
 const PAGE_READINESS_CHECK_INTERVAL_MS = 50;
 const PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS = 1000;
 const CONSOLE_ENABLEMENT_TIMEOUT_MS = 20 * 1000;
@@ -29,15 +39,13 @@ export function frameDetached () {
 }
 
 /**
- * @this {RemoteDebugger & HasNavigationRelatedProperties}
+ * @this {RemoteDebugger}
  * @returns {void}
  */
 export function cancelPageLoad () {
   this.log.debug('Unregistering from page readiness notifications');
-  this._pageLoading = false;
-  if (this._pageLoadDelay) {
-    this._pageLoadDelay.cancel();
-  }
+  setPageLoading(this, false);
+  getPageLoadDelay(this)?.cancel();
 }
 
 /**
@@ -49,7 +57,7 @@ export function cancelPageLoad () {
  * @returns {boolean}
  */
 export function isPageLoadingCompleted (readyState) {
-  const _pageLoadStrategy = _.toLower(this._pageLoadStrategy);
+  const _pageLoadStrategy = _.toLower(getPageLoadStartegy(this));
   if (_pageLoadStrategy === PAGE_LOAD_STRATEGY.NONE) {
     return true;
   }
@@ -70,15 +78,15 @@ export function isPageLoadingCompleted (readyState) {
  */
 export async function waitForDom (startPageLoadTimer) {
   this.log.debug('Waiting for page readiness');
-  const readinessTimeoutMs = this._pageLoadMs || DEFAULT_PAGE_READINESS_TIMEOUT_MS;
+  const readinessTimeoutMs = this.pageLoadMs;
   if (!_.isFunction(startPageLoadTimer?.getDuration)) {
     this.log.debug(`Page load timer not a timer. Creating new timer`);
     startPageLoadTimer = new timing.Timer().start();
   }
 
   let isPageLoading = true;
-  this._pageLoading = true;
-  this._pageLoadDelay = util.cancellableDelay(readinessTimeoutMs);
+  setPageLoading(this, true);
+  setPageLoadDelay(this, util.cancellableDelay(readinessTimeoutMs));
   /** @type {B<void>} */
   const pageReadinessPromise = B.resolve((async () => {
     let retry = 0;
@@ -93,7 +101,7 @@ export async function waitForDom (startPageLoadTimer) {
       );
       await B.delay(intervalMs);
       // we can get this called in the middle of trying to find a new app
-      if (!this._appIdKey) {
+      if (!getAppIdKey(this)) {
         this.log.debug('Not connected to an application. Ignoring page readiess check');
         return;
       }
@@ -119,7 +127,7 @@ export async function waitForDom (startPageLoadTimer) {
   /** @type {B<void>} */
   const cancellationPromise = B.resolve((async () => {
     try {
-      await this._pageLoadDelay;
+      await getPageLoadDelay(this);
     } catch (ign) {}
   })());
 
@@ -127,8 +135,8 @@ export async function waitForDom (startPageLoadTimer) {
     await B.any([cancellationPromise, pageReadinessPromise]);
   } finally {
     isPageLoading = false;
-    this._pageLoading = false;
-    this._pageLoadDelay = B.resolve();
+    setPageLoading(this, false);
+    setPageLoadDelay(this, B.resolve());
   }
 }
 
@@ -138,20 +146,23 @@ export async function waitForDom (startPageLoadTimer) {
  * @returns {Promise<boolean>}
  */
 export async function checkPageIsReady (timeoutMs) {
-  checkParams({appIdKey: this._appIdKey});
+  checkParams({
+    appIdKey: getAppIdKey(this),
+  });
 
   const readyCmd = 'document.readyState;';
+  const actualTimeoutMs = timeoutMs ?? getPageReadyTimeout(this);
   try {
     const readyState = await B.resolve(this.execute(readyCmd, true))
-      .timeout(timeoutMs ?? this._pageReadyTimeout);
+      .timeout(actualTimeoutMs);
     this.log.debug(`Document readyState is '${readyState}'. ` +
-      `The pageLoadStrategy is '${this._pageLoadStrategy || PAGE_LOAD_STRATEGY.NORMAL}'`);
+      `The pageLoadStrategy is '${getPageLoadStartegy(this) ?? PAGE_LOAD_STRATEGY.NORMAL}'`);
     return this.isPageLoadingCompleted(readyState);
   } catch (err) {
     if (!(err instanceof B.TimeoutError)) {
       throw err;
     }
-    this.log.debug(`Page readiness check timed out after ${this._pageReadyTimeout}ms`);
+    this.log.debug(`Page readiness check timed out after ${actualTimeoutMs}ms`);
     return false;
   }
 }
@@ -162,7 +173,10 @@ export async function checkPageIsReady (timeoutMs) {
  * @returns {Promise<void>}
  */
 export async function navToUrl (url) {
-  checkParams({appIdKey: this._appIdKey, pageIdKey: this._pageIdKey});
+  checkParams({
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
+  });
   const rpcClient = this.requireRpcClient();
 
   try {
@@ -171,17 +185,17 @@ export async function navToUrl (url) {
     throw new TypeError(`'${url}' is not a valid URL`);
   }
 
-  this._navigatingToPage = true;
+  setNavigatingToPage(this, true);
   this.log.debug(`Navigating to new URL: '${url}'`);
-  const readinessTimeoutMs = this._pageLoadMs || DEFAULT_PAGE_READINESS_TIMEOUT_MS;
+  const readinessTimeoutMs = this.pageLoadMs;
   /** @type {(() => void)|undefined} */
   let onPageLoaded;
   /** @type {(() => void)|undefined} */
   let onTargetProvisioned;
   /** @type {NodeJS.Timeout|undefined|null} */
   let onPageLoadedTimeout;
-  this._pageLoadDelay = util.cancellableDelay(readinessTimeoutMs);
-  this._pageLoading = true;
+  setPageLoadDelay(this, util.cancellableDelay(readinessTimeoutMs));
+  setPageLoading(this, true);
   let isPageLoading = true;
   let didPageFinishLoad = false;
   const start = new timing.Timer().start();
@@ -236,24 +250,24 @@ export async function navToUrl (url) {
 
     rpcClient.send('Page.navigate', {
       url,
-      appIdKey: this._appIdKey,
-      pageIdKey: this._pageIdKey,
+      appIdKey: getAppIdKey(this),
+      pageIdKey: getPageIdKey(this),
     });
   });
   /** @type {B<void>} */
   const cancellationPromise = B.resolve((async () => {
     try {
-      await this._pageLoadDelay;
+      await getPageLoadDelay(this);
     } catch (ign) {}
   })());
 
   try {
     await B.any([cancellationPromise, pageReadinessPromise]);
   } finally {
-    this._pageLoading = false;
+    setPageLoading(this, false);
     isPageLoading = false;
-    this._navigatingToPage = false;
-    this._pageLoadDelay = B.resolve();
+    setNavigatingToPage(this, false);
+    setPageLoadDelay(this, B.resolve());
     if (onPageLoadedTimeout && pageReadinessPromise.isFulfilled()) {
       clearTimeout(onPageLoadedTimeout);
       onPageLoadedTimeout = null;
@@ -270,8 +284,8 @@ export async function navToUrl (url) {
   // get notified when navigating to a local page
   try {
     await B.resolve(rpcClient.send('Console.enable', {
-      appIdKey: this._appIdKey,
-      pageIdKey: this._pageIdKey,
+      appIdKey: getAppIdKey(this),
+      pageIdKey: getPageIdKey(this),
     }, didPageFinishLoad)).timeout(CONSOLE_ENABLEMENT_TIMEOUT_MS);
   } catch (err) {
     if (err instanceof B.TimeoutError) {
@@ -283,18 +297,5 @@ export async function navToUrl (url) {
 }
 
 /**
- * @typedef {Object} HasNavigationRelatedProperties
- * @property {boolean} _pageLoading
- * @property {B<void>} _pageLoadDelay
- * @property {string | undefined} _pageLoadStrategy
- * @property {number | undefined} _pageLoadMs
- * @property {string | null | undefined} _appIdKey
- * @property {string | number | null | undefined} _pageIdKey
- * @property {boolean} _navigatingToPage
- * @property {number} _pageReadyTimeout
- * @property {(this: RemoteDebugger, command: string, override?: boolean | undefined) => Promise<any>} execute:
- */
-
-/**
- * @typedef {import('../remote-debugger').RemoteDebugger & HasNavigationRelatedProperties} RemoteDebugger
+ * @typedef {import('../remote-debugger').RemoteDebugger} RemoteDebugger
  */

--- a/lib/mixins/property-accessors.ts
+++ b/lib/mixins/property-accessors.ts
@@ -1,0 +1,96 @@
+/* eslint-disable dot-notation */
+import type { StringRecord } from '@appium/types';
+import type { RemoteDebugger } from '../remote-debugger';
+import type { EventListener } from '../types';
+
+export function getAppDict(instance: RemoteDebugger): typeof instance['_appDict'] {
+  return instance['_appDict'];
+}
+
+export function getAppIdKey(instance: RemoteDebugger): typeof instance['_appIdKey'] {
+  return instance['_appIdKey'];
+}
+
+export function setAppIdKey(instance: RemoteDebugger, value: typeof instance['_appIdKey']): void {
+  instance['_appIdKey'] = value;
+}
+
+export function getRcpClient(instance: RemoteDebugger): typeof instance['_rpcClient'] {
+  return instance['_rpcClient'];
+}
+
+export function getPageIdKey(instance: RemoteDebugger): typeof instance['_pageIdKey'] {
+  return instance['_pageIdKey'];
+}
+
+export function setPageIdKey(instance: RemoteDebugger, value: typeof instance['_pageIdKey']): void {
+  instance['_pageIdKey'] = value;
+}
+
+export function getIsSafari(instance: RemoteDebugger): typeof instance['_isSafari'] {
+  return instance['_isSafari'];
+}
+
+export function getIncludeSafari(instance: RemoteDebugger): typeof instance['_includeSafari'] {
+  return instance['_includeSafari'];
+}
+
+export function getBundleId(instance: RemoteDebugger): typeof instance['_bundleId'] {
+  return instance['_bundleId'];
+}
+
+export function getAdditionalBundleIds(instance: RemoteDebugger): typeof instance['_additionalBundleIds'] {
+  return instance['_additionalBundleIds'];
+}
+
+export function getSkippedApps(instance: RemoteDebugger): typeof instance['_skippedApps'] {
+  return instance['_skippedApps'];
+}
+
+export function getClientEventListeners(instance: RemoteDebugger): StringRecord<EventListener[]> {
+  return instance['_clientEventListeners'];
+}
+
+export function getPageLoading(instance: RemoteDebugger): boolean {
+  return instance['_pageLoading'];
+}
+
+export function setPageLoading(instance: RemoteDebugger, value: boolean): void {
+  instance['_pageLoading'] = value;
+}
+
+export function getGarbageCollectOnExecute(instance: RemoteDebugger): typeof instance['_garbageCollectOnExecute'] {
+  return instance['_garbageCollectOnExecute'];
+}
+
+export function getNavigatingToPage(instance: RemoteDebugger): typeof instance['_navigatingToPage'] {
+  return instance['_navigatingToPage'];
+}
+
+export function setNavigatingToPage(instance: RemoteDebugger, value: typeof instance['_navigatingToPage']): void {
+  instance['_navigatingToPage'] = value;
+}
+
+export function setCurrentState(instance: RemoteDebugger, value: typeof instance['_currentState']): void {
+  instance['_currentState'] = value;
+}
+
+export function setConnectedDrivers(instance: RemoteDebugger, value: typeof instance['_connectedDrivers']): void {
+  instance['_connectedDrivers'] = value;
+}
+
+export function getPageLoadDelay(instance: RemoteDebugger): typeof instance['_pageLoadDelay'] {
+  return instance['_pageLoadDelay'];
+}
+
+export function setPageLoadDelay(instance: RemoteDebugger, value: typeof instance['_pageLoadDelay']): void {
+  instance['_pageLoadDelay'] = value;
+}
+
+export function getPageLoadStartegy(instance: RemoteDebugger): typeof instance['_pageLoadStrategy'] {
+  return instance['_pageLoadStrategy'];
+}
+
+export function getPageReadyTimeout(instance: RemoteDebugger): typeof instance['_pageReadyTimeout'] {
+  return instance['_pageReadyTimeout'];
+}

--- a/lib/mixins/screenshot.js
+++ b/lib/mixins/screenshot.js
@@ -1,3 +1,8 @@
+import {
+  getAppIdKey,
+  getPageIdKey,
+} from './property-accessors';
+
 /**
  * Capture a rect of the page or by default the viewport
  * @this {RemoteDebugger}
@@ -15,8 +20,8 @@ export async function captureScreenshot(opts = {}) {
   ));
   const response = await this.requireRpcClient().send('Page.snapshotRect', {
     ...arect,
-    appIdKey: this._appIdKey,
-    pageIdKey: this._pageIdKey,
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
     coordinateSystem,
   });
 
@@ -34,12 +39,5 @@ export async function captureScreenshot(opts = {}) {
  */
 
 /**
- * @typedef {Object} HasScreenshotRelatedProperties
- * @property {string | null | undefined} _appIdKey
- * @property {string | number | null | undefined} _pageIdKey
- * @property {(this: RemoteDebugger, atom: string, args?: any[], frames?: string[]) => Promise<any>} executeAtom:
- */
-
-/**
- * @typedef {import('../remote-debugger').RemoteDebugger & HasScreenshotRelatedProperties} RemoteDebugger
+ * @typedef {import('../remote-debugger').RemoteDebugger} RemoteDebugger
  */

--- a/lib/remote-debugger.ts
+++ b/lib/remote-debugger.ts
@@ -141,6 +141,7 @@ export class RemoteDebugger extends EventEmitter {
     this._includeSafari = includeSafari;
     this._useNewSafari = useNewSafari;
     this._pageLoadMs = pageLoadMs;
+    this._allowNavigationWithoutReload = false;
     this.log.debug(`useNewSafari --> ${this._useNewSafari}`);
 
     this._garbageCollectOnExecute = garbageCollectOnExecute;
@@ -188,7 +189,9 @@ export class RemoteDebugger extends EventEmitter {
     this._pageIdKey = null;
     this._pageLoading = false;
     this._navigatingToPage = false;
-    this._allowNavigationWithoutReload = false;
+    this._currentState = undefined;
+    this._connectedDrivers = undefined;
+    this._pageLoadDelay = undefined;
 
     this._rpcClient = null;
     this._clientEventListeners = {};

--- a/lib/remote-debugger.ts
+++ b/lib/remote-debugger.ts
@@ -34,11 +34,12 @@ export class RemoteDebugger extends EventEmitter {
   protected _pageIdKey: string | number | null | undefined;
   protected _connectedDrivers: StringRecord[] | undefined;
   protected _currentState: string | undefined;
-  protected _pageLoadDelay: B<void>;
+  protected _pageLoadDelay: B<void> | undefined;
   protected _rpcClient: RpcClient | null;
   protected _pageLoading: boolean;
   protected _navigatingToPage: boolean;
   protected _allowNavigationWithoutReload: boolean;
+  protected _pageLoadMs: number | undefined;
   protected readonly _pageLoadStrategy: string | undefined;
   protected readonly _log: AppiumLogger;
   protected readonly _bundleId: string | undefined;
@@ -47,7 +48,6 @@ export class RemoteDebugger extends EventEmitter {
   protected readonly _isSafari: boolean;
   protected readonly _includeSafari: boolean;
   protected readonly _useNewSafari: boolean;
-  protected readonly _pageLoadMs: number | undefined;
   protected readonly _garbageCollectOnExecute: boolean;
   protected readonly _host: string | undefined;
   protected readonly _port: number | undefined;
@@ -163,6 +163,8 @@ export class RemoteDebugger extends EventEmitter {
 
     this._pageLoadStrategy = pageLoadStrategy;
     this._skippedApps = [];
+
+    this.setup();
   }
 
   get log(): AppiumLogger {
@@ -241,6 +243,18 @@ export class RemoteDebugger extends EventEmitter {
 
   get currentState (): string | undefined {
     return this._currentState;
+  }
+
+  get connectedDrivers (): StringRecord[] | undefined {
+    return this._connectedDrivers;
+  }
+
+  get pageLoadMs (): number {
+    return this._pageLoadMs ?? navigationMixins.DEFAULT_PAGE_READINESS_TIMEOUT_MS;
+  }
+
+  set pageLoadMs (value: number) {
+    this._pageLoadMs = value;
   }
 }
 


### PR DESCRIPTION
It looks like typescript was not really happy about the hack with mixin interfaces (which works for Python, he-he).
So I have implemented them differently using package-private accessors to make the compiler happy