### PR TITLE
fix: Tune page initialization

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -34,7 +34,9 @@ jobs:
       with:
         node-version: lts/*
         check-latest: true
-    - name: Prepare iOS simulator
+    - name: Start iOS Simulator UI
+      run: open -Fn "$(xcode-select --print-path)/Applications/Simulator.app"
+    - name: Boot iOS Simulator
       id: prepareSimulator
       uses: futureware-tech/simulator-action@v4
       with:

--- a/lib/remote-debugger.ts
+++ b/lib/remote-debugger.ts
@@ -32,35 +32,35 @@ export class RemoteDebugger extends EventEmitter {
   protected _skippedApps: string[];
   protected _clientEventListeners: StringRecord<EventListener[]>;
   protected _appDict: AppDict;
-  protected _appIdKey: AppIdKey | null | undefined;
-  protected _pageIdKey: PageIdKey | null | undefined;
-  protected _connectedDrivers: StringRecord[] | undefined;
-  protected _currentState: string | undefined;
-  protected _pageLoadDelay: B<void> | undefined;
+  protected _appIdKey?: AppIdKey;
+  protected _pageIdKey?: PageIdKey;
+  protected _connectedDrivers?: StringRecord[];
+  protected _currentState?: string;
+  protected _pageLoadDelay?: B<void>;
   protected _rpcClient: RpcClient | null;
   protected _pageLoading: boolean;
   protected _navigatingToPage: boolean;
   protected _allowNavigationWithoutReload: boolean;
-  protected _pageLoadMs: number | undefined;
-  protected readonly _pageLoadStrategy: string | undefined;
+  protected _pageLoadMs?: number;
+  protected readonly _pageLoadStrategy?: string;
   protected readonly _log: AppiumLogger;
-  protected readonly _bundleId: string | undefined;
-  protected readonly _additionalBundleIds: string[] | undefined;
-  protected readonly _platformVersion: string | undefined;
+  protected readonly _bundleId?: string;
+  protected readonly _additionalBundleIds?: string[];
+  protected readonly _platformVersion?: string;
   protected readonly _isSafari: boolean;
   protected readonly _includeSafari: boolean;
   protected readonly _useNewSafari: boolean;
   protected readonly _garbageCollectOnExecute: boolean;
-  protected readonly _host: string | undefined;
-  protected readonly _port: number | undefined;
-  protected readonly _socketPath: string | undefined;
-  protected readonly _remoteDebugProxy: any | undefined;
+  protected readonly _host?: string;
+  protected readonly _port?: number;
+  protected readonly _socketPath?: string;
+  protected readonly _remoteDebugProxy?: any;
   protected readonly _pageReadyTimeout: number;
   protected readonly _logAllCommunication: boolean;
   protected readonly _logAllCommunicationHexDump: boolean;
-  protected readonly _socketChunkSize: number | undefined;
-  protected readonly _webInspectorMaxFrameLength: number | undefined;
-  protected readonly _fullPageInitialization: boolean | undefined;
+  protected readonly _socketChunkSize?: number;
+  protected readonly _webInspectorMaxFrameLength?: number;
+  protected readonly _fullPageInitialization?: boolean;
 
   // events
   static readonly EVENT_PAGE_CHANGE: string;
@@ -187,8 +187,8 @@ export class RemoteDebugger extends EventEmitter {
   setup (): void {
     // app handling configuration
     this._appDict = {};
-    this._appIdKey = null;
-    this._pageIdKey = null;
+    this._appIdKey = undefined;
+    this._pageIdKey = undefined;
     this._pageLoading = false;
     this._navigatingToPage = false;
     this._currentState = undefined;
@@ -203,8 +203,8 @@ export class RemoteDebugger extends EventEmitter {
     this.log.debug('Cleaning up listeners');
 
     this._appDict = {};
-    this._appIdKey = null;
-    this._pageIdKey = null;
+    this._appIdKey = undefined;
+    this._pageIdKey = undefined;
     this._pageLoading = false;
 
     this._rpcClient = null;

--- a/lib/rpc/remote-messages.js
+++ b/lib/rpc/remote-messages.js
@@ -81,7 +81,7 @@ export class RemoteMessages {
    * @param {string} connId
    * @param {string} senderId
    * @param {import('../types').AppIdKey} appIdKey
-   * @param {import('../types').PageIdKey} pageIdKey
+   * @param {import('../types').PageIdKey} [pageIdKey]
    * @returns {import('../types').RemoteCommand}
    */
   setSenderKey (connId, senderId, appIdKey, pageIdKey) {
@@ -101,8 +101,8 @@ export class RemoteMessages {
    *
    * @param {string} connId
    * @param {import('../types').AppIdKey} appIdKey
-   * @param {import('../types').PageIdKey} pageIdKey
-   * @param {boolean} enabled
+   * @param {import('../types').PageIdKey} [pageIdKey]
+   * @param {boolean} [enabled]
    * @returns {import('../types').RemoteCommand}
    */
   indicateWebView (connId, appIdKey, pageIdKey, enabled) {
@@ -291,18 +291,18 @@ export class RemoteMessages {
         }
         return this.setConnectionKey(connId);
       case 'indicateWebView':
-        if (!connId) {
-          throw new Error('Cannot indicate web view without a connection ID');
+        if (!connId || !appIdKey) {
+          throw new Error('Cannot indicate web view without a connection ID and app ID');
         }
         return this.indicateWebView(connId, appIdKey, pageIdKey, !!opts.enabled);
       case 'connectToApp':
-        if (!connId) {
-          throw new Error('Cannot connect to app without a connection ID');
+        if (!connId || !appIdKey) {
+          throw new Error('Cannot connect to app without a connection ID and app ID');
         }
         return this.connectToApp(connId, appIdKey);
       case 'setSenderKey':
-        if (!connId || !senderId) {
-          throw new Error('Cannot set sender key without a connection ID and sender ID');
+        if (!connId || !senderId || !appIdKey) {
+          throw new Error('Cannot set sender key without a connection ID, sender ID, and app ID');
         }
         return this.setSenderKey(connId, senderId, appIdKey, pageIdKey);
       case 'launchApplication':
@@ -315,7 +315,7 @@ export class RemoteMessages {
     // deal with WebKit commands
     const builderFunction = COMMANDS[command] || MINIMAL_COMMAND;
     return this[builderFunction]({
-      ...getProtocolCommand(id, command, opts),
+      ...getProtocolCommand(/** @type {string} */ (id), command, opts),
       connId,
       appIdKey,
       senderId,

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -298,11 +298,11 @@ export class RpcClient {
   /**
    *
    * @param {string} command
-   * @param {Record<string, any>} [opts]
+   * @param {import('../types').RemoteCommandOpts} opts
    * @param {boolean} [waitForResponse]
    * @returns {Promise<any>}
    */
-  async send (command, opts = {}, waitForResponse = true) {
+  async send (command, opts, waitForResponse = true) {
     const timer = new timing.Timer().start();
     const {
       appIdKey,
@@ -319,9 +319,9 @@ export class RpcClient {
         );
         this.isTargetBased = false;
         return await this.sendToDevice(command, opts, waitForResponse);
-      } else if (NO_TARGET_PRESENT_YET_ERRORS.some((error) => messageLc.includes(error))) {
+      } else if (appIdKey && NO_TARGET_PRESENT_YET_ERRORS.some((error) => messageLc.includes(error))) {
         this.isTargetBased = true;
-        await this.waitForTarget(appIdKey, pageIdKey);
+        await this.waitForTarget(appIdKey, /** @type {import('../types').PageIdKey} */ (pageIdKey));
         return await this.sendToDevice(command, opts, waitForResponse);
       }
       throw err;
@@ -333,11 +333,11 @@ export class RpcClient {
   /**
    *
    * @param {string} command
-   * @param {Record<string, any>} opts
+   * @param {import('../types').RemoteCommandOpts} opts
    * @param {boolean} [waitForResponse]
    * @returns {Promise<any>}
    */
-  async sendToDevice (command, opts = {}, waitForResponse = true) {
+  async sendToDevice (command, opts, waitForResponse = true) {
     return await new B(async (resolve, reject) => {
       // promise to be resolved whenever remote debugger
       // replies to our request
@@ -579,11 +579,14 @@ export class RpcClient {
   }
 
   /**
-   * @param {import('../types').AppIdKey} appIdKey
-   * @param {import('../types').PageIdKey} pageIdKey
-   * @returns {any}
+   * @param {import('../types').AppIdKey} [appIdKey]
+   * @param {import('../types').PageIdKey} [pageIdKey]
+   * @returns {string | undefined}
    */
   getTarget (appIdKey, pageIdKey) {
+    if (!appIdKey || !pageIdKey) {
+      return;
+    }
     return (this.targets[appIdKey] || {})[pageIdKey];
   }
 
@@ -641,17 +644,25 @@ export class RpcClient {
       pageIdKey,
     };
 
-    await this.send('Inspector.enable', sendOpts, false);
-    await this.send('Page.enable', sendOpts, false);
+    // The sequence of domains is important
+    for (const domain of [
+      'Inspector.enable',
+      'Page.enable',
+      'Runtime.enable',
 
-    // go through the tasks to initialize
-    await this.send('Network.enable', sendOpts, false);
-    await this.send('Runtime.enable', sendOpts, false);
-    await this.send('Heap.enable', sendOpts, false);
-    await this.send('Debugger.enable', sendOpts, false);
-    await this.send('Console.enable', sendOpts, false);
+      'Network.enable',
+      'Heap.enable',
+      'Debugger.enable',
+      'Console.enable',
 
-    await this.send('Inspector.initialized', sendOpts);
+      'Inspector.initialized',
+    ]) {
+      try {
+        await this.send(domain, sendOpts);
+      } catch (err) {
+        log.info(`Cannot enable domain '${domain}' during initialization: ${err.message}`);
+      }
+    }
   }
 
   /**
@@ -668,61 +679,84 @@ export class RpcClient {
       pageIdKey,
     };
 
-    await this.send('Inspector.enable', sendOpts, false);
-    await this.send('Page.enable', sendOpts, false);
+    // The sequence of commands here is important
+    const domainsToOptsMap = {
+      'Inspector.enable': sendOpts,
+      'Page.enable': sendOpts,
+      'Runtime.enable': sendOpts,
 
-    // go through the tasks to initialize
-    await this.send('Page.getResourceTree', sendOpts, false);
-    await this.send('Network.enable', sendOpts, false);
-    await this.send('Network.setResourceCachingDisabled', Object.assign({
-      disabled: false,
-    }, sendOpts), false);
-    await this.send('DOMStorage.enable', sendOpts, false);
-    await this.send('Database.enable', sendOpts, false);
-    await this.send('IndexedDB.enable', sendOpts, false);
-    await this.send('CSS.enable', sendOpts, false);
-    await this.send('Runtime.enable', sendOpts, false);
-    await this.send('Heap.enable', sendOpts, false);
-    await this.send('Memory.enable', sendOpts, false);
-    await this.send('ApplicationCache.enable', sendOpts, false);
-    await this.send('ApplicationCache.getFramesWithManifests', sendOpts, false);
-    await this.send('Timeline.setInstruments', Object.assign({
-      instruments: ['Timeline', 'ScriptProfiler', 'CPU'],
-    }, sendOpts), false);
-    await this.send('Timeline.setAutoCaptureEnabled', Object.assign({
-      enabled: false,
-    }, sendOpts), false);
-    await this.send('Debugger.enable', sendOpts, false);
-    await this.send('Debugger.setBreakpointsActive', Object.assign({
-      active: true,
-    }, sendOpts), false);
-    await this.send('Debugger.setPauseOnExceptions', Object.assign({
-      state: 'none',
-    }, sendOpts), false);
-    await this.send('Debugger.setPauseOnAssertions', Object.assign({
-      enabled: false,
-    }, sendOpts), false);
-    await this.send('Debugger.setAsyncStackTraceDepth', Object.assign({
-      depth: 200,
-    }, sendOpts), false);
-    await this.send('Debugger.setPauseForInternalScripts', Object.assign({
-      shouldPause: false,
-    }, sendOpts), false);
+      'Page.getResourceTree': sendOpts,
+      'Network.enable': sendOpts,
+      'Network.setResourceCachingDisabled': {
+        disabled: false,
+        ...sendOpts,
+      },
+      'DOMStorage.enable': sendOpts,
+      'Database.enable': sendOpts,
+      'IndexedDB.enable': sendOpts,
+      'CSS.enable': sendOpts,
+      'Heap.enable': sendOpts,
+      'Memory.enable': sendOpts,
+      'ApplicationCache.enable': sendOpts,
+      'ApplicationCache.getFramesWithManifests': sendOpts,
+      'Timeline.setInstruments': {
+        instruments: ['Timeline', 'ScriptProfiler', 'CPU'],
+        ...sendOpts,
+      },
+      'Timeline.setAutoCaptureEnabled': {
+        enabled: false,
+        ...sendOpts,
+      },
+      'Debugger.enable': sendOpts,
+      'Debugger.setBreakpointsActive': {
+        active: true,
+        ...sendOpts,
+      },
+      'Debugger.setPauseOnExceptions': {
+        state: 'none',
+        ...sendOpts,
+      },
+      'Debugger.setPauseOnAssertions': {
+        enabled: false,
+        ...sendOpts,
+      },
+      'Debugger.setAsyncStackTraceDepth': {
+        depth: 200,
+        ...sendOpts,
+      },
+      'Debugger.setPauseForInternalScripts': {
+        shouldPause: false,
+        ...sendOpts,
+      },
+      'LayerTree.enable': sendOpts,
+      'Worker.enable': sendOpts,
+      'Canvas.enable': sendOpts,
+      'Console.enable': sendOpts,
+      'DOM.getDocument': sendOpts,
+      'Console.getLoggingChannels': sendOpts,
 
-    await this.send('LayerTree.enable', sendOpts, false);
-    await this.send('Worker.enable', sendOpts, false);
-    await this.send('Canvas.enable', sendOpts, false);
-    await this.send('Console.enable', sendOpts, false);
-    await this.send('DOM.getDocument', sendOpts, false);
-    const loggingChannels = await this.send('Console.getLoggingChannels', sendOpts);
-    for (const source of (loggingChannels.channels || []).map((entry) => entry.source)) {
-      await this.send('Console.setLoggingChannelLevel', Object.assign({
-        source,
-        level: 'verbose',
-      }, sendOpts), false);
+      'Inspector.initialized': sendOpts,
+    };
+
+    for (const [domain, opts] of Object.entries(domainsToOptsMap)) {
+      try {
+        const res = await this.send(domain, opts);
+        if (domain === 'Console.getLoggingChannels') {
+          for (const source of (res?.channels || []).map((/** @type {{ source: any; }} */ entry) => entry.source)) {
+            try {
+              await this.send('Console.setLoggingChannelLevel', Object.assign({
+                source,
+                level: 'verbose',
+              }, sendOpts));
+            } catch (err) {
+              log.info(`Cannot set logging channel level for '${source}': ${err.message}`);
+            }
+          }
+        }
+      } catch (err) {
+        log.info(`Cannot enable domain '${domain}' during full initialization: ${err.message}`);
+      }
     }
-
-    await this.send('Inspector.initialized', sendOpts);
   }
 
   /**

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -548,11 +548,10 @@ export class RpcClient {
           targets[page] = newTargetId;
           const opts = {appIdKey: app, pageIdKey: parseInt(page, 10)};
           (async () => {
-            try {
-              // This is needed to enable the broadcast of page lifecycle events
-              await this.sendToDevice('Page.enable', opts, true);
-            } catch (err) {
-              log.warn(err.message);
+            if (this.fullPageInitialization) {
+              await this.initializePageFull(opts.appIdKey, opts.pageIdKey);
+            } else {
+              await this.initializePage(opts.appIdKey, opts.pageIdKey);
             }
             this._targetSubscriptions.emit(ON_TARGET_PROVISIONED_EVENT, {
               ...opts,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -85,14 +85,15 @@ export type AppIdKey = string | number;
 export type PageIdKey = string | number;
 
 export interface RemoteCommandOpts {
-  appIdKey: AppIdKey;
-  pageIdKey: PageIdKey;
-  id: string;
+  appIdKey?: AppIdKey;
+  pageIdKey?: PageIdKey;
+  id?: string;
   connId?: string;
   senderId?: string;
   targetId?: string;
   bundleId?: string;
   enabled?: boolean;
+  [key: string]: any;
 }
 
 export interface ProtocolCommandOpts {


### PR DESCRIPTION
Internet says that Safari's remote debugger is fragile, that is why it makes sense to enable domains sequentially and in the particular order to avoid possible issues later.