### PR TITLE
feat: Update server compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "url": "https://github.com/appium/appium-remote-debugger/issues"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "types": "./build/index.d.ts",
   "main": "./build/index.js",
@@ -33,16 +33,16 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@appium/base-driver": "^9.0.0",
-    "@appium/support": "^6.0.0",
-    "appium-ios-device": "^2.9.0",
+    "@appium/base-driver": "^10.0.0-rc.1",
+    "@appium/support": "^7.0.0-rc.1",
+    "appium-ios-device": "^3.0.0",
     "asyncbox": "^3.0.0",
     "async-lock": "^1.4.1",
     "bluebird": "^3.4.7",
     "glob": "^10.3.3",
     "lodash": "^4.17.11",
     "source-map-support": "^0.x",
-    "teen_process": "^2.0.0"
+    "teen_process": "^3.0.0"
   },
   "scripts": {
     "build": "tsc -b",
@@ -65,24 +65,23 @@
     "singleQuote": true
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.x",
-    "@appium/tsconfig": "^0.x",
-    "@appium/types": "^0.x",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/bluebird": "^3.5.38",
     "@types/lodash": "^4.14.196",
     "@types/mocha": "^10.0.1",
     "@types/node": "^24.0.0",
-    "@types/teen_process": "^2.0.0",
-    "appium-ios-simulator": "^6.1.2",
+    "appium-ios-simulator": "^7.0.0",
     "chai": "^5.1.1",
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "mocha": "^11.0.1",
     "mocha-junit-reporter": "^2.0.0",
     "mocha-multi-reporters": "^1.5.1",
-    "node-simctl": "^7.0.1",
+    "node-simctl": "^8.0.0",
     "prettier": "^3.0.0",
     "serve-static": "^2.2.0",
     "semantic-release": "^24.0.0",


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10
BREAKING CHANGE: Required base driver version has been bumped to >=10.0.0-rc.1