### PR TITLE
fix: Start page status monitoring on page change event as well

### DIFF
--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -205,8 +205,7 @@ export async function navToUrl (url) {
 
   /** @type {B<void>} */
   const pageReadinessPromise = new B((resolve) => {
-    /** @type {() => Promise<any>} */
-    let performPageReadinessCheck = async () => {
+    const performPageReadinessCheck = async () => {
       while (isPageLoading) {
         const pageReadyCheckStart = new timing.Timer().start();
         try {

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -1,4 +1,4 @@
-import { checkParams } from '../utils';
+import { checkParams, pageArrayFromDict } from '../utils';
 import events from './events';
 import { timing, util } from '@appium/support';
 import _ from 'lodash';
@@ -173,10 +173,9 @@ export async function checkPageIsReady (timeoutMs) {
  * @returns {Promise<void>}
  */
 export async function navToUrl (url) {
-  checkParams({
-    appIdKey: getAppIdKey(this),
-    pageIdKey: getPageIdKey(this),
-  });
+  const appIdKey = getAppIdKey(this);
+  const pageIdKey = getPageIdKey(this);
+  checkParams({appIdKey, pageIdKey});
   const rpcClient = this.requireRpcClient();
 
   try {
@@ -191,6 +190,8 @@ export async function navToUrl (url) {
   /** @type {(() => void)|undefined} */
   let onPageLoaded;
   /** @type {(() => void)|undefined} */
+  let onPageChanged;
+  /** @type {(() => void)|undefined} */
   let onTargetProvisioned;
   /** @type {NodeJS.Timeout|undefined|null} */
   let onPageLoadedTimeout;
@@ -198,10 +199,29 @@ export async function navToUrl (url) {
   setPageLoading(this, true);
   let isPageLoading = true;
   let didPageFinishLoad = false;
+  /** @type {Promise<void>|null} */
+  let pageReadinessCheckPromise = null;
   const start = new timing.Timer().start();
 
   /** @type {B<void>} */
   const pageReadinessPromise = new B((resolve) => {
+    /** @type {() => Promise<any>} */
+    let performPageReadinessCheck = async () => {
+      while (isPageLoading) {
+        const pageReadyCheckStart = new timing.Timer().start();
+        try {
+          const isReady = await this.checkPageIsReady(PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS);
+          if (isReady && isPageLoading && onPageLoaded) {
+            return onPageLoaded();
+          }
+        } catch (ign) {}
+        const msLeft = PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS - pageReadyCheckStart.getDuration().asMilliSeconds;
+        if (msLeft > 0 && isPageLoading) {
+          await B.delay(msLeft);
+        }
+      }
+    };
+
     onPageLoadedTimeout = setTimeout(() => {
       if (isPageLoading) {
         isPageLoading = false;
@@ -225,33 +245,55 @@ export async function navToUrl (url) {
       didPageFinishLoad = true;
       return resolve();
     };
+
+    // Sometimes it could be observed that we do not receive
+    // any events for target provisioning while navigating to a new page,
+    // but only events related to the page change.
+    // So lets just start the monitoring loop as soon as any of these events arrives
+    // for the target page.
+    onPageChanged = async (
+      /** @type {Error|null} */ err,
+      /** @type {string} */ _appIdKey,
+      /** @type {import("@appium/types").StringRecord} */ pageDict
+    ) => {
+      if (_appIdKey !== appIdKey) {
+        return;
+      }
+
+      /** @type {import('../types').Page|undefined} */
+      const targetPage = pageArrayFromDict(pageDict)
+        .find(({id}) => parseInt(`${id}`, 10) === parseInt(`${pageIdKey}`, 10));
+      if (targetPage?.url === url) {
+        this.log.debug(`The page ${targetPage.id} got a new URL ${url}`);
+        if (pageReadinessCheckPromise) {
+          this.log.debug('Page readiness monitoring is already running');
+        } else {
+          this.log.debug('Monitoring its readiness');
+          pageReadinessCheckPromise = performPageReadinessCheck();
+          await pageReadinessCheckPromise;
+        }
+      }
+    };
+    rpcClient.on('_rpc_forwardGetListing:', onPageChanged);
+
     // https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-loadEventFired
     rpcClient.once('Page.loadEventFired', onPageLoaded);
-    // Pages that have no proper DOM structure do not fire the `Page.loadEventFired` event
-    // so we rely on the very first event after target change, which is `onTargetProvisioned`
-    // and start sending `document.readyState` requests until we either succeed or
-    // another event/timeout happens
     onTargetProvisioned = async () => {
-      while (isPageLoading) {
-        const pageReadyCheckStart = new timing.Timer().start();
-        try {
-          const isReady = await this.checkPageIsReady(PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS);
-          if (isReady && isPageLoading && onPageLoaded) {
-            return onPageLoaded();
-          }
-        } catch (ign) {}
-        const msLeft = PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS - pageReadyCheckStart.getDuration().asMilliSeconds;
-        if (msLeft > 0 && isPageLoading) {
-          await B.delay(msLeft);
-        }
+      this.log.debug('The page target has been provisioned');
+      if (pageReadinessCheckPromise) {
+        this.log.debug('Page readiness monitoring is already running');
+      } else {
+        this.log.debug('Monitoring its readiness');
+        pageReadinessCheckPromise = performPageReadinessCheck();
+        await pageReadinessCheckPromise;
       }
     };
     rpcClient.targetSubscriptions.once(rpcConstants.ON_TARGET_PROVISIONED_EVENT, onTargetProvisioned);
 
     rpcClient.send('Page.navigate', {
       url,
-      appIdKey: getAppIdKey(this),
-      pageIdKey: getPageIdKey(this),
+      appIdKey,
+      pageIdKey,
     });
   });
   /** @type {B<void>} */
@@ -277,6 +319,9 @@ export async function navToUrl (url) {
     }
     if (onPageLoaded) {
       rpcClient.off('Page.loadEventFired', onPageLoaded);
+    }
+    if (onPageChanged) {
+      rpcClient.off('_rpc_forwardGetListing:', onPageChanged);
     }
   }
 


### PR DESCRIPTION
Case without target provisioning event that this PR tries to address:

```
{"level":"VERBOSE","message":"[1a70c491][XCUITestDriver@339b] Attempting to set url 'http://127.0.0.1:8100/health'","timestamp":"2024-08-07 12:24:25.231"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Navigating to new URL: 'http://127.0.0.1:8100/health'","timestamp":"2024-08-07 12:24:25.232"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:530', page '1', target 'page-11' (id: 30): 'Page.navigate'","timestamp":"2024-08-07 12:24:25.232"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Received data response from send (id: 30): '{}'","timestamp":"2024-08-07 12:24:25.262"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Pages changed for PID:530: [{\"id\":1,\"title\":\"\",\"url\":\"about:blank\",\"isKey\":false}] -> [{\"id\":1,\"title\":\"\",\"url\":\"about:blank\",\"isKey\":true}]","timestamp":"2024-08-07 12:24:25.264"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Notified that an application has been updated","timestamp":"2024-08-07 12:24:25.264"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Sending to Web Inspector took 32ms","timestamp":"2024-08-07 12:24:25.264"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Pages changed for PID:530: [{\"id\":1,\"title\":\"\",\"url\":\"about:blank\",\"isKey\":true}] -> [{\"id\":1,\"title\":\"Health Check\",\"url\":\"http://127.0.0.1:8100/health\",\"isKey\":true}]","timestamp":"2024-08-07 12:24:25.398"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Notified that an application has been updated","timestamp":"2024-08-07 12:24:25.454"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Notified that an application has been updated","timestamp":"2024-08-07 12:24:25.456"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Notified that new application 'PID:540' has connected","timestamp":"2024-08-07 12:24:25.511"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Notified that an application has been updated","timestamp":"2024-08-07 12:24:25.626"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Notified that new application 'PID:542' has connected","timestamp":"2024-08-07 12:24:27.674"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Notified that an application has been updated","timestamp":"2024-08-07 12:24:27.950"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Timed out after 6000ms of waiting for the http://127.0.0.1:8100/health page readiness. Continuing anyway","timestamp":"2024-08-07 12:24:31.232"}
```

Case with provisioning event:

```
{"level":"VERBOSE","message":"[1a70c491][XCUITestDriver@339b] Attempting to set url 'https://www.example.io/referral'","timestamp":"2024-08-07 12:24:34.651"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Navigating to new URL: 'https://www.example.io/referral'","timestamp":"2024-08-07 12:24:34.651"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:530', page '1', target 'page-11' (id: 34): 'Page.navigate'","timestamp":"2024-08-07 12:24:34.651"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Received data response from send (id: 34): '{}'","timestamp":"2024-08-07 12:24:34.664"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Sending to Web Inspector took 13ms","timestamp":"2024-08-07 12:24:34.664"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Provisional target created for app 'PID:530', 'page-25'. Ignoring until target update event","timestamp":"2024-08-07 12:24:34.689"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Notified that an application has been updated","timestamp":"2024-08-07 12:24:34.695"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Notified that an application has been updated","timestamp":"2024-08-07 12:24:34.697"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Target updated for app 'PID:530'. Old target: 'page-11', new target: 'page-25'","timestamp":"2024-08-07 12:24:35.042"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Target destroyed for app 'PID:530': page-11","timestamp":"2024-08-07 12:24:35.045"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Found provisional target for app 'PID:530'. Old target: 'page-11', new target: 'page-25'. Updating","timestamp":"2024-08-07 12:24:35.045"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:530', page '1', target 'page-25' (id: 36): 'Page.enable'","timestamp":"2024-08-07 12:24:35.045"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Received data response from send (id: 36): '{}'","timestamp":"2024-08-07 12:24:35.073"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Sending javascript command: 'document.readyState;'","timestamp":"2024-08-07 12:24:35.073"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:530', page '1', target 'page-25' (id: 38): 'Runtime.evaluate'","timestamp":"2024-08-07 12:24:35.073"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Notified that an application has been updated","timestamp":"2024-08-07 12:24:35.074"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Received data response from send (id: 38): '\"loading\"'","timestamp":"2024-08-07 12:24:35.117"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Sending to Web Inspector took 43ms","timestamp":"2024-08-07 12:24:35.117"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Document readyState is 'loading'. The pageLoadStrategy is 'normal'","timestamp":"2024-08-07 12:24:35.117"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Notified that an application has been updated","timestamp":"2024-08-07 12:24:35.143"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Pages changed for PID:530: [{\"id\":1,\"title\":\"Health Check\",\"url\":\"http://127.0.0.1:8100/health\",\"isKey\":true}] -> [{\"id\":1,\"title\":\"Referral\",\"url\":\"https://www.example.io/referral\",\"isKey\":true}]","timestamp":"2024-08-07 12:24:35.243"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Received page change notice for app 'PID:530' but the listing has not changed. Ignoring.","timestamp":"2024-08-07 12:24:35.583"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] The page https://www.example.io/referral is ready in 938ms","timestamp":"2024-08-07 12:24:35.590"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:530', page '1', target 'page-25' (id: 40): 'Console.enable'","timestamp":"2024-08-07 12:24:35.590"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Received data response from send (id: 40): '{}'","timestamp":"2024-08-07 12:24:35.649"}
{"level":"VERBOSE","message":"[1a70c491][RemoteDebugger] Sending to Web Inspector took 59ms","timestamp":"2024-08-07 12:24:35.649"}
{"level":"VERBOSE","message":"[1a70c491][XCUITestDriver@339b] Responding to client with driver.setUrl() result: null","timestamp":"2024-08-07 12:24:35.649"}
```