### PR TITLE
chore: Bump the default timeout for the target creation event

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         include:
         - os: macos-15
-          xcode: '16.2'
-          ios: '18.2'
-          device: iPhone 16
+          xcode: '16.4'
+          ios: '18.5'
+          device: 'iPhone 16'
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -44,6 +44,6 @@ jobs:
         os_version: "${{ matrix.ios }}"
         shutdown_after_job: false
         wait_for_boot: true
-    - run: xcrun simctl openurl booted "https://google.com" &
+    - run: nohup xcrun simctl openurl booted "https://google.com" &
     - run: npm install
     - run: npm run e2e-test

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -44,6 +44,5 @@ jobs:
         os_version: "${{ matrix.ios }}"
         shutdown_after_job: false
         wait_for_boot: true
-    - run: nohup xcrun simctl openurl booted "https://google.com" &
     - run: npm install
     - run: npm run e2e-test

--- a/lib/remote-debugger-real-device.ts
+++ b/lib/remote-debugger-real-device.ts
@@ -21,6 +21,7 @@ export class RemoteDebuggerRealDevice extends RemoteDebugger {
       socketChunkSize: this._socketChunkSize,
       webInspectorMaxFrameLength: this._webInspectorMaxFrameLength,
       udid: this._udid,
+      pageLoadTimeoutMs: this._pageLoadMs,
     });
   }
 }

--- a/lib/remote-debugger.ts
+++ b/lib/remote-debugger.ts
@@ -232,6 +232,7 @@ export class RemoteDebugger extends EventEmitter {
       logAllCommunicationHexDump: this._logAllCommunicationHexDump,
       fullPageInitialization: this._fullPageInitialization,
       webInspectorMaxFrameLength: this._webInspectorMaxFrameLength,
+      pageLoadTimeoutMs: this._pageLoadMs,
     });
   }
 

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -277,6 +277,10 @@ export class RpcClient {
 
     // otherwise waiting is necessary to see what the target is
     const waitMs = Math.max(MIN_WAIT_FOR_TARGET_TIMEOUT_MS, this.pageLoadTimeoutMs || 0);
+    log.debug(
+      `Waiting up to ${waitMs}ms for a target to be created for ` +
+      `app '${appIdKey}' and page '${pageIdKey}'`
+    );
     try {
       await waitForCondition(() => {
         target = this.getTarget(appIdKey, pageIdKey);

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -9,7 +9,7 @@ import { EventEmitter } from 'node:events';
 import AsyncLock from 'async-lock';
 
 const DATA_LOG_LENGTH = {length: 200};
-const WAIT_FOR_TARGET_TIMEOUT_MS = 10000;
+const MIN_WAIT_FOR_TARGET_TIMEOUT_MS = 30000;
 const WAIT_FOR_TARGET_INTERVAL_MS = 100;
 const MIN_PLATFORM_FOR_TARGET_BASED = '12.2';
 // `Target.exists` protocol method was removed from WebKit in 13.4
@@ -81,6 +81,9 @@ export class RpcClient {
   /** @type {string|undefined} */
   bundleId;
 
+  /** @type {number | undefined} */
+  pageLoadTimeoutMs;
+
   /** @type {string} */
   platformVersion;
 
@@ -111,6 +114,7 @@ export class RpcClient {
       socketChunkSize,
       fullPageInitialization = false,
       udid,
+      pageLoadTimeoutMs,
     } = opts;
 
     this.isSafari = isSafari;
@@ -126,6 +130,7 @@ export class RpcClient {
     this.logAllCommunicationHexDump = logAllCommunicationHexDump;
     this.socketChunkSize = socketChunkSize;
     this.webInspectorMaxFrameLength = webInspectorMaxFrameLength;
+    this.pageLoadTimeoutMs = pageLoadTimeoutMs;
 
     this.fullPageInitialization = fullPageInitialization;
 
@@ -271,12 +276,13 @@ export class RpcClient {
     }
 
     // otherwise waiting is necessary to see what the target is
+    const waitMs = Math.max(MIN_WAIT_FOR_TARGET_TIMEOUT_MS, this.pageLoadTimeoutMs || 0);
     try {
       await waitForCondition(() => {
         target = this.getTarget(appIdKey, pageIdKey);
         return !_.isEmpty(target);
       }, {
-        waitMs: WAIT_FOR_TARGET_TIMEOUT_MS,
+        waitMs,
         intervalMs: WAIT_FOR_TARGET_INTERVAL_MS,
       });
       return target;
@@ -285,8 +291,7 @@ export class RpcClient {
         throw err;
       }
       throw new Error(
-        `No targets could be matched for the app '${appIdKey}' and page '${pageIdKey}' after ` +
-        `${WAIT_FOR_TARGET_TIMEOUT_MS}ms. This is likely a bug.`
+        `No targets could be matched for the app '${appIdKey}' and page '${pageIdKey}' after ${waitMs}ms`
       );
     }
   }
@@ -954,6 +959,7 @@ export default RpcClient;
  * @property {number} [webInspectorMaxFrameLength]
  * @property {number} [socketChunkSize]
  * @property {boolean} [fullPageInitialization=false]
+ * @property {number} [pageLoadTimeoutMs]
  * @property {string} [udid]
  */
 


### PR DESCRIPTION
I sometimes observe setContext timeouts due to slow CI env, for example https://github.com/appium/java-client/actions/runs/16948552767/job/48035614358#step:17:1511