### PR TITLE
refactor: Introduce pauseOnStart for targets creation

### DIFF
--- a/lib/mixins/connect.js
+++ b/lib/mixins/connect.js
@@ -240,7 +240,7 @@ async function searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
         if (![NEW_APP_CONNECTED_ERROR, EMPTY_PAGE_DICTIONARY_ERROR].some((msg) => msg === err.message)) {
           this.log.debug(err.stack);
         }
-        this.log.warn(`Error checking application ${attemptedAppIdKey}: '${err.message}'`);
+        this.log.warn(`The application ${attemptedAppIdKey} is not connectable yet: ${err.message}`);
       }
     }
     retryCount++;

--- a/lib/mixins/connect.js
+++ b/lib/mixins/connect.js
@@ -18,6 +18,7 @@ import {
   getBundleId,
   getAdditionalBundleIds,
 } from './property-accessors';
+import { NEW_APP_CONNECTED_ERROR, EMPTY_PAGE_DICTIONARY_ERROR } from '../rpc/rpc-client';
 
 const APP_CONNECT_TIMEOUT_MS = 0;
 const APP_CONNECT_INTERVAL_MS = 100;
@@ -236,7 +237,9 @@ async function searchForApp (currentUrl, maxTries, ignoreAboutBlankUrl) {
           this.log.debug('Received app, but no match was found. Trying again.');
         }
       } catch (err) {
-        this.log.debug(err.stack);
+        if (![NEW_APP_CONNECTED_ERROR, EMPTY_PAGE_DICTIONARY_ERROR].some((msg) => msg === err.message)) {
+          this.log.debug(err.stack);
+        }
         this.log.warn(`Error checking application ${attemptedAppIdKey}: '${err.message}'`);
       }
     }

