### PR TITLE
fix: Apply initialisation lock per app

### DIFF
--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -544,14 +544,19 @@ export class RpcClient {
     }
 
     log.debug(`Target created for app '${appIdKey}' and page '${pageIdKey}': ${JSON.stringify(targetInfo)}`);
-    if (_.has(this.targets[appIdKey], pageIdKey)) {
-      log.debug(`There is already a target for this app and page ('${this.targets[appIdKey][pageIdKey]}'). This might cause problems`);
+    if (!_.isPlainObject(this.targets[appIdKey])) {
+      this.targets[appIdKey] = {
+        lock: new AsyncLock(),
+      };
+    } else if (_.has(this.targets[appIdKey], pageIdKey)) {
+      log.debug(
+        `There is already a target for this app and page ('${this.targets[appIdKey][pageIdKey]}'). ` +
+        `This might cause problems`
+      );
     }
-    const lock = new AsyncLock();
-    this.targets[app] = this.targets[app] || { lock };
     this.targets[appIdKey][pageIdKey] = targetInfo.targetId;
 
-    await lock.acquire(appIdKey, async () => {
+    await this.targets[appIdKey].lock.acquire(appIdKey, async () => {
       try {
         await this.send('Target.setPauseOnStart', {
           pauseOnStart: true,
@@ -656,7 +661,7 @@ export class RpcClient {
     if (!appIdKey || !pageIdKey) {
       return;
     }
-    return (this.targets[appIdKey] || {})[pageIdKey];
+    return this.targets[appIdKey]?.[pageIdKey];
   }
 
   /**
@@ -715,6 +720,7 @@ export class RpcClient {
     };
 
     log.debug(`Initializing page '${pageIdKey}' for app '${appIdKey}'`);
+    const timer = new timing.Timer().start();
     if (!this.fullPageInitialization) {
       // The sequence of domains is important
       for (const domain of [
@@ -735,7 +741,10 @@ export class RpcClient {
           log.info(`Cannot enable domain '${domain}' during initialization: ${err.message}`);
         }
       }
-      log.debug(`Simple initialization of page '${pageIdKey}' for app '${appIdKey}' completed`);
+      log.debug(
+        `Simple initialization of page '${pageIdKey}' for app '${appIdKey}' completed ` +
+        `in ${timer.getDuration().asMilliSeconds}ms`
+      );
       return;
     }
 
@@ -817,7 +826,10 @@ export class RpcClient {
         log.info(`Cannot enable domain '${domain}' during full initialization: ${err.message}`);
       }
     }
-    log.debug(`Full initialization of page '${pageIdKey}' for app '${appIdKey}' completed`);
+    log.debug(
+      `Full initialization of page '${pageIdKey}' for app '${appIdKey}' completed ` +
+      `in ${timer.getDuration().asMilliSeconds}ms`
+    );
   }
 
   /**
@@ -928,15 +940,10 @@ export class RpcClient {
     if (!appTargetsMap) {
       throw new Error(`No targets found for app '${appIdKey}'`);
     }
-    /** @type {AsyncLock | undefined}  */
     const lock = appTargetsMap.lock;
-    if (lock?.isBusy()) {
-      const timer = new timing.Timer().start();
-      log.debug(`Waiting until page ${pageIdKey}@${appIdKey} is fully initialized`);
+    if (lock.isBusy()) {
+      log.debug(`Waiting until the page ${pageIdKey}@${appIdKey} is initialized`);
       await lock.acquire(appIdKey, async () => await B.delay(0));
-      log.debug(
-        `The initalization of the page ${pageIdKey}@${appIdKey} took ${timer.getDuration().asMilliSeconds}ms`
-      );
     }
   }
 }
@@ -962,6 +969,6 @@ export default RpcClient;
  */
 
 /**
- * @typedef {PageDict & {provisional?: import('../types').ProvisionalTargetInfo, lock: import('async-lock').default}} PagesToTargets
+ * @typedef {PageDict & {provisional?: import('../types').ProvisionalTargetInfo, lock: AsyncLock}} PagesToTargets
  * @typedef {{[key: import('../types').AppIdKey]: PagesToTargets}} AppToTargetsMap
  */

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -532,7 +532,7 @@ export class RpcClient {
       log.debug(`The target ${targetInfo.targetId}@${appIdKey} is paused`);
       const appTargetsMap = this.targets[appIdKey];
       if (appTargetsMap) {
-        await appTargetsMap.lock.acquire(toLockKey(appIdKey, pageIdKey), async () => {
+        await appTargetsMap.lock.acquire(appIdKey, async () => {
           try {
             await this._initializePage(appIdKey, pageIdKey, targetInfo.targetId);
           } finally {
@@ -551,7 +551,7 @@ export class RpcClient {
     this.targets[app] = this.targets[app] || { lock };
     this.targets[appIdKey][pageIdKey] = targetInfo.targetId;
 
-    await lock.acquire(toLockKey(appIdKey, pageIdKey), async () => {
+    await lock.acquire(appIdKey, async () => {
       try {
         await this.send('Target.setPauseOnStart', {
           pauseOnStart: true,
@@ -933,22 +933,12 @@ export class RpcClient {
     if (lock?.isBusy()) {
       const timer = new timing.Timer().start();
       log.debug(`Waiting until page ${pageIdKey}@${appIdKey} is fully initialized`);
-      await lock.acquire(toLockKey(appIdKey, pageIdKey), async () => await B.delay(0));
+      await lock.acquire(appIdKey, async () => await B.delay(0));
       log.debug(
         `The initalization of the page ${pageIdKey}@${appIdKey} took ${timer.getDuration().asMilliSeconds}ms`
       );
     }
   }
-}
-
-/**
- *
- * @param {import('../types').AppIdKey} appIdKey
- * @param {import('../types').PageIdKey} pageIdKey
- * @returns {string}
- */
-export function toLockKey(appIdKey, pageIdKey) {
-  return `${appIdKey}-${pageIdKey}`;
 }
 
 export default RpcClient;


### PR DESCRIPTION
We should not be able to send any requests to an app while any of its page is being initialized. Doing so may cause unexpected freezes or crashes