### PR TITLE
feat: Drop the obsolete non-target based communication protocol support

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -49,4 +49,9 @@ jobs:
         shutdown_after_job: false
         wait_for_boot: true
     - run: npm install
-    - run: npm run e2e-test
+    - name: Retry E2E Tests
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 40
+        max_attempts: 2
+        command: npm run e2e-test

--- a/lib/rpc/remote-messages.js
+++ b/lib/rpc/remote-messages.js
@@ -27,25 +27,6 @@ const COMMANDS = /** @type {const} */ ({
 });
 
 export class RemoteMessages {
-  constructor (isTargetBased = true) {
-    this._isTargetBased = isTargetBased;
-  }
-
-  /**
-   * @param {boolean} isTargetBased
-   * @returns {boolean}
-   */
-  set isTargetBased (isTargetBased) {
-    this._isTargetBased = isTargetBased;
-  }
-
-  /**
-   * @returns {boolean}
-   */
-  get isTargetBased () {
-    return this._isTargetBased;
-  }
-
   // #region Connection functions
 
   /**
@@ -158,34 +139,22 @@ export class RemoteMessages {
      * JavaScript).
      */
 
-    let realMethod;
-    let realParams;
-    if (this.isTargetBased) {
-      realMethod = 'Target.sendMessageToTarget';
-      realParams = {
-        targetId,
-        message: JSON.stringify({
-          id,
-          method,
-          params: Object.assign({
-            objectGroup: OBJECT_GROUP,
-            includeCommandLineAPI: true,
-            doNotPauseOnExceptionsAndMuteConsole: false,
-            emulateUserGesture: false,
-            generatePreview: false,
-            saveResult: false,
-          }, params)
-        }),
-      };
-    } else {
-      realMethod = method;
-      realParams = Object.assign({
-        objectGroup: OBJECT_GROUP,
-        includeCommandLineAPI: true,
-        doNotPauseOnExceptionsAndMuteConsole: false,
-        emulateUserGesture: false,
-      }, params);
-    }
+    const realMethod = 'Target.sendMessageToTarget';
+    const realParams = {
+      targetId,
+      message: JSON.stringify({
+        id,
+        method,
+        params: Object.assign({
+          objectGroup: OBJECT_GROUP,
+          includeCommandLineAPI: true,
+          doNotPauseOnExceptionsAndMuteConsole: false,
+          emulateUserGesture: false,
+          generatePreview: false,
+          saveResult: false,
+        }, params)
+      }),
+    };
 
     const plist = {
       __argument: {
@@ -212,19 +181,15 @@ export class RemoteMessages {
   getMinimalCommand (opts) {
     const {method, params, connId, senderId, appIdKey, pageIdKey, targetId, id} = opts;
 
-    let realMethod = method;
-    let realParams = params;
-    if (this.isTargetBased) {
-      realMethod = 'Target.sendMessageToTarget';
-      realParams = {
-        targetId,
-        message: JSON.stringify({
-          id,
-          method,
-          params,
-        }),
-      };
-    }
+    const realMethod = 'Target.sendMessageToTarget';
+    const realParams = {
+      targetId,
+      message: JSON.stringify({
+        id,
+        method,
+        params,
+      }),
+    };
 
     const plist = {
       __argument: {

--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -14,9 +14,6 @@ const MIN_WAIT_FOR_TARGET_TIMEOUT_MS = 30000;
 // although we still should not allow it to take forever
 const PAGE_INIT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const WAIT_FOR_TARGET_INTERVAL_MS = 100;
-const MIN_PLATFORM_FOR_TARGET_BASED = '12.2';
-// `Target.exists` protocol method was removed from WebKit in 13.4
-const MIN_PLATFORM_NO_TARGET_EXISTS = '13.4';
 const NO_TARGET_SUPPORTED_ERROR = `'target' domain was not found`;
 const MISSING_TARGET_ERROR_PATTERN = /Missing target/i;
 const NO_TARGET_PRESENT_YET_ERRORS = [
@@ -27,20 +24,6 @@ const NO_TARGET_PRESENT_YET_ERRORS = [
 export const NEW_APP_CONNECTED_ERROR = 'New application has connected';
 export const EMPTY_PAGE_DICTIONARY_ERROR = 'Empty page dictionary received';
 
-/**
- * @param {boolean} isSafari
- * @param {string} platformVersion
- * @returns {boolean}
- */
-function isTargetBased (isSafari, platformVersion) {
-  // On iOS 12.2 the messages get sent through the Target domain
-  // On iOS 13.0+, WKWebView also needs to follow the Target domain,
-  // so here only check the target OS version as the default behaviour.
-  const isHighVersion = util.compareVersions(platformVersion, '>=', MIN_PLATFORM_FOR_TARGET_BASED);
-  log.debug(`Checking which communication style to use (${isSafari ? '' : 'non-'}Safari on platform version '${platformVersion}')`);
-  log.debug(`Platform version equal or higher than '${MIN_PLATFORM_FOR_TARGET_BASED}': ${isHighVersion}`);
-  return isHighVersion;
-}
 
 export class RpcClient {
   /** @type {RpcMessageHandler|undefined} */
@@ -146,8 +129,15 @@ export class RpcClient {
     this._targetSubscriptions = new EventEmitter();
     this._provisionedPages = new Set();
 
-    // start with a best guess for the protocol
-    this.isTargetBased = platformVersion ? isTargetBased(isSafari, platformVersion) : true;
+    this.remoteMessages = new RemoteMessages();
+
+    this.messageHandler = new RpcMessageHandler();
+    // add handlers for internal events
+    this.messageHandler.on('Target.targetCreated', this.addTarget.bind(this));
+    this.messageHandler.on('Target.didCommitProvisionalTarget', this.updateTarget.bind(this));
+    this.messageHandler.on('Target.targetDestroyed', this.removeTarget.bind(this));
+    this.messageHandler.on('Runtime.executionContextCreated', this.onExecutionContextCreated.bind(this));
+    this.messageHandler.on('Heap.garbageCollected', this.onGarbageCollected.bind(this));
   }
 
   /**
@@ -155,13 +145,6 @@ export class RpcClient {
    */
   get contexts () {
     return this._contexts;
-  }
-
-  /**
-   * @returns {boolean}
-   */
-  get needsTarget () {
-    return this.isTargetBased;
   }
 
   /**
@@ -228,50 +211,12 @@ export class RpcClient {
   }
 
   /**
-   * @param {boolean} isTargetBased
-   */
-  set isTargetBased (isTargetBased) {
-    log.warn(`Setting communication protocol: using ${isTargetBased ? 'Target-based' : 'full Web Inspector protocol'} communication`);
-    this._isTargetBased = isTargetBased;
-
-    if (!this.remoteMessages) {
-      this.remoteMessages = new RemoteMessages(isTargetBased);
-    } else {
-      this.remoteMessages.isTargetBased = isTargetBased;
-    }
-
-    if (!this.messageHandler) {
-      this.messageHandler = new RpcMessageHandler(isTargetBased);
-
-      // add handlers for internal events
-      this.messageHandler.on('Target.targetCreated', this.addTarget.bind(this));
-      this.messageHandler.on('Target.didCommitProvisionalTarget', this.updateTarget.bind(this));
-      this.messageHandler.on('Target.targetDestroyed', this.removeTarget.bind(this));
-      this.messageHandler.on('Runtime.executionContextCreated', this.onExecutionContextCreated.bind(this));
-      this.messageHandler.on('Heap.garbageCollected', this.onGarbageCollected.bind(this));
-    } else {
-      this.messageHandler.isTargetBased = isTargetBased;
-    }
-  }
-
-  /**
-   * @returns {boolean}
-   */
-  get isTargetBased () {
-    return !!this._isTargetBased;
-  }
-
-  /**
    *
    * @param {import('../types').AppIdKey} appIdKey
    * @param {import('../types').PageIdKey} pageIdKey
    * @returns {Promise<import('../types').TargetId | undefined>}
    */
   async waitForTarget (appIdKey, pageIdKey) {
-    if (!this.needsTarget) {
-      log.debug(`Target-based communication is not needed, skipping wait for target`);
-      return;
-    }
     let target = this.getTarget(appIdKey, pageIdKey);
     if (target) {
       log.debug(
@@ -323,14 +268,8 @@ export class RpcClient {
       } = opts;
       const messageLc = (err.message || '').toLowerCase();
       if (messageLc.includes(NO_TARGET_SUPPORTED_ERROR)) {
-        log.info(
-          'The target device does not support Target based communication. ' +
-          'Will follow non-target based communication.'
-        );
-        this.isTargetBased = false;
         return await this.sendToDevice(command, opts, waitForResponse);
       } else if (appIdKey && NO_TARGET_PRESENT_YET_ERRORS.some((error) => messageLc.includes(error))) {
-        this.isTargetBased = true;
         await this.waitForTarget(appIdKey, /** @type {import('../types').PageIdKey} */ (pageIdKey));
         return await this.sendToDevice(command, opts, waitForResponse);
       }
@@ -356,18 +295,15 @@ export class RpcClient {
 
       // keep track of the messages coming and going using a simple sequential id
       const msgId = this.msgId++;
-      let wrapperMsgId = msgId;
-      if (this.isTargetBased) {
-        // for target-base communication, everything is wrapped up
-        wrapperMsgId = this.msgId++;
-        // acknowledge wrapper message
-        // @ts-ignore messageHandler must be defined
-        this.messageHandler.on(wrapperMsgId.toString(), function (err) {
-          if (err) {
-            reject(err);
-          }
-        });
-      }
+      // for target-base communication, everything is wrapped up
+      const wrapperMsgId = this.msgId++;
+      // acknowledge wrapper message
+      // @ts-ignore messageHandler must be defined
+      this.messageHandler.on(wrapperMsgId.toString(), function (err) {
+        if (err) {
+          reject(err);
+        }
+      });
 
       const appIdKey = opts.appIdKey;
       const pageIdKey = opts.pageIdKey;
@@ -456,7 +392,7 @@ export class RpcClient {
       const msg = `Sending '${cmd.__selector}' message` +
         (appIdKey ? ` to app '${appIdKey}'` : '') +
         (pageIdKey ? `, page '${pageIdKey}'` : '') +
-        (this.needsTarget && targetId ? `, target '${targetId}'` : '') +
+        (targetId ? `, target '${targetId}'` : '') +
         ` (id: ${msgId}): '${command}'`;
       log.debug(msg);
       try {
@@ -720,15 +656,6 @@ export class RpcClient {
 
     await this.send('setSenderKey', sendOpts);
     log.debug('Sender key set');
-
-    if (!this.isTargetBased) {
-      await this._initializePage(appIdKey, pageIdKey);
-      return;
-    }
-
-    if (this.isTargetBased && util.compareVersions(this.platformVersion, '<', MIN_PLATFORM_NO_TARGET_EXISTS)) {
-      await this.send('Target.exists', sendOpts, false);
-    }
 
     await this.waitForTarget(appIdKey, pageIdKey);
     await this.waitForPageInitialization(appIdKey, pageIdKey);

--- a/lib/rpc/rpc-message-handler.js
+++ b/lib/rpc/rpc-message-handler.js
@@ -5,27 +5,8 @@ import EventEmitters from 'events';
 
 
 export default class RpcMessageHandler extends EventEmitters {
-  constructor (isTargetBased = true) {
+  constructor () {
     super();
-    this._isTargetBased = isTargetBased;
-  }
-
-  /**
-   * Get whether the message handler is target-based or not.
-   * @return {boolean}
-   */
-  get isTargetBased () {
-    return this._isTargetBased;
-  }
-
-  /**
-   * Set whether the message handler is target-based or not.
-   *
-   * @param {boolean} isTargetBased
-   * @returns {void}
-   */
-  set isTargetBased (isTargetBased) {
-    this._isTargetBased = !!isTargetBased;
   }
 
   /**
@@ -225,7 +206,7 @@ export default class RpcMessageHandler extends EventEmitters {
         return;
       }
       case 'Target.dispatchMessageFromTarget': {
-        if (!dataKey.error && this.isTargetBased) {
+        if (!dataKey.error) {
           try {
             const message = JSON.parse(dataKey.params.message);
             msgId = _.isUndefined(message.id) ? '' : String(message.id);


### PR DESCRIPTION
Full target-based protocol support should be present since iOS 13.2 (year 2019). Our minimum major supported version is 17.
Also we do not run any tests to validate that legacy support.

BREAKING CHANGE: Changed constructor signature of RemoteMessages class. It does not accept any arguments now
BREAKING CHANGE: Removed the obsolete isTargetBased getter and setter from RemoteMessages class instances
BREAKING CHANGE: Removed the obsolete needsTarget getter and  isTargetBased property from RpcClient class instances
BREAKING CHANGE: Removed the obsolete isTargetBased getter and  setter from RpcClient class instances
BREAKING CHANGE: Changed constructor signature of RpcMessageHandler class. It does not accept any arguments now
BREAKING CHANGE: Removed the obsolete isTargetBased getter and  setter from RpcMessageHandler class instances