--- a/lib/mixins/connect.js
+++ b/lib/mixins/connect.js
@@ -118,48 +118,41 @@ export async function disconnect () {
  */
 export async function selectApp (currentUrl = null, maxTries = SELECT_APP_RETRIES, ignoreAboutBlankUrl = false) {
   this.log.debug('Selecting application');
-  const rpcClient = this.requireRpcClient();
 
-  const shouldCheckForTarget = rpcClient.shouldCheckForTarget;
-  rpcClient.shouldCheckForTarget = false;
-  try {
-    const timer = new timing.Timer().start();
-    if (_.isEmpty(getAppDict(this))) {
-      this.log.debug('No applications currently connected.');
-      return [];
-    }
-
-    const { appIdKey } = await searchForApp.bind(this)(currentUrl, maxTries, ignoreAboutBlankUrl);
-    if (getAppIdKey(this) !== appIdKey) {
-      this.log.debug(`Received altered app id, updating from '${getAppIdKey(this)}' to '${appIdKey}'`);
-      setAppIdKey(this, appIdKey);
-    }
-    logApplicationDictionary.bind(this)();
-    // translate the dictionary into a useful form, and return to sender
-    this.log.debug(`Finally selecting app ${getAppIdKey(this)}`);
-
-    /** @type {import('../types').Page[]} */
-    const fullPageArray = [];
-    for (const [app, info] of _.toPairs(getAppDict(this))) {
-      if (!_.isArray(info.pageArray) || !info.isActive) {
-        continue;
-      }
-      const id = app.replace('PID:', '');
-      for (const page of info.pageArray) {
-        if (!(ignoreAboutBlankUrl && page.url === BLANK_PAGE_URL)) {
-          const pageDict = _.clone(page);
-          pageDict.id = `${id}.${pageDict.id}`;
-          pageDict.bundleId = info.bundleId;
-          fullPageArray.push(pageDict);
-        }
-      }
-    }
-
-    this.log.debug(`Selected app after ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
-    return fullPageArray;
-  } finally {
-    rpcClient.shouldCheckForTarget = shouldCheckForTarget;
+  const timer = new timing.Timer().start();
+  if (_.isEmpty(getAppDict(this))) {
+    this.log.debug('No applications currently connected.');
+    return [];
   }
+
+  const { appIdKey } = await searchForApp.bind(this)(currentUrl, maxTries, ignoreAboutBlankUrl);
+  if (getAppIdKey(this) !== appIdKey) {
+    this.log.debug(`Received altered app id, updating from '${getAppIdKey(this)}' to '${appIdKey}'`);
+    setAppIdKey(this, appIdKey);
+  }
+  logApplicationDictionary.bind(this)();
+  // translate the dictionary into a useful form, and return to sender
+  this.log.debug(`Finally selecting app ${getAppIdKey(this)}`);
+
+  /** @type {import('../types').Page[]} */
+  const fullPageArray = [];
+  for (const [app, info] of _.toPairs(getAppDict(this))) {
+    if (!_.isArray(info.pageArray) || !info.isActive) {
+      continue;
+    }
+    const id = app.replace('PID:', '');
+    for (const page of info.pageArray) {
+      if (!(ignoreAboutBlankUrl && page.url === BLANK_PAGE_URL)) {
+        const pageDict = _.clone(page);
+        pageDict.id = `${id}.${pageDict.id}`;
+        pageDict.bundleId = info.bundleId;
+        fullPageArray.push(pageDict);
+      }
+    }
+  }
+
+  this.log.debug(`Selected app after ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
+  return fullPageArray;
 }
 
 /**

--- a/lib/mixins/execute.js
+++ b/lib/mixins/execute.js
@@ -140,23 +140,26 @@ export async function execute (command, override) {
     await this.waitForDom();
   }
 
-  if (_.isNil(getAppIdKey(this))) {
-    throw new Error('Missing parameter: appIdKey. Is the target web application still alive?');
-  }
-  if (_.isNil(getPageIdKey(this))) {
-    throw new Error('Missing parameter: pageIdKey. Is the target web page still alive?');
-  }
+  const {appIdKey, pageIdKey} = checkParams({
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
+  });
 
   if (getGarbageCollectOnExecute(this)) {
     await this.garbageCollect();
   }
 
+  const rpcClient = this.requireRpcClient(true);
+  await rpcClient.waitForPageInitialization(
+    /** @type {import('../types').AppIdKey} */ (appIdKey),
+    /** @type {import('../types').PageIdKey} */ (pageIdKey)
+  );
   this.log.debug(`Sending javascript command: '${_.truncate(command, {length: 50})}'`);
-  const res = await this.requireRpcClient(true).send('Runtime.evaluate', {
+  const res = await rpcClient.send('Runtime.evaluate', {
     expression: command,
     returnByValue: true,
-    appIdKey: getAppIdKey(this),
-    pageIdKey: getPageIdKey(this),
+    appIdKey,
+    pageIdKey,
   });
   return convertResult(res);
 }
@@ -168,7 +171,7 @@ export async function execute (command, override) {
  * @param {any[]} [args]
  */
 export async function callFunction (objectId, fn, args) {
-  checkParams({
+  const {appIdKey, pageIdKey} = checkParams({
     appIdKey: getAppIdKey(this),
     pageIdKey: getPageIdKey(this),
   });
@@ -183,8 +186,8 @@ export async function callFunction (objectId, fn, args) {
     functionDeclaration: fn,
     arguments: args,
     returnByValue: true,
-    appIdKey: getAppIdKey(this),
-    pageIdKey: getPageIdKey(this),
+    appIdKey,
+    pageIdKey,
   });
 
   return convertResult(res);

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -1,10 +1,9 @@
-import { checkParams, pageArrayFromDict } from '../utils';
+import { checkParams } from '../utils';
 import { events } from './events';
 import { timing, util } from '@appium/support';
 import _ from 'lodash';
 import B, { TimeoutError as BTimeoutError } from 'bluebird';
 import { errors } from '@appium/base-driver';
-import { rpcConstants } from '../rpc';
 import {
   getAppIdKey,
   setPageLoading,
@@ -15,10 +14,10 @@ import {
   getPageIdKey,
   setNavigatingToPage,
 } from './property-accessors';
+import { toLockKey } from '../rpc/rpc-client';
 
 export const DEFAULT_PAGE_READINESS_TIMEOUT_MS = 20 * 1000;
 const PAGE_READINESS_CHECK_INTERVAL_MS = 50;
-const PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS = 1000;
 const CONSOLE_ENABLEMENT_TIMEOUT_MS = 20 * 1000;
 
 /**
@@ -184,160 +183,99 @@ export async function navToUrl (url) {
     throw new TypeError(`'${url}' is not a valid URL`);
   }
 
-  setNavigatingToPage(this, true);
-  this.log.debug(`Navigating to new URL: '${url}'`);
-  const readinessTimeoutMs = this.pageLoadMs;
-  /** @type {(() => void)|undefined} */
-  let onPageLoaded;
-  /** @type {(() => void)|undefined} */
-  let onPageChanged;
-  /** @type {(() => void)|undefined} */
-  let onTargetProvisioned;
-  /** @type {NodeJS.Timeout|undefined|null} */
-  let onPageLoadedTimeout;
-  setPageLoadDelay(this, util.cancellableDelay(readinessTimeoutMs));
-  setPageLoading(this, true);
-  let isPageLoading = true;
-  let didPageFinishLoad = false;
-  /** @type {Promise<void>|null} */
-  let pageReadinessCheckPromise = null;
-  const start = new timing.Timer().start();
+  const appTargets = rpcClient.targets[/** @type {import('../types').AppIdKey} */ (appIdKey)];
+  const lockKey = toLockKey(
+    /** @type {import('../types').AppIdKey} */ (appIdKey),
+    /** @type {import('../types').PageIdKey} */ (pageIdKey)
+  );
+  await appTargets.lock.acquire(lockKey, async () => {
+    setNavigatingToPage(this, true);
+    this.log.debug(`Navigating to new URL: '${url}'`);
+    const readinessTimeoutMs = this.pageLoadMs;
+    /** @type {(() => void)|undefined} */
+    let onPageLoaded;
+    /** @type {NodeJS.Timeout|undefined|null} */
+    let onPageLoadedTimeout;
+    setPageLoadDelay(this, util.cancellableDelay(readinessTimeoutMs));
+    setPageLoading(this, true);
+    let isPageLoading = true;
+    let didPageFinishLoad = false;
+    // /** @type {Promise<void>|null} */
+    const start = new timing.Timer().start();
 
-  /** @type {B<void>} */
-  const pageReadinessPromise = new B((resolve) => {
-    const performPageReadinessCheck = async () => {
-      while (isPageLoading) {
-        const pageReadyCheckStart = new timing.Timer().start();
-        try {
-          const isReady = await this.checkPageIsReady(PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS);
-          if (isReady && isPageLoading && onPageLoaded) {
-            return onPageLoaded();
-          }
-        } catch {}
-        const msLeft = PAGE_READINESS_JS_MIN_CHECK_INTERVAL_MS - pageReadyCheckStart.getDuration().asMilliSeconds;
-        if (msLeft > 0 && isPageLoading) {
-          await B.delay(msLeft);
+    /** @type {B<void>} */
+    const pageReadinessPromise = new B((resolve) => {
+      onPageLoadedTimeout = setTimeout(() => {
+        if (isPageLoading) {
+          isPageLoading = false;
+          this.log.info(
+            `Timed out after ${start.getDuration().asMilliSeconds.toFixed(0)}ms of waiting ` +
+            `for the ${url} page readiness. Continuing anyway`
+          );
         }
-      }
-    };
+        return resolve();
+      }, readinessTimeoutMs);
 
-    onPageLoadedTimeout = setTimeout(() => {
-      if (isPageLoading) {
-        isPageLoading = false;
-        this.log.info(
-          `Timed out after ${start.getDuration().asMilliSeconds.toFixed(0)}ms of waiting ` +
-          `for the ${url} page readiness. Continuing anyway`
-        );
-      }
-      return resolve();
-    }, readinessTimeoutMs);
+      onPageLoaded = () => {
+        if (isPageLoading) {
+          isPageLoading = false;
+          this.log.debug(`The page ${url} is ready in ${start.getDuration().asMilliSeconds.toFixed(0)}ms`);
+        }
+        if (onPageLoadedTimeout) {
+          clearTimeout(onPageLoadedTimeout);
+          onPageLoadedTimeout = null;
+        }
+        didPageFinishLoad = true;
+        return resolve();
+      };
 
-    onPageLoaded = () => {
-      if (isPageLoading) {
-        isPageLoading = false;
-        this.log.debug(`The page ${url} is ready in ${start.getDuration().asMilliSeconds.toFixed(0)}ms`);
-      }
-      if (onPageLoadedTimeout) {
+      // https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-loadEventFired
+      rpcClient.once('Page.loadEventFired', onPageLoaded);
+
+      rpcClient.send('Page.navigate', {
+        url,
+        appIdKey,
+        pageIdKey,
+      });
+    });
+    /** @type {B<void>} */
+    const cancellationPromise = B.resolve((async () => {
+      try {
+        await getPageLoadDelay(this);
+      } catch {}
+    })());
+
+    try {
+      await B.any([cancellationPromise, pageReadinessPromise]);
+    } finally {
+      setPageLoading(this, false);
+      isPageLoading = false;
+      setNavigatingToPage(this, false);
+      setPageLoadDelay(this, B.resolve());
+      if (onPageLoadedTimeout && pageReadinessPromise.isFulfilled()) {
         clearTimeout(onPageLoadedTimeout);
         onPageLoadedTimeout = null;
       }
-      didPageFinishLoad = true;
-      return resolve();
-    };
-
-    // Sometimes it could be observed that we do not receive
-    // any events for target provisioning while navigating to a new page,
-    // but only events related to the page change.
-    // So lets just start the monitoring loop as soon as any of these events arrives
-    // for the target page.
-    onPageChanged = async (
-      /** @type {Error|null} */ err,
-      /** @type {string} */ _appIdKey,
-      /** @type {import("@appium/types").StringRecord} */ pageDict
-    ) => {
-      if (_appIdKey !== appIdKey) {
-        return;
+      if (onPageLoaded) {
+        rpcClient.off('Page.loadEventFired', onPageLoaded);
       }
+    }
 
-      /** @type {import('../types').Page|undefined} */
-      const targetPage = pageArrayFromDict(pageDict)
-        .find(({id}) => parseInt(`${id}`, 10) === parseInt(`${pageIdKey}`, 10));
-      if (targetPage?.url === url) {
-        this.log.debug(`The page ${targetPage.id} has the expected URL ${url}`);
-        if (pageReadinessCheckPromise) {
-          this.log.debug('Page readiness monitoring is already running');
-        } else {
-          this.log.debug('Monitoring page readiness');
-          pageReadinessCheckPromise = performPageReadinessCheck();
-          await pageReadinessCheckPromise;
-        }
-      }
-    };
-    rpcClient.on('_rpc_forwardGetListing:', onPageChanged);
-
-    // https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-loadEventFired
-    rpcClient.once('Page.loadEventFired', onPageLoaded);
-    onTargetProvisioned = async () => {
-      this.log.debug('The page target has been provisioned');
-      if (pageReadinessCheckPromise) {
-        this.log.debug('Page readiness monitoring is already running');
-      } else {
-        this.log.debug('Monitoring page readiness');
-        pageReadinessCheckPromise = performPageReadinessCheck();
-        await pageReadinessCheckPromise;
-      }
-    };
-    rpcClient.targetSubscriptions.once(rpcConstants.ON_TARGET_PROVISIONED_EVENT, onTargetProvisioned);
-
-    rpcClient.send('Page.navigate', {
-      url,
-      appIdKey,
-      pageIdKey,
-    });
-  });
-  /** @type {B<void>} */
-  const cancellationPromise = B.resolve((async () => {
+    // enable console logging, so we get the events (otherwise we only
+    // get notified when navigating to a local page
     try {
-      await getPageLoadDelay(this);
-    } catch {}
-  })());
-
-  try {
-    await B.any([cancellationPromise, pageReadinessPromise]);
-  } finally {
-    setPageLoading(this, false);
-    isPageLoading = false;
-    setNavigatingToPage(this, false);
-    setPageLoadDelay(this, B.resolve());
-    if (onPageLoadedTimeout && pageReadinessPromise.isFulfilled()) {
-      clearTimeout(onPageLoadedTimeout);
-      onPageLoadedTimeout = null;
+      await B.resolve(rpcClient.send('Console.enable', {
+        appIdKey: getAppIdKey(this),
+        pageIdKey: getPageIdKey(this),
+      }, didPageFinishLoad)).timeout(CONSOLE_ENABLEMENT_TIMEOUT_MS);
+    } catch (err) {
+      if (err instanceof BTimeoutError) {
+        throw new errors.TimeoutError(`Could not enable console events after the page load within ` +
+          `${CONSOLE_ENABLEMENT_TIMEOUT_MS}ms. The Web Inspector/Safari may need to be restarted.`);
+      }
+      throw err;
     }
-    if (onTargetProvisioned) {
-      rpcClient.targetSubscriptions.off(rpcConstants.ON_TARGET_PROVISIONED_EVENT, onTargetProvisioned);
-    }
-    if (onPageLoaded) {
-      rpcClient.off('Page.loadEventFired', onPageLoaded);
-    }
-    if (onPageChanged) {
-      rpcClient.off('_rpc_forwardGetListing:', onPageChanged);
-    }
-  }
-
-  // enable console logging, so we get the events (otherwise we only
-  // get notified when navigating to a local page
-  try {
-    await B.resolve(rpcClient.send('Console.enable', {
-      appIdKey: getAppIdKey(this),
-      pageIdKey: getPageIdKey(this),
-    }, didPageFinishLoad)).timeout(CONSOLE_ENABLEMENT_TIMEOUT_MS);
-  } catch (err) {
-    if (err instanceof BTimeoutError) {
-      throw new errors.TimeoutError(`Could not enable console events after the page load within ` +
-        `${CONSOLE_ENABLEMENT_TIMEOUT_MS}ms. The Web Inspector/Safari may need to be restarted.`);
-    }
-    throw err;
-  }
+  });
 }
 
 /**

--- a/lib/mixins/navigate.js
+++ b/lib/mixins/navigate.js
@@ -3,7 +3,6 @@ import { events } from './events';
 import { timing, util } from '@appium/support';
 import _ from 'lodash';
 import B, { TimeoutError as BTimeoutError } from 'bluebird';
-import { errors } from '@appium/base-driver';
 import {
   getAppIdKey,
   setPageLoading,
@@ -14,11 +13,9 @@ import {
   getPageIdKey,
   setNavigatingToPage,
 } from './property-accessors';
-import { toLockKey } from '../rpc/rpc-client';
 
 export const DEFAULT_PAGE_READINESS_TIMEOUT_MS = 20 * 1000;
 const PAGE_READINESS_CHECK_INTERVAL_MS = 50;
-const CONSOLE_ENABLEMENT_TIMEOUT_MS = 20 * 1000;
 
 /**
  * pageLoadStrategy in WebDriver definitions.
@@ -145,10 +142,6 @@ export async function waitForDom (startPageLoadTimer) {
  * @returns {Promise<boolean>}
  */
 export async function checkPageIsReady (timeoutMs) {
-  checkParams({
-    appIdKey: getAppIdKey(this),
-  });
-
   const readyCmd = 'document.readyState;';
   const actualTimeoutMs = timeoutMs ?? getPageReadyTimeout(this);
   try {
@@ -172,9 +165,10 @@ export async function checkPageIsReady (timeoutMs) {
  * @returns {Promise<void>}
  */
 export async function navToUrl (url) {
-  const appIdKey = getAppIdKey(this);
-  const pageIdKey = getPageIdKey(this);
-  checkParams({appIdKey, pageIdKey});
+  const {appIdKey, pageIdKey} = checkParams({
+    appIdKey: getAppIdKey(this),
+    pageIdKey: getPageIdKey(this),
+  });
   const rpcClient = this.requireRpcClient();
 
   try {
@@ -183,99 +177,79 @@ export async function navToUrl (url) {
     throw new TypeError(`'${url}' is not a valid URL`);
   }
 
-  const appTargets = rpcClient.targets[/** @type {import('../types').AppIdKey} */ (appIdKey)];
-  const lockKey = toLockKey(
+  this.log.debug(`Navigating to new URL: '${url}'`);
+  setNavigatingToPage(this, true);
+  await rpcClient.waitForPageInitialization(
     /** @type {import('../types').AppIdKey} */ (appIdKey),
     /** @type {import('../types').PageIdKey} */ (pageIdKey)
   );
-  await appTargets.lock.acquire(lockKey, async () => {
-    setNavigatingToPage(this, true);
-    this.log.debug(`Navigating to new URL: '${url}'`);
-    const readinessTimeoutMs = this.pageLoadMs;
-    /** @type {(() => void)|undefined} */
-    let onPageLoaded;
-    /** @type {NodeJS.Timeout|undefined|null} */
-    let onPageLoadedTimeout;
-    setPageLoadDelay(this, util.cancellableDelay(readinessTimeoutMs));
-    setPageLoading(this, true);
-    let isPageLoading = true;
-    let didPageFinishLoad = false;
-    // /** @type {Promise<void>|null} */
-    const start = new timing.Timer().start();
+  const readinessTimeoutMs = this.pageLoadMs;
+  /** @type {(() => void)|undefined} */
+  let onPageLoaded;
+  /** @type {NodeJS.Timeout|undefined|null} */
+  let onPageLoadedTimeout;
+  setPageLoadDelay(this, util.cancellableDelay(readinessTimeoutMs));
+  setPageLoading(this, true);
+  let isPageLoading = true;
+  // /** @type {Promise<void>|null} */
+  const start = new timing.Timer().start();
 
-    /** @type {B<void>} */
-    const pageReadinessPromise = new B((resolve) => {
-      onPageLoadedTimeout = setTimeout(() => {
-        if (isPageLoading) {
-          isPageLoading = false;
-          this.log.info(
-            `Timed out after ${start.getDuration().asMilliSeconds.toFixed(0)}ms of waiting ` +
-            `for the ${url} page readiness. Continuing anyway`
-          );
-        }
-        return resolve();
-      }, readinessTimeoutMs);
+  /** @type {B<void>} */
+  const pageReadinessPromise = new B((resolve) => {
+    onPageLoadedTimeout = setTimeout(() => {
+      if (isPageLoading) {
+        isPageLoading = false;
+        this.log.info(
+          `Timed out after ${start.getDuration().asMilliSeconds.toFixed(0)}ms of waiting ` +
+          `for the ${url} page readiness. Continuing anyway`
+        );
+      }
+      return resolve();
+    }, readinessTimeoutMs);
 
-      onPageLoaded = () => {
-        if (isPageLoading) {
-          isPageLoading = false;
-          this.log.debug(`The page ${url} is ready in ${start.getDuration().asMilliSeconds.toFixed(0)}ms`);
-        }
-        if (onPageLoadedTimeout) {
-          clearTimeout(onPageLoadedTimeout);
-          onPageLoadedTimeout = null;
-        }
-        didPageFinishLoad = true;
-        return resolve();
-      };
-
-      // https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-loadEventFired
-      rpcClient.once('Page.loadEventFired', onPageLoaded);
-
-      rpcClient.send('Page.navigate', {
-        url,
-        appIdKey,
-        pageIdKey,
-      });
-    });
-    /** @type {B<void>} */
-    const cancellationPromise = B.resolve((async () => {
-      try {
-        await getPageLoadDelay(this);
-      } catch {}
-    })());
-
-    try {
-      await B.any([cancellationPromise, pageReadinessPromise]);
-    } finally {
-      setPageLoading(this, false);
-      isPageLoading = false;
-      setNavigatingToPage(this, false);
-      setPageLoadDelay(this, B.resolve());
-      if (onPageLoadedTimeout && pageReadinessPromise.isFulfilled()) {
+    onPageLoaded = () => {
+      if (isPageLoading) {
+        isPageLoading = false;
+        this.log.debug(`The page ${url} is ready in ${start.getDuration().asMilliSeconds.toFixed(0)}ms`);
+      }
+      if (onPageLoadedTimeout) {
         clearTimeout(onPageLoadedTimeout);
         onPageLoadedTimeout = null;
       }
-      if (onPageLoaded) {
-        rpcClient.off('Page.loadEventFired', onPageLoaded);
-      }
-    }
+      return resolve();
+    };
 
-    // enable console logging, so we get the events (otherwise we only
-    // get notified when navigating to a local page
-    try {
-      await B.resolve(rpcClient.send('Console.enable', {
-        appIdKey: getAppIdKey(this),
-        pageIdKey: getPageIdKey(this),
-      }, didPageFinishLoad)).timeout(CONSOLE_ENABLEMENT_TIMEOUT_MS);
-    } catch (err) {
-      if (err instanceof BTimeoutError) {
-        throw new errors.TimeoutError(`Could not enable console events after the page load within ` +
-          `${CONSOLE_ENABLEMENT_TIMEOUT_MS}ms. The Web Inspector/Safari may need to be restarted.`);
-      }
-      throw err;
-    }
+    // https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-loadEventFired
+    rpcClient.once('Page.loadEventFired', onPageLoaded);
+
+    rpcClient.send('Page.navigate', {
+      url,
+      appIdKey,
+      pageIdKey,
+    });
   });
+  /** @type {B<void>} */
+  const cancellationPromise = B.resolve((async () => {
+    try {
+      await getPageLoadDelay(this);
+    } catch {}
+  })());
+
+  try {
+    await B.any([cancellationPromise, pageReadinessPromise]);
+  } finally {
+    setPageLoading(this, false);
+    isPageLoading = false;
+    setNavigatingToPage(this, false);
+    setPageLoadDelay(this, B.resolve());
+    if (onPageLoadedTimeout && pageReadinessPromise.isFulfilled()) {
+      clearTimeout(onPageLoadedTimeout);
+      onPageLoadedTimeout = null;
+    }
+    if (onPageLoaded) {
+      rpcClient.off('Page.loadEventFired', onPageLoaded);
+    }
+  }
 }
 
 /**

--- a/lib/protocol/index.js
+++ b/lib/protocol/index.js
@@ -175,6 +175,8 @@ const COMMANDS = /** @type {const} */ ({
   // https://github.com/WebKit/WebKit/blob/main/Source/JavaScriptCore/inspector/protocol/Target.json
   //#region TARGET DOMAIN
   'Target.exists': [], // removed since WebKit in 13.4
+  'Target.setPauseOnStart': ['pauseOnStart'],
+  'Target.resume': ['targetId'],
   //#endregion
 
   // https://github.com/WebKit/WebKit/blob/main/Source/JavaScriptCore/inspector/protocol/Timeline.json
@@ -200,32 +202,12 @@ const COMMANDS = /** @type {const} */ ({
  *
  * @param {string} id
  * @param {string} method
- * @param {import('@appium/types').StringRecord} params
- * @returns {import('../types').ProtocolCommandOpts}
- */
-function getCommand (id, method, params = {}) {
-  return {
-    id,
-    method,
-    params: Object.assign({
-      objectGroup: OBJECT_GROUP,
-      includeCommandLineAPI: true,
-      doNotPauseOnExceptionsAndMuteConsole: false,
-      emulateUserGesture: false,
-      generatePreview: false,
-      saveResult: false,
-    }, params),
-  };
-}
-
-/**
- *
- * @param {string} id
- * @param {string} method
  * @param {import('../types').RemoteCommandOpts} opts
+ * @param {boolean} [direct=false] - if set to false then the resulting command params
+ * will be patched with default values
  * @returns {import('../types').ProtocolCommandOpts}
  */
-export function getProtocolCommand (id, method, opts) {
+export function getProtocolCommand (id, method, opts, direct = false) {
   const paramNames = COMMANDS[method];
   if (!paramNames) {
     throw new Error(`Unknown command: '${method}'`);
@@ -235,7 +217,23 @@ export function getProtocolCommand (id, method, opts) {
     params[name] = opts[name];
     return params;
   }, {});
-  return getCommand(id, method, params);
+  const result = {
+    id,
+    method,
+    params,
+  };
+  if (!direct) {
+    result.params = {
+      objectGroup: OBJECT_GROUP,
+      includeCommandLineAPI: true,
+      doNotPauseOnExceptionsAndMuteConsole: false,
+      emulateUserGesture: false,
+      generatePreview: false,
+      saveResult: false,
+      ...result.params,
+    };
+  }
+  return result;
 }
 
 export default getProtocolCommand;

--- a/lib/rpc/constants.js
+++ b/lib/rpc/constants.js
@@ -1,1 +1,0 @@
-export const ON_TARGET_PROVISIONED_EVENT = 'onTargetProvisioned';

--- a/lib/rpc/index.js
+++ b/lib/rpc/index.js
@@ -1,6 +1,4 @@
 import { RpcClientSimulator } from './rpc-client-simulator';
 import { RpcClientRealDevice } from './rpc-client-real-device';
-import * as rpcConstants from './constants';
 
-
-export { RpcClientSimulator, RpcClientRealDevice, rpcConstants };
+export { RpcClientSimulator, RpcClientRealDevice };

--- a/lib/rpc/remote-messages.js
+++ b/lib/rpc/remote-messages.js
@@ -19,6 +19,8 @@ const COMMANDS = /** @type {const} */ ({
   'Runtime.evaluate': FULL_COMMAND,
 
   'Target.exists': DIRECT_COMMAND,
+  'Target.setPauseOnStart': DIRECT_COMMAND,
+  'Target.resume': DIRECT_COMMAND,
 
   'Timeline.start': FULL_COMMAND,
   'Timeline.stop': FULL_COMMAND,
@@ -49,7 +51,7 @@ export class RemoteMessages {
   /**
    *
    * @param {string} connId
-   * @returns {import('../types').RemoteCommand}
+   * @returns {import('../types').RawRemoteCommand}
    */
   setConnectionKey (connId) {
     return {
@@ -64,7 +66,7 @@ export class RemoteMessages {
    *
    * @param {string} connId
    * @param {import('../types').AppIdKey} appIdKey
-   * @returns {import('../types').RemoteCommand}
+   * @returns {import('../types').RawRemoteCommand}
    */
   connectToApp (connId, appIdKey) {
     return {
@@ -82,7 +84,7 @@ export class RemoteMessages {
    * @param {string} senderId
    * @param {import('../types').AppIdKey} appIdKey
    * @param {import('../types').PageIdKey} [pageIdKey]
-   * @returns {import('../types').RemoteCommand}
+   * @returns {import('../types').RawRemoteCommand}
    */
   setSenderKey (connId, senderId, appIdKey, pageIdKey) {
     return {
@@ -91,7 +93,7 @@ export class RemoteMessages {
         WIRConnectionIdentifierKey: connId,
         WIRSenderKey: senderId,
         WIRPageIdentifierKey: pageIdKey,
-        WIRAutomaticallyPause: false
+        WIRAutomaticallyPause: false,
       },
       __selector: '_rpc_forwardSocketSetup:'
     };
@@ -103,7 +105,7 @@ export class RemoteMessages {
    * @param {import('../types').AppIdKey} appIdKey
    * @param {import('../types').PageIdKey} [pageIdKey]
    * @param {boolean} [enabled]
-   * @returns {import('../types').RemoteCommand}
+   * @returns {import('../types').RawRemoteCommand}
    */
   indicateWebView (connId, appIdKey, pageIdKey, enabled) {
     return {
@@ -120,7 +122,7 @@ export class RemoteMessages {
   /**
    *
    * @param {string} bundleId
-   * @returns {import('../types').RemoteCommand}
+   * @returns {import('../types').RawRemoteCommand}
    */
   launchApplication (bundleId) {
     return {
@@ -134,7 +136,7 @@ export class RemoteMessages {
   /**
    *
    * @param {import('../types').RemoteCommandOpts & import('../types').ProtocolCommandOpts} opts
-   * @returns {import('../types').RemoteCommand}
+   * @returns {import('../types').RawRemoteCommand}
    */
   getFullCommand (opts) {
     const {
@@ -205,7 +207,7 @@ export class RemoteMessages {
   /**
    *
    * @param {import('../types').RemoteCommandOpts & import('../types').ProtocolCommandOpts} opts
-   * @returns {import('../types').RemoteCommand}
+   * @returns {import('../types').RawRemoteCommand}
    */
   getMinimalCommand (opts) {
     const {method, params, connId, senderId, appIdKey, pageIdKey, targetId, id} = opts;
@@ -244,7 +246,7 @@ export class RemoteMessages {
   /**
    *
    * @param {import('../types').RemoteCommandOpts & import('../types').ProtocolCommandOpts} opts
-   * @returns {import('../types').RemoteCommand}
+   * @returns {import('../types').RawRemoteCommand}
    */
   getDirectCommand (opts) {
     const {method, params, connId, senderId, appIdKey, pageIdKey, id} = opts;
@@ -271,7 +273,7 @@ export class RemoteMessages {
    *
    * @param {string} command
    * @param {import('../types').RemoteCommandOpts} opts
-   * @returns {import('../types').RemoteCommand}
+   * @returns {import('../types').RawRemoteCommand}
    */
   getRemoteCommand (command, opts) {
     const {
@@ -314,8 +316,14 @@ export class RemoteMessages {
 
     // deal with WebKit commands
     const builderFunction = COMMANDS[command] || MINIMAL_COMMAND;
+    const commonOpts = getProtocolCommand(
+      /** @type {string} */ (id),
+      command,
+      opts,
+      isDirectCommand(command),
+    );
     return this[builderFunction]({
-      ...getProtocolCommand(/** @type {string} */ (id), command, opts),
+      ...commonOpts,
       connId,
       appIdKey,
       senderId,
@@ -325,6 +333,15 @@ export class RemoteMessages {
   }
 
   // #endregion
+}
+
+/**
+ *
+ * @param {string} command
+ * @returns {boolean}
+ */
+export function isDirectCommand (command) {
+  return COMMANDS[command] === DIRECT_COMMAND;
 }
 
 export default RemoteMessages;

--- a/lib/rpc/rpc-client-real-device.js
+++ b/lib/rpc/rpc-client-real-device.js
@@ -8,9 +8,7 @@ export class RpcClientRealDevice extends RpcClient {
    * @param {import('./rpc-client').RpcClientOptions} [opts={}]
    */
   constructor (opts = {}) {
-    super(Object.assign({
-      shouldCheckForTarget: false,
-    }, opts));
+    super(opts);
   }
 
   /**

--- a/lib/rpc/rpc-client-simulator.js
+++ b/lib/rpc/rpc-client-simulator.js
@@ -25,9 +25,7 @@ export class RpcClientSimulator extends RpcClient {
    * @param {import('./rpc-client').RpcClientOptions & RpcClientSimulatorOptions} [opts={}]
    */
   constructor (opts = {}) {
-    super(Object.assign({
-      shouldCheckForTarget: false,
-    }, opts));
+    super(opts);
 
     const {
       socketPath,

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -520,19 +520,17 @@ export class RpcClient {
         return;
       }
 
+      log.debug(`The target ${targetInfo.targetId}@${appIdKey} is paused`);
       const appTargetsMap = this.targets[appIdKey];
-      if (!appTargetsMap) {
-        return;
+      if (appTargetsMap) {
+        await appTargetsMap.lock.acquire(toLockKey(appIdKey, pageIdKey), async () => {
+          try {
+            await this._initializePage(appIdKey, pageIdKey, targetInfo.targetId);
+          } finally {
+            await this._resumeTarget(appIdKey, pageIdKey, targetInfo.targetId);
+          }
+        });
       }
-
-      log.debug(`The target ${targetInfo.targetId}@${appIdKey} is paused. Initializing the page.`);
-      await appTargetsMap.lock.acquire(toLockKey(appIdKey, pageIdKey), async () => {
-        try {
-          await this._initializePage(appIdKey, pageIdKey, targetInfo.targetId);
-        } finally {
-          await this._resumeTarget(appIdKey, pageIdKey, targetInfo.targetId);
-        }
-      });
       return;
     }
 

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -20,6 +20,8 @@ const NO_TARGET_PRESENT_YET_ERRORS = [
   `some arguments of method`,
   `missing target`,
 ];
+export const NEW_APP_CONNECTED_ERROR = 'New application has connected';
+export const EMPTY_PAGE_DICTIONARY_ERROR = 'Empty page dictionary received';
 
 /**
  * @param {boolean} isSafari
@@ -253,33 +255,39 @@ export class RpcClient {
    *
    * @param {import('../types').AppIdKey} appIdKey
    * @param {import('../types').PageIdKey} pageIdKey
-   * @returns {Promise<void>}
+   * @returns {Promise<import('../types').TargetId | undefined>}
    */
   async waitForTarget (appIdKey, pageIdKey) {
     if (!this.needsTarget) {
       log.debug(`Target-based communication is not needed, skipping wait for target`);
       return;
     }
-    const target = this.getTarget(appIdKey, pageIdKey);
+    let target = this.getTarget(appIdKey, pageIdKey);
     if (target) {
       log.debug(
         `The target '${target}' for app '${appIdKey}' and page '${pageIdKey}' already exists, no need to wait`
       );
-      return;
+      return target;
     }
 
     // otherwise waiting is necessary to see what the target is
     try {
-      await waitForCondition(() => !_.isEmpty(this.getTarget(appIdKey, pageIdKey)), {
+      await waitForCondition(() => {
+        target = this.getTarget(appIdKey, pageIdKey);
+        return !_.isEmpty(target);
+      }, {
         waitMs: WAIT_FOR_TARGET_TIMEOUT_MS,
         intervalMs: WAIT_FOR_TARGET_INTERVAL_MS,
-        error: 'No targets found, unable to communicate with device',
       });
+      return target;
     } catch (err) {
       if (!err.message.includes('Condition unmet')) {
         throw err;
       }
-      throw new Error('No targets found, unable to communicate with device');
+      throw new Error(
+        `No targets could be matched for the app '${appIdKey}' and page '${pageIdKey}' after ` +
+        `${WAIT_FOR_TARGET_TIMEOUT_MS}ms. This is likely a bug.`
+      );
     }
   }
 
@@ -486,39 +494,45 @@ export class RpcClient {
    */
   async addTarget (err, app, targetInfo) {
     if (_.isNil(targetInfo?.targetId)) {
-      log.warn(`Received 'Target.targetCreated' event for app '${app}' with no target. Skipping`);
+      log.info(`Received 'Target.targetCreated' event for app '${app}' with no target. Skipping`);
       return;
     }
     if (!this._pendingTargetNotification) {
-      log.warn(`Received 'Target.targetCreated' event for app '${app}' with no pending request: ${JSON.stringify(targetInfo)}`);
+      log.info(
+        `Received 'Target.targetCreated' event for app '${app}' with no pending request: ${JSON.stringify(targetInfo)}`
+      );
       return;
     }
 
     const [appIdKey, pageIdKey] = this._pendingTargetNotification;
     if (appIdKey !== app) {
-      log.warn(`Received 'Target.targetCreated' event for app '${app}' with no pending request: ${JSON.stringify(targetInfo)}`);
+      log.info(
+        `Received 'Target.targetCreated' event for app '${app}' with no pending request: ${JSON.stringify(targetInfo)}`
+      );
       return;
     }
 
     if (targetInfo.isProvisional) {
       log.debug(
-        `Provisional target created for app '${app}', '${targetInfo.targetId}'. Ignoring until target update event`
+        `Provisional target created for app '${appIdKey}' and page '${pageIdKey}': '${targetInfo.targetId}'`
       );
-      if (targetInfo.isPaused && this._pendingTargetNotification) {
-        const appTargetsMap = this.targets[appIdKey];
-        if (!appTargetsMap) {
-          return;
-        }
-
-        log.debug(`The target ${targetInfo.targetId}@${appIdKey} is paused. Initializing the page and resuming it`);
-        await appTargetsMap.lock.acquire(toLockKey(appIdKey, pageIdKey), async () => {
-          try {
-            await this.initializePage(appIdKey, pageIdKey, targetInfo.targetId);
-          } finally {
-            await this._resumeTarget(appIdKey, pageIdKey, targetInfo.targetId);
-          }
-        });
+      if (!targetInfo.isPaused) {
+        return;
       }
+
+      const appTargetsMap = this.targets[appIdKey];
+      if (!appTargetsMap) {
+        return;
+      }
+
+      log.debug(`The target ${targetInfo.targetId}@${appIdKey} is paused. Initializing the page.`);
+      await appTargetsMap.lock.acquire(toLockKey(appIdKey, pageIdKey), async () => {
+        try {
+          await this._initializePage(appIdKey, pageIdKey, targetInfo.targetId);
+        } finally {
+          await this._resumeTarget(appIdKey, pageIdKey, targetInfo.targetId);
+        }
+      });
       return;
     }
 
@@ -539,7 +553,7 @@ export class RpcClient {
         });
       } catch {}
       try {
-        await this.initializePage(appIdKey, pageIdKey);
+        await this._initializePage(appIdKey, pageIdKey);
       } finally {
         if (targetInfo.isPaused) {
           await this._resumeTarget(appIdKey, pageIdKey);
@@ -556,7 +570,11 @@ export class RpcClient {
    * @returns {Promise<void>}
    */
   async updateTarget (err, app, targetInfo) {
-    log.debug(`Target updated for app '${app}'. Old target: '${targetInfo.oldTargetId}', new target: '${targetInfo.newTargetId}'`);
+    const {
+      oldTargetId,
+      newTargetId,
+    } = targetInfo;
+    log.debug(`Target updated for app '${app}'. Old target: '${oldTargetId}', new target: '${newTargetId}'`);
 
     const appTargetsMap = this.targets[app];
     if (!appTargetsMap) {
@@ -566,8 +584,8 @@ export class RpcClient {
 
     // save this, to be used if/when the existing target is destroyed
     appTargetsMap.provisional = {
-      oldTargetId: targetInfo.oldTargetId,
-      newTargetId: targetInfo.newTargetId,
+      oldTargetId,
+      newTargetId,
     };
   }
 
@@ -661,7 +679,7 @@ export class RpcClient {
     log.debug('Sender key set');
 
     if (!this.isTargetBased) {
-      await this.initializePage(appIdKey, pageIdKey);
+      await this._initializePage(appIdKey, pageIdKey);
       return;
     }
 
@@ -670,6 +688,7 @@ export class RpcClient {
     }
 
     await this.waitForTarget(appIdKey, pageIdKey);
+    await this.waitForPageInitialization(appIdKey, pageIdKey);
   }
 
   /**
@@ -681,7 +700,7 @@ export class RpcClient {
    * @param {import('../types').TargetId} [targetId]
    * @returns {Promise<void>}
    */
-  async initializePage (appIdKey, pageIdKey, targetId) {
+  async _initializePage (appIdKey, pageIdKey, targetId) {
     const sendOpts = {
       appIdKey,
       pageIdKey,
@@ -819,7 +838,7 @@ export class RpcClient {
                     `Using id ${correctAppIdKey} instead of ${oldAppIdKey}`);
         }
 
-        reject(new Error('New application has connected'));
+        reject(new Error(NEW_APP_CONNECTED_ERROR));
       };
       this.messageHandler?.prependOnceListener('_rpc_applicationConnected:', onAppChange);
 
@@ -830,7 +849,7 @@ export class RpcClient {
           // sometimes the connect logic happens, but with an empty dictionary
           // which leads to the remote debugger getting disconnected, and into a loop
           if (_.isEmpty(pageDict)) {
-            reject(new Error('Empty page dictionary received'));
+            reject(new Error(EMPTY_PAGE_DICTIONARY_ERROR));
           } else {
             resolve([connectedAppIdKey, pageDict]);
           }
@@ -888,7 +907,30 @@ export class RpcClient {
         pageIdKey,
         targetId,
       });
+      log.debug(`Successfully resumed the target ${targetId}@${appIdKey}`);
     } catch {}
+  }
+
+  /**
+   *
+   * @param {import('../types').AppIdKey} appIdKey
+   * @param {import('../types').PageIdKey} pageIdKey
+   */
+  async waitForPageInitialization (appIdKey, pageIdKey) {
+    const appTargetsMap = this.targets[appIdKey];
+    if (!appTargetsMap) {
+      throw new Error(`No targets found for app '${appIdKey}'`);
+    }
+    /** @type {AsyncLock | undefined}  */
+    const lock = appTargetsMap.lock;
+    if (lock?.isBusy()) {
+      const timer = new timing.Timer().start();
+      log.debug(`Waiting until page ${pageIdKey}@${appIdKey} is fully initialized`);
+      await lock.acquire(toLockKey(appIdKey, pageIdKey), async () => await B.delay(0));
+      log.debug(
+        `The initalization of the page ${pageIdKey}@${appIdKey} took ${timer.getDuration().asMilliSeconds}ms`
+      );
+    }
   }
 }
 

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -6,7 +6,7 @@ import B from 'bluebird';
 import RpcMessageHandler from './rpc-message-handler';
 import { util, timing } from '@appium/support';
 import { EventEmitter } from 'node:events';
-import { ON_TARGET_PROVISIONED_EVENT } from './constants';
+import AsyncLock from 'async-lock';
 
 const DATA_LOG_LENGTH = {length: 200};
 const WAIT_FOR_TARGET_TIMEOUT_MS = 10000;
@@ -85,14 +85,14 @@ export class RpcClient {
   /** @type {string[]} */
   _contexts;
 
-  /** @type {import('@appium/types').StringRecord} */
+  /** @type {AppToTargetsMap} */
   _targets;
 
   /** @type {EventEmitter} */
   _targetSubscriptions;
 
-  /** @type {boolean} */
-  _shouldCheckForTarget;
+  /** @type {[import('../types').AppIdKey, import('../types').PageIdKey] | undefined} */
+  _pendingTargetNotification;
 
   /**
    *
@@ -135,7 +135,6 @@ export class RpcClient {
     this._targetSubscriptions = new EventEmitter();
 
     // start with a best guess for the protocol
-    this._shouldCheckForTarget = !!opts.shouldCheckForTarget;
     this.isTargetBased = platformVersion ? isTargetBased(isSafari, platformVersion) : true;
   }
 
@@ -150,25 +149,14 @@ export class RpcClient {
    * @returns {boolean}
    */
   get needsTarget () {
-    return this.shouldCheckForTarget && this.isTargetBased;
+    return this.isTargetBased;
   }
 
   /**
-   * @returns {import('@appium/types').StringRecord}
+   * @returns {AppToTargetsMap}
    */
   get targets () {
     return this._targets;
-  }
-
-  /**
-   * @returns {boolean}
-   */
-  get shouldCheckForTarget () {
-    return this._shouldCheckForTarget;
-  }
-
-  set shouldCheckForTarget (shouldCheckForTarget) {
-    this._shouldCheckForTarget = !!shouldCheckForTarget;
   }
 
   /**
@@ -299,18 +287,18 @@ export class RpcClient {
    *
    * @param {string} command
    * @param {import('../types').RemoteCommandOpts} opts
-   * @param {boolean} [waitForResponse]
+   * @param {boolean} [waitForResponse=true]
    * @returns {Promise<any>}
    */
   async send (command, opts, waitForResponse = true) {
     const timer = new timing.Timer().start();
-    const {
-      appIdKey,
-      pageIdKey
-    } = opts;
     try {
       return await this.sendToDevice(command, opts, waitForResponse);
     } catch (err) {
+      const {
+        appIdKey,
+        pageIdKey
+      } = opts;
       const messageLc = (err.message || '').toLowerCase();
       if (messageLc.includes(NO_TARGET_SUPPORTED_ERROR)) {
         log.info(
@@ -332,11 +320,13 @@ export class RpcClient {
 
   /**
    *
+   * @template {boolean} TWaitForResponse
    * @param {string} command
    * @param {import('../types').RemoteCommandOpts} opts
-   * @param {boolean} [waitForResponse]
-   * @returns {Promise<any>}
+   * @param {TWaitForResponse} [waitForResponse=true]
+   * @returns {Promise<TWaitForResponse extends true ? import('../types').RemoteCommandOpts : any>}
    */
+  // @ts-ignore Compiler issue
   async sendToDevice (command, opts, waitForResponse = true) {
     return await new B(async (resolve, reject) => {
       // promise to be resolved whenever remote debugger
@@ -359,25 +349,41 @@ export class RpcClient {
 
       const appIdKey = opts.appIdKey;
       const pageIdKey = opts.pageIdKey;
-      const targetId = this.getTarget(appIdKey, pageIdKey);
+      const targetId = opts.targetId ?? this.getTarget(appIdKey, pageIdKey);
 
       // retrieve the correct command to send
+      /** @type {import('../types').RemoteCommandOpts} */
       const fullOpts = _.defaults({
         connId: this.connId,
         senderId: this.senderId,
         targetId,
         id: msgId,
       }, opts);
-      // @ts-ignore remoteMessages must be defined
-      const cmd = this.remoteMessages.getRemoteCommand(command, fullOpts);
+      /** @type {import('../types').RawRemoteCommand} */
+      let cmd;
+      try {
+        // @ts-ignore remoteMessages must be defined
+        cmd = this.remoteMessages.getRemoteCommand(command, fullOpts);
+      } catch (err) {
+        log.error(err);
+        return reject(err);
+      }
 
-      if (cmd?.__argument?.WIRSocketDataKey) {
+      /** @type {import('../types').RemoteCommand} */
+      const finalCommand = {
+        __argument: _.omit(cmd.__argument, ['WIRSocketDataKey']),
+        __selector: cmd.__selector,
+      };
+
+      const hasSocketData = _.isPlainObject(cmd.__argument?.WIRSocketDataKey);
+      if (hasSocketData) {
         // make sure the message being sent has all the information that is needed
+        // @ts-ignore We have asserted it's a plain object above
         if (_.isNil(cmd.__argument.WIRSocketDataKey.id)) {
+          // @ts-ignore We have already asserted it's a plain object above
           cmd.__argument.WIRSocketDataKey.id = wrapperMsgId;
         }
-        cmd.__argument.WIRSocketDataKey =
-          Buffer.from(JSON.stringify(cmd.__argument.WIRSocketDataKey));
+        finalCommand.__argument.WIRSocketDataKey = Buffer.from(JSON.stringify(cmd.__argument.WIRSocketDataKey));
       }
 
       let messageHandled = true;
@@ -390,7 +396,10 @@ export class RpcClient {
           if (err) {
             // we are not waiting for this, and if it errors it is most likely
             // a protocol change. Log and check during testing
-            log.error(`Received error from send that is not being waited for (id: ${msgId}): '${_.truncate(JSON.stringify(err), DATA_LOG_LENGTH)}'`);
+            log.error(
+              `Received error from send that is not being waited for (id: ${msgId}): ` +
+              _.truncate(JSON.stringify(err), DATA_LOG_LENGTH)
+            );
             // reject, though it is very rare that this will be triggered, since
             // the promise is resolved directlty after send. On the off chance,
             // though, it will alert of a protocol change.
@@ -405,9 +414,10 @@ export class RpcClient {
             return reject(err);
           }
           log.debug(`Received response from send (id: ${msgId}): '${_.truncate(JSON.stringify(args), DATA_LOG_LENGTH)}'`);
+          // @ts-ignore This is ok
           resolve(args);
         });
-      } else if (cmd?.__argument?.WIRSocketDataKey) {
+      } else if (hasSocketData) {
         // @ts-ignore messageHandler must be defined
         this.messageHandler.once(msgId.toString(), function (err, value) {
           if (err) {
@@ -428,11 +438,12 @@ export class RpcClient {
         ` (id: ${msgId}): '${command}'`;
       log.debug(msg);
       try {
-        const res = await this.sendMessage(cmd);
+        await this.sendMessage(finalCommand);
         if (!messageHandled) {
           // There are no handlers waiting for a response before resolving,
           // and no errors sending the message over the socket, so resolve
-          resolve(res);
+          // @ts-ignore This is ok
+          resolve(fullOpts);
         }
       } catch (err) {
         return reject(err);
@@ -468,66 +479,106 @@ export class RpcClient {
 
   /**
    *
-   * @param {Error?} err
-   * @param {string} app
-   * @param {Record<string, any>} targetInfo
-   * @returns {void}
+   * @param {Error | undefined} err
+   * @param {import('../types').AppIdKey} app
+   * @param {import('../types').TargetInfo} targetInfo
+   * @returns {Promise<void>}
    */
-  addTarget (err, app, targetInfo) {
+  async addTarget (err, app, targetInfo) {
     if (_.isNil(targetInfo?.targetId)) {
       log.warn(`Received 'Target.targetCreated' event for app '${app}' with no target. Skipping`);
       return;
     }
-    if (_.isEmpty(this.pendingTargetNotification) && !targetInfo.isProvisional) {
+    if (!this._pendingTargetNotification) {
+      log.warn(`Received 'Target.targetCreated' event for app '${app}' with no pending request: ${JSON.stringify(targetInfo)}`);
+      return;
+    }
+
+    const [appIdKey, pageIdKey] = this._pendingTargetNotification;
+    if (appIdKey !== app) {
       log.warn(`Received 'Target.targetCreated' event for app '${app}' with no pending request: ${JSON.stringify(targetInfo)}`);
       return;
     }
 
     if (targetInfo.isProvisional) {
-      log.debug(`Provisional target created for app '${app}', '${targetInfo.targetId}'. Ignoring until target update event`);
+      log.debug(
+        `Provisional target created for app '${app}', '${targetInfo.targetId}'. Ignoring until target update event`
+      );
+      if (targetInfo.isPaused && this._pendingTargetNotification) {
+        const appTargetsMap = this.targets[appIdKey];
+        if (!appTargetsMap) {
+          return;
+        }
+
+        log.debug(`The target ${targetInfo.targetId}@${appIdKey} is paused. Initializing the page and resuming it`);
+        await appTargetsMap.lock.acquire(toLockKey(appIdKey, pageIdKey), async () => {
+          try {
+            await this.initializePage(appIdKey, pageIdKey, targetInfo.targetId);
+          } finally {
+            await this._resumeTarget(appIdKey, pageIdKey, targetInfo.targetId);
+          }
+        });
+      }
       return;
     }
-
-    // @ts-ignore this.pendingTargetNotification must be defined here
-    const [appIdKey, pageIdKey] = this.pendingTargetNotification;
 
     log.debug(`Target created for app '${appIdKey}' and page '${pageIdKey}': ${JSON.stringify(targetInfo)}`);
     if (_.has(this.targets[appIdKey], pageIdKey)) {
       log.debug(`There is already a target for this app and page ('${this.targets[appIdKey][pageIdKey]}'). This might cause problems`);
     }
-    this.targets[app] = this.targets[app] || {};
+    const lock = new AsyncLock();
+    this.targets[app] = this.targets[app] || { lock };
     this.targets[appIdKey][pageIdKey] = targetInfo.targetId;
+
+    await lock.acquire(toLockKey(appIdKey, pageIdKey), async () => {
+      try {
+        await this.send('Target.setPauseOnStart', {
+          pauseOnStart: true,
+          appIdKey,
+          pageIdKey,
+        });
+      } catch {}
+      try {
+        await this.initializePage(appIdKey, pageIdKey);
+      } finally {
+        if (targetInfo.isPaused) {
+          await this._resumeTarget(appIdKey, pageIdKey);
+        }
+      }
+    });
   }
 
   /**
    *
-   * @param {Error?} err
-   * @param {string} app
-   * @param {string} oldTargetId
-   * @param {string} newTargetId
-   * @returns {void}
+   * @param {Error | undefined} err
+   * @param {import('../types').AppIdKey} app
+   * @param {import('../types').ProvisionalTargetInfo} targetInfo
+   * @returns {Promise<void>}
    */
-  updateTarget (err, app, oldTargetId, newTargetId) {
-    log.debug(`Target updated for app '${app}'. Old target: '${oldTargetId}', new target: '${newTargetId}'`);
-    if (!this.targets[app]) {
+  async updateTarget (err, app, targetInfo) {
+    log.debug(`Target updated for app '${app}'. Old target: '${targetInfo.oldTargetId}', new target: '${targetInfo.newTargetId}'`);
+
+    const appTargetsMap = this.targets[app];
+    if (!appTargetsMap) {
       log.warn(`No existing target for app '${app}'. Not sure what to do`);
       return;
     }
+
     // save this, to be used if/when the existing target is destroyed
-    this.targets[app].provisional = {
-      oldTargetId,
-      newTargetId,
+    appTargetsMap.provisional = {
+      oldTargetId: targetInfo.oldTargetId,
+      newTargetId: targetInfo.newTargetId,
     };
   }
 
   /**
    *
-   * @param {Error?} err
-   * @param {string} app
-   * @param {Record<string, any>} targetInfo
-   * @returns {void}
+   * @param {Error | undefined} err
+   * @param {import('../types').AppIdKey} app
+   * @param {import('../types').TargetInfo} targetInfo
+   * @returns {Promise<void>}
    */
-  removeTarget (err, app, targetInfo) {
+  async removeTarget (err, app, targetInfo) {
     if (_.isNil(targetInfo?.targetId)) {
       log.debug(`Received 'Target.targetDestroyed' event with no target. Skipping`);
       return;
@@ -541,29 +592,23 @@ export class RpcClient {
       delete this.targets[app].provisional;
 
       // we do not know the page, so go through and find the existing target
-      const targets = this.targets[app];
-      for (const [page, targetId] of _.toPairs(targets)) {
+      const appTargetsMap = this.targets[app];
+      for (const [page, targetId] of _.toPairs(appTargetsMap)) {
         if (targetId === oldTargetId) {
-          log.debug(`Found provisional target for app '${app}'. Old target: '${oldTargetId}', new target: '${newTargetId}'. Updating`);
-          targets[page] = newTargetId;
-          const opts = {appIdKey: app, pageIdKey: parseInt(page, 10)};
-          (async () => {
-            if (this.fullPageInitialization) {
-              await this.initializePageFull(opts.appIdKey, opts.pageIdKey);
-            } else {
-              await this.initializePage(opts.appIdKey, opts.pageIdKey);
-            }
-            this._targetSubscriptions.emit(ON_TARGET_PROVISIONED_EVENT, {
-              ...opts,
-              oldTargetId,
-              targetId: newTargetId,
-            });
-          })();
+          log.debug(
+            `Found provisional target for app '${app}'. ` +
+            `Old target: '${oldTargetId}', new target: '${newTargetId}'. Updating`
+          );
+          appTargetsMap[page] = newTargetId;
           return;
         }
       }
-      log.warn(`Provisional target for app '${app}' found, but no suitable existing target found. This may cause problems`);
-      log.warn(`Old target: '${oldTargetId}', new target: '${newTargetId}'. Existing targets: ${JSON.stringify(targets)}`);
+      log.warn(
+        `Provisional target for app '${app}' found, but no suitable existing target found. This may cause problems`
+      );
+      log.warn(
+        `Old target: '${oldTargetId}', new target: '${newTargetId}'. Existing targets: ${JSON.stringify(appTargetsMap)}`
+      );
     }
 
     // if there is no waiting provisional target, just get rid of the existing one
@@ -595,9 +640,7 @@ export class RpcClient {
    * @returns {Promise<void>}
    */
   async selectPage (appIdKey, pageIdKey) {
-    /** @type {[import('../types').AppIdKey, import('../types').PageIdKey]} */
-    this.pendingTargetNotification = [appIdKey, pageIdKey];
-    this.shouldCheckForTarget = false;
+    this._pendingTargetNotification = [appIdKey, pageIdKey];
 
     // go through the steps that the Desktop Safari system
     // goes through to initialize the Web Inspector session
@@ -617,51 +660,16 @@ export class RpcClient {
     await this.send('setSenderKey', sendOpts);
     log.debug('Sender key set');
 
+    if (!this.isTargetBased) {
+      await this.initializePage(appIdKey, pageIdKey);
+      return;
+    }
+
     if (this.isTargetBased && util.compareVersions(this.platformVersion, '<', MIN_PLATFORM_NO_TARGET_EXISTS)) {
       await this.send('Target.exists', sendOpts, false);
     }
 
-    this.shouldCheckForTarget = true;
-
     await this.waitForTarget(appIdKey, pageIdKey);
-    if (this.fullPageInitialization) {
-      await this.initializePageFull(appIdKey, pageIdKey);
-    } else {
-      await this.initializePage(appIdKey, pageIdKey);
-    }
-  }
-
-  /**
-   * Perform the minimal initialization to get the Web Inspector working
-   * @param {import('../types').AppIdKey} appIdKey
-   * @param {import('../types').PageIdKey} pageIdKey
-   * @returns {Promise<void>}
-   */
-  async initializePage (appIdKey, pageIdKey) {
-    const sendOpts = {
-      appIdKey,
-      pageIdKey,
-    };
-
-    // The sequence of domains is important
-    for (const domain of [
-      'Inspector.enable',
-      'Page.enable',
-      'Runtime.enable',
-
-      'Network.enable',
-      'Heap.enable',
-      'Debugger.enable',
-      'Console.enable',
-
-      'Inspector.initialized',
-    ]) {
-      try {
-        await this.send(domain, sendOpts);
-      } catch (err) {
-        log.info(`Cannot enable domain '${domain}' during initialization: ${err.message}`);
-      }
-    }
   }
 
   /**
@@ -670,13 +678,40 @@ export class RpcClient {
    *
    * @param {import('../types').AppIdKey} appIdKey
    * @param {import('../types').PageIdKey} pageIdKey
+   * @param {import('../types').TargetId} [targetId]
    * @returns {Promise<void>}
    */
-  async initializePageFull (appIdKey, pageIdKey) {
+  async initializePage (appIdKey, pageIdKey, targetId) {
     const sendOpts = {
       appIdKey,
       pageIdKey,
+      targetId,
     };
+
+    log.debug(`Initializing page '${pageIdKey}' for app '${appIdKey}'`);
+    if (!this.fullPageInitialization) {
+      // The sequence of domains is important
+      for (const domain of [
+        'Inspector.enable',
+        'Page.enable',
+        'Runtime.enable',
+
+        'Network.enable',
+        'Heap.enable',
+        'Debugger.enable',
+        'Console.enable',
+
+        'Inspector.initialized',
+      ]) {
+        try {
+          await this.send(domain, sendOpts);
+        } catch (err) {
+          log.info(`Cannot enable domain '${domain}' during initialization: ${err.message}`);
+        }
+      }
+      log.debug(`Simple initialization of page '${pageIdKey}' for app '${appIdKey}' completed`);
+      return;
+    }
 
     // The sequence of commands here is important
     const domainsToOptsMap = {
@@ -756,6 +791,7 @@ export class RpcClient {
         log.info(`Cannot enable domain '${domain}' during full initialization: ${err.message}`);
       }
     }
+    log.debug(`Full initialization of page '${pageIdKey}' for app '${appIdKey}' completed`);
   }
 
   /**
@@ -837,6 +873,33 @@ export class RpcClient {
     // { scriptId: '13', url: '', startLine: 0, startColumn: 0, endLine: 82, endColumn: 3 }
     log.debug(`Script parsed: ${JSON.stringify(scriptInfo)}`);
   }
+
+  /**
+   *
+   * @param {import('../types').AppIdKey} appIdKey
+   * @param {import('../types').PageIdKey} pageIdKey
+   * @param {import('../types').TargetId} [targetId]
+   * @returns {Promise<void>}
+   */
+  async _resumeTarget (appIdKey, pageIdKey, targetId) {
+    try {
+      await this.send('Target.resume', {
+        appIdKey,
+        pageIdKey,
+        targetId,
+      });
+    } catch {}
+  }
+}
+
+/**
+ *
+ * @param {import('../types').AppIdKey} appIdKey
+ * @param {import('../types').PageIdKey} pageIdKey
+ * @returns {string}
+ */
+export function toLockKey(appIdKey, pageIdKey) {
+  return `${appIdKey}-${pageIdKey}`;
 }
 
 export default RpcClient;
@@ -852,5 +915,13 @@ export default RpcClient;
  * @property {number} [socketChunkSize]
  * @property {boolean} [fullPageInitialization=false]
  * @property {string} [udid]
- * @property {boolean} [shouldCheckForTarget]
+ */
+
+/**
+ * @typedef {{[key: import('../types').PageIdKey]: import('../types').TargetId}} PageDict
+ */
+
+/**
+ * @typedef {PageDict & {provisional?: import('../types').ProvisionalTargetInfo, lock: import('async-lock').default}} PagesToTargets
+ * @typedef {{[key: import('../types').AppIdKey]: PagesToTargets}} AppToTargetsMap
  */

--- a/lib/rpc/rpc-message-handler.js
+++ b/lib/rpc/rpc-message-handler.js
@@ -107,19 +107,19 @@ export default class RpcMessageHandler extends EventEmitters {
   /**
    * Dispatch a data message.
    *
-   * @param {string | undefined} msgId
-   * @param {string} method
-   * @param {import('@appium/types').StringRecord} params
+   * @param {string} msgId If not empty then the following event is going to be emitted:
+   * - <msgId, error, result>
+   * If empty then the following event is going to be emitted:
+   * - <name, error, ..args>
+   * @param {string | undefined} method
+   * @param {import('@appium/types').StringRecord | undefined} params
    * @param {any} result
-   * @param {Error} [error]
+   * @param {Error | undefined} error
    * @returns {Promise<void>}
    */
   async dispatchDataMessage (msgId, method, params, result, error) {
-    if (!_.isEmpty(msgId)) {
-      log.debug(`Handling message (id: '${msgId}')`);
-    }
-
     if (msgId) {
+      log.debug(`Handling message id: '${msgId}'`);
       if (this.listenerCount(msgId)) {
         if (_.has(result?.result, 'value')) {
           result = result.result.value;
@@ -134,7 +134,7 @@ export default class RpcMessageHandler extends EventEmitters {
       return;
     }
 
-    /** @type {string[]} */
+    /** @type {any[]} */
     const eventNames = [method];
     /** @type {any[]} */
     let args = [params];
@@ -152,10 +152,10 @@ export default class RpcMessageHandler extends EventEmitters {
         args = [params || params.record];
         break;
       case 'Console.messageAdded':
-        args = [params.message];
+        args = [params?.message];
         break;
       case 'Runtime.executionContextCreated':
-        args = [params.context];
+        args = [params?.context];
         break;
       default:
         // pass
@@ -190,76 +190,76 @@ export default class RpcMessageHandler extends EventEmitters {
     let result = dataKey.result;
 
     let method = dataKey.method;
-    let params;
+    let params = dataKey.params;
 
-    if (method === 'Target.targetCreated') {
-      // this is in response to a `_rpc_forwardSocketSetup:` call
-      // targetInfo: { targetId: 'page-1', type: 'page' }
-      const app = plist.__argument.WIRApplicationIdentifierKey;
-      const targetInfo = dataKey.params.targetInfo;
-      this.emit('Target.targetCreated', null, app, targetInfo);
-      return;
-    } else if (method === 'Target.didCommitProvisionalTarget') {
-      const app = plist.__argument.WIRApplicationIdentifierKey;
-      const oldTargetId = dataKey.params.oldTargetId;
-      const newTargetId = dataKey.params.newTargetId;
-      this.emit('Target.didCommitProvisionalTarget', null, app, oldTargetId, newTargetId);
-      return;
-    } else if (method === 'Target.targetDestroyed') {
-      const app = plist.__argument.WIRApplicationIdentifierKey;
-      const targetInfo = dataKey.params.targetInfo || {targetId: dataKey.params.targetId};
-      this.emit('Target.targetDestroyed', null, app, targetInfo);
-      return;
-    }
+    const parseError = () => {
+      const defaultMessage = 'Error occurred in handling data message';
+      if (result?.wasThrown) {
+        const message = (result?.result?.value || result?.result?.description)
+          ? (result?.result?.value || result?.result?.description)
+          : (dataKey.error ?? defaultMessage);
+        return new Error(message);
+      }
+      if (dataKey.error) {
+        if (_.isPlainObject(dataKey.error)) {
+          const dataKeyError = /** @type {DataErrorMessage} */ (dataKey.error);
+          let error = new Error(defaultMessage);
+          for (const key of Object.keys(dataKeyError)) {
+            error[key] = dataKeyError[key];
+          }
+          return error;
+        }
+        return new Error(String(dataKey.error || defaultMessage));
+      }
+      return undefined;
+    };
 
-    if (!dataKey.error && this.isTargetBased) {
-      if (dataKey.method !== 'Target.dispatchMessageFromTarget') {
-        // this sort of message, at this point, is just an acknowledgement
-        // that the original message was received
+    switch (method) {
+      case 'Target.targetCreated': {
+        // this is in response to a `_rpc_forwardSocketSetup:` call
+        // targetInfo: { targetId: 'page-1', type: 'page' }
+        const app = plist.__argument.WIRApplicationIdentifierKey;
+        const targetInfo = dataKey.params.targetInfo;
+        this.emit('Target.targetCreated', null, app, targetInfo);
         return;
       }
-
-      // at this point, we have a Target-based message wrapping a protocol message
-      let message;
-      try {
-        message = JSON.parse(dataKey.params.message);
-        msgId = message.id;
-        method = message.method;
-        result = message.result || message;
-        params = result.params;
-      } catch (err) {
-        // if this happens then some aspect of the protocol is missing to us
-        // so print the entire message to get visibiity into what is going on
-        log.error(`Unexpected message format from Web Inspector:`);
-        log.warn(util.jsonStringify(plist, null));
-        throw err;
+      case 'Target.didCommitProvisionalTarget': {
+        const app = plist.__argument.WIRApplicationIdentifierKey;
+        const oldTargetId = dataKey.params.oldTargetId;
+        const newTargetId = dataKey.params.newTargetId;
+        this.emit('Target.didCommitProvisionalTarget', null, app, oldTargetId, newTargetId);
+        return;
       }
-    } else {
-      params = dataKey.params;
-    }
-
-    // we can get an error, or we can get a response that is an error
-    let error;
-    const defaultMessage = 'Error occurred in handling data message';
-    if (result?.wasThrown) {
-      const message = (result?.result?.value || result?.result?.description)
-        ? (result?.result?.value || result?.result?.description)
-        : (dataKey.error ?? defaultMessage);
-      error = new Error(message);
-    } else if (dataKey.error) {
-      if (_.isPlainObject(dataKey.error)) {
-        const dataKeyError = /** @type {DataErrorMessage} */ (dataKey.error);
-        error = new Error(defaultMessage);
-        for (const key of Object.keys(dataKeyError)) {
-          error[key] = dataKeyError[key];
+      case 'Target.targetDestroyed': {
+        const app = plist.__argument.WIRApplicationIdentifierKey;
+        const targetInfo = dataKey.params.targetInfo || {targetId: dataKey.params.targetId};
+        this.emit('Target.targetDestroyed', null, app, targetInfo);
+        return;
+      }
+      case 'Target.dispatchMessageFromTarget': {
+        if (!dataKey.error && this.isTargetBased) {
+          try {
+            const message = JSON.parse(dataKey.params.message);
+            msgId = _.isUndefined(message.id) ? '' : String(message.id);
+            method = message.method;
+            result = message.result || message;
+            params = result.params;
+          } catch (err) {
+            // if this happens then some aspect of the protocol is missing to us
+            // so print the entire message to get visibiity into what is going on
+            log.error(`Unexpected message format from Web Inspector: ${util.jsonStringify(plist, null)}`);
+            throw err;
+          }
         }
-      } else {
-        error = new Error(String(dataKey.error || defaultMessage));
-      }
-    }
 
-    await this.dispatchDataMessage(msgId, method, params, result, error);
-  }
+        await this.dispatchDataMessage(msgId, method, params, result, parseError());
+        return;
+      }
+      default: {
+        await this.dispatchDataMessage(msgId, method, params, result, parseError());
+      }
+    } // switch
+  } // function
 }
 
 /**

--- a/lib/rpc/rpc-message-handler.js
+++ b/lib/rpc/rpc-message-handler.js
@@ -118,20 +118,11 @@ export default class RpcMessageHandler extends EventEmitters {
    * @returns {Promise<void>}
    */
   async dispatchDataMessage (msgId, method, params, result, error) {
-    const logEmit = (/** @type {string} */ name, /** @type {Error | undefined} */ err) => {
-      let logMessage = `Emitting data event '${name}'`;
-      if (err) {
-        logMessage += ` (error: ${err.message})`;
-      }
-      log.debug(logMessage);
-    };
-
     if (msgId) {
       if (this.listenerCount(msgId)) {
         if (_.has(result?.result, 'value')) {
           result = result.result.value;
         }
-        logEmit(msgId, error);
         this.emit(msgId, error, result);
       } else {
         log.error(`Web Inspector returned data for message '${msgId}' ` +
@@ -182,7 +173,6 @@ export default class RpcMessageHandler extends EventEmitters {
     }
 
     for (const name of eventNames) {
-      logEmit(name, error);
       this.emit(name, error, ...args);
     }
   }

--- a/lib/rpc/rpc-message-handler.js
+++ b/lib/rpc/rpc-message-handler.js
@@ -118,12 +118,20 @@ export default class RpcMessageHandler extends EventEmitters {
    * @returns {Promise<void>}
    */
   async dispatchDataMessage (msgId, method, params, result, error) {
+    const logEmit = (/** @type {string} */ name, /** @type {Error | undefined} */ err) => {
+      let logMessage = `Emitting data event '${name}'`;
+      if (err) {
+        logMessage += ` (error: ${err.message})`;
+      }
+      log.debug(logMessage);
+    };
+
     if (msgId) {
-      log.debug(`Handling message id: '${msgId}'`);
       if (this.listenerCount(msgId)) {
         if (_.has(result?.result, 'value')) {
           result = result.result.value;
         }
+        logEmit(msgId, error);
         this.emit(msgId, error, result);
       } else {
         log.error(`Web Inspector returned data for message '${msgId}' ` +
@@ -174,6 +182,7 @@ export default class RpcMessageHandler extends EventEmitters {
     }
 
     for (const name of eventNames) {
+      logEmit(name, error);
       this.emit(name, error, ...args);
     }
   }
@@ -215,25 +224,14 @@ export default class RpcMessageHandler extends EventEmitters {
     };
 
     switch (method) {
-      case 'Target.targetCreated': {
-        // this is in response to a `_rpc_forwardSocketSetup:` call
-        // targetInfo: { targetId: 'page-1', type: 'page' }
-        const app = plist.__argument.WIRApplicationIdentifierKey;
-        const targetInfo = dataKey.params.targetInfo;
-        this.emit('Target.targetCreated', null, app, targetInfo);
-        return;
-      }
+      case 'Target.targetCreated':
+      case 'Target.targetDestroyed':
       case 'Target.didCommitProvisionalTarget': {
         const app = plist.__argument.WIRApplicationIdentifierKey;
-        const oldTargetId = dataKey.params.oldTargetId;
-        const newTargetId = dataKey.params.newTargetId;
-        this.emit('Target.didCommitProvisionalTarget', null, app, oldTargetId, newTargetId);
-        return;
-      }
-      case 'Target.targetDestroyed': {
-        const app = plist.__argument.WIRApplicationIdentifierKey;
-        const targetInfo = dataKey.params.targetInfo || {targetId: dataKey.params.targetId};
-        this.emit('Target.targetDestroyed', null, app, targetInfo);
+        const args = method === 'Target.didCommitProvisionalTarget'
+          ? params
+          : (params.targetInfo ?? {targetId: params.targetId});
+        this.emit(method, null, app, args);
         return;
       }
       case 'Target.dispatchMessageFromTarget': {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -83,6 +83,7 @@ export type RemoteDebuggerRealDeviceOptions = RemoteDebuggerRealDeviceSpecificOp
 
 export type AppIdKey = string | number;
 export type PageIdKey = string | number;
+export type TargetId = string;
 
 export interface RemoteCommandOpts {
   appIdKey?: AppIdKey;
@@ -90,7 +91,7 @@ export interface RemoteCommandOpts {
   id?: string;
   connId?: string;
   senderId?: string;
-  targetId?: string;
+  targetId?: TargetId;
   bundleId?: string;
   enabled?: boolean;
   [key: string]: any;
@@ -102,7 +103,36 @@ export interface ProtocolCommandOpts {
   params: StringRecord;
 }
 
-export interface RemoteCommand {
-  __argument: StringRecord;
+type SocketDataKey = Buffer | StringRecord;
+
+interface RemoteCommandArgument<T extends SocketDataKey> {
+  WIRSocketDataKey?: T;
+  WIRConnectionIdentifierKey?: string;
+  WIRSenderKey?: string;
+  WIRApplicationIdentifierKey?: AppIdKey;
+  WIRPageIdentifierKey?: PageIdKey;
+  WIRMessageDataTypeKey?: string;
+  WIRDestinationKey?: string;
+  WIRMessageDataKey?: string;
+  [key: string]: any;
+}
+
+interface RemoteCommandTemplated<T extends SocketDataKey> {
+  __argument: RemoteCommandArgument<T>;
   __selector: string;
+}
+
+export type RawRemoteCommand = RemoteCommandTemplated<StringRecord>;
+export type RemoteCommand = RemoteCommandTemplated<Buffer>;
+
+export interface TargetInfo {
+  targetId: string;
+  type: 'page' | 'service-worker' | 'worker';
+  isProvisional: boolean;
+  isPaused: boolean;
+}
+
+export interface ProvisionalTargetInfo {
+  oldTargetId: string;
+  newTargetId: string;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -96,8 +96,9 @@ export function appIdsForBundle (bundleId, appDict) {
 }
 
 /**
- * @param {import('@appium/types').StringRecord} params
- * @returns {void}
+ * @template {import('@appium/types').StringRecord} T
+ * @param {T} params
+ * @returns {T}
  */
 export function checkParams (params) {
   // check if all parameters have a value
@@ -107,6 +108,7 @@ export function checkParams (params) {
   if (errors.length) {
     throw new Error(`Missing ${util.pluralize('parameter', errors.length)}: ${errors.join(', ')}`);
   }
+  return params;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@appium/support": "^6.0.0",
     "appium-ios-device": "^2.0.0",
     "asyncbox": "^3.0.0",
+    "async-lock": "^1.4.1",
     "bluebird": "^3.4.7",
     "glob": "^10.3.3",
     "lodash": "^4.17.11",

--- a/test/functional/safari-e2e-specs.js
+++ b/test/functional/safari-e2e-specs.js
@@ -189,12 +189,12 @@ describe('Safari remote debugger', function () {
     });
   });
 
-  it('should be able to monitor network events', async function () {
+  it.only('should be able to monitor network events', async function () {
     const networkEvents = [];
     // eslint-disable-next-line promise/prefer-await-to-callbacks
-    rd.startNetwork((err, event) => {
-      if (event) {
-        networkEvents.push(event);
+    rd.startNetwork((err, event, method) => {
+      if (event && method) {
+        networkEvents.push({event, method});
       }
     });
 
@@ -202,11 +202,15 @@ describe('Safari remote debugger', function () {
     const [appIdKey, pageIdKey] = page.id.split('.').map((id) => parseInt(id, 10));
     await rd.selectPage(appIdKey, pageIdKey);
 
+    await rd.navToUrl(`https://github.com`);
+
     await rd.navToUrl(`${address}/frameset.html`);
 
     await retryInterval(50, 100, function () {
       networkEvents.length.should.be.at.least(1);
     });
+
+    console.log('Network events:', JSON.stringify(networkEvents)); // eslint-disable-line no-console
   });
 
   it('capture full viewport', async function () {

--- a/test/functional/safari-e2e-specs.js
+++ b/test/functional/safari-e2e-specs.js
@@ -211,7 +211,7 @@ describe('Safari remote debugger', function () {
 
     await retryInterval(50, 100, function () {
       networkEvents.length.should.be.at.least(1);
-      expect(networkEvents.find((req) => req?.url === 'https://github.com/')).to.exist;
+      expect(networkEvents.find(({event}) => event?.request?.url === 'https://github.com/')).to.exist;
     });
   });
 

--- a/test/functional/safari-e2e-specs.js
+++ b/test/functional/safari-e2e-specs.js
@@ -36,6 +36,8 @@ describe('Safari remote debugger', function () {
   this.retries(2);
 
   let chai;
+  /** @type {Chai.ExpectStatic} */
+  let expect;
   /** @type {import('appium-ios-simulator').Simulator} */
   let sim;
   let simCreated = false;
@@ -48,6 +50,7 @@ describe('Safari remote debugger', function () {
     const chaiAsPromised = await import('chai-as-promised');
     chai.should();
     chai.use(chaiAsPromised.default);
+    expect = chai.expect;
 
     sim = await getExistingSim(DEVICE_NAME, PLATFORM_VERSION);
     if (!sim) {
@@ -189,7 +192,7 @@ describe('Safari remote debugger', function () {
     });
   });
 
-  it.only('should be able to monitor network events', async function () {
+  it('should be able to monitor network events', async function () {
     const networkEvents = [];
     // eslint-disable-next-line promise/prefer-await-to-callbacks
     rd.startNetwork((err, event, method) => {
@@ -208,9 +211,8 @@ describe('Safari remote debugger', function () {
 
     await retryInterval(50, 100, function () {
       networkEvents.length.should.be.at.least(1);
+      expect(networkEvents.find((req) => req?.url === 'https://github.com/')).to.exist;
     });
-
-    console.log('Network events:', JSON.stringify(networkEvents)); // eslint-disable-line no-console
   });
 
   it('capture full viewport', async function () {

--- a/test/unit/mixins/execute-specs.js
+++ b/test/unit/mixins/execute-specs.js
@@ -22,6 +22,7 @@ describe('execute', function () {
         _rpcClient: {
           isConnected: true,
           send: () => ({hello: 'world'}),
+          waitForPageInitialization: async () => {},
         },
       };
       ctx.requireRpcClient = () => ctx._rpcClient;
@@ -39,6 +40,7 @@ describe('execute', function () {
         _rpcClient: {
           isConnected: true,
           send: () => ({result: {objectId: 'fake-object-id'}}),
+          waitForPageInitialization: async () => {},
         },
       };
       ctx.requireRpcClient = () => ctx._rpcClient;
@@ -62,6 +64,7 @@ describe('execute', function () {
             return {result: {objectId: 'fake-object-id'}};
           },
           isConnected: true,
+          waitForPageInitialization: async () => {},
         },
         waitForDom () { },
         _pageLoading: true,


### PR DESCRIPTION
BREAKING CHANGE: Removed the obsolete ON_TARGET_PROVISIONED_EVENT exported constant

This change is quite large and introduces a couple of important fixes:
- Usage of `Target.setPauseOnStart` command. This allows to properly control the life cycle of targets allowing for proper target initialization before interacting with them.
- Better log messages
- Fixes related to data events emitting
- Better RPC synchronization and page state detection 