### PR TITLE
fix: Do not wait for existing targets

### DIFF
--- a/lib/rpc/rpc-client.js
+++ b/lib/rpc/rpc-client.js
@@ -680,6 +680,11 @@ export class RpcClient {
       this._pendingTargetNotification = [appIdKey, pageIdKey, pageReadinessDetector];
       this._provisionedPages.clear();
 
+      if (this.getTarget(appIdKey, pageIdKey)) {
+        log.debug(`Page '${pageIdKey}' is already selected for app '${appIdKey}'`);
+        return;
+      }
+
       // go through the steps that the Desktop Safari system
       // goes through to initialize the Web Inspector session
 


### PR DESCRIPTION
Resolves 

```
2025-10-03 07:56:52:470 - [6df9aeb9][HTTP] --> DELETE /session/6df9aeb9-8bc1-4c9e-b30d-7873316ecf63/window 
2025-10-03 07:56:52:470 - [6df9aeb9][XCUITestDriver@ba61] Calling AppiumDriver.closeWindow() with args: ["6df9aeb9-8bc1-4c9e-b30d-7873316ecf63"]
2025-10-03 07:56:52:471 - [6df9aeb9][XCUITestDriver@ba61] Executing command 'closeWindow'
2025-10-03 07:56:52:474 - [6df9aeb9][RemoteDebugger] Executing atom 'execute_script' with 'args=["setTimeout(function () {window.open('','_self').close();}, 0); return true;",[]]; frames='
2025-10-03 07:56:52:476 - [6df9aeb9][RemoteDebugger] Executing 'execute_script' atom in default context
2025-10-03 07:56:52:477 - [6df9aeb9][RemoteDebugger] Sending javascript command: '(function(){return (function(){var e=this||self...'
2025-10-03 07:56:52:478 - [6df9aeb9][RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:37059', page '3', target 'page-55' (id: 68): 'Runtime.evaluate'
2025-10-03 07:56:52:681 - [6df9aeb9][RemoteDebugger] Received data response from send (id: 68): '{"status":0,"value":true}'
2025-10-03 07:56:52:682 - [6df9aeb9][RemoteDebugger] Sending to Web Inspector took 204ms
2025-10-03 07:56:52:682 - [6df9aeb9][RemoteDebugger] Received result for atom 'execute_script' execution: true
2025-10-03 07:56:52:726 - [6df9aeb9][RemoteDebugger] Pages changed for PID:37059: [{"id":1,"title":"I am a page title","url":"http://127.0.0.1:4567/test/guinea-pig","isKey":true},{"id":3,"title":"I am another page title","url":"http://127.0.0.1:4567/test/guinea-pig2.html","isKey":true}] -> [{"id":1,"title":"I am a page title","url":"http://127.0.0.1:4567/test/guinea-pig","isKey":true}]
2025-10-03 07:56:52:727 - [6df9aeb9][XCUITestDriver@ba61] Remote debugger notified us of a new page listing: {"appIdKey":"37059","pageArray":[{"id":1,"title":"I am a page title","url":"http://127.0.0.1:4567/test/guinea-pig","isKey":true}]}
2025-10-03 07:56:52:727 - [6df9aeb9][XCUITestDriver@ba61] New page listing from remote debugger does not contain current window; assuming it is closed
2025-10-03 07:56:52:727 - [6df9aeb9][XCUITestDriver@ba61] Debugger already selected page '1', confirming that choice.
2025-10-03 07:56:52:727 - [6df9aeb9][RemoteDebugger] Selecting page '1' on app 'PID:37059' and forwarding socket setup
2025-10-03 07:56:52:728 - [6df9aeb9][RemoteDebugger] Sending '_rpc_forwardIndicateWebView:' message to app 'PID:37059', page '1', target 'page-15' (id: 70): 'indicateWebView'
2025-10-03 07:56:52:754 - [6df9aeb9][RemoteDebugger] Sending to Web Inspector took 26ms
2025-10-03 07:56:52:756 - [6df9aeb9][RemoteDebugger] Sending '_rpc_forwardIndicateWebView:' message to app 'PID:37059', page '1', target 'page-15' (id: 72): 'indicateWebView'
2025-10-03 07:56:52:763 - [6df9aeb9][XCUITestDriver@ba61] Responding to client with driver.closeWindow() result: true
2025-10-03 07:56:52:765 - [6df9aeb9][HTTP] <-- DELETE /session/6df9aeb9-8bc1-4c9e-b30d-7873316ecf63/window 200 294 ms - 14 
2025-10-03 07:56:52:765 - [6df9aeb9][RemoteDebugger] Sending to Web Inspector took 10ms
2025-10-03 07:56:52:765 - [6df9aeb9][RemoteDebugger] Sending '_rpc_forwardSocketSetup:' message to app 'PID:37059', page '1', target 'page-15' (id: 74): 'setSenderKey'
2025-10-03 07:56:52:766 - [6df9aeb9][RemoteDebugger] Sending to Web Inspector took 1ms
2025-10-03 07:56:52:766 - [6df9aeb9][RemoteDebugger] Waiting up to 719962ms for page '1' of app 'PID:37059' to be selected
2025-10-03 07:56:52:972 - [6df9aeb9][HTTP] --> POST /session/6df9aeb9-8bc1-4c9e-b30d-7873316ecf63/url {"url":"http://127.0.0.1:4567/test/guinea-pig"}
2025-10-03 07:56:52:973 - [6df9aeb9][XCUITestDriver@ba61] Calling AppiumDriver.setUrl() with args: ["http://127.0.0.1:4567/test/guinea-pig","6df9aeb9-8bc1-4c9e-b30d-7873316ecf63"]
2025-10-03 07:56:52:973 - [6df9aeb9][XCUITestDriver@ba61] Executing command 'setUrl'
2025-10-03 07:56:52:973 - [6df9aeb9][XCUITestDriver@ba61] Attempting to set url 'http://127.0.0.1:4567/test/guinea-pig'
2025-10-03 07:56:52:973 - [6df9aeb9][RemoteDebugger] Navigating to new URL: 'http://127.0.0.1:4567/test/guinea-pig'
2025-10-03 07:57:02:085 - [6df9aeb9][RemoteDebugger] Received page change notice for app 'PID:37059' but the listing has not changed. Ignoring.
2025-10-03 07:57:11:019 - [6df9aeb9][RemoteDebugger] Web Inspector garbage collected
2025-10-03 07:57:11:025 - [6df9aeb9][RemoteDebugger] Web Inspector garbage collected
2025-10-03 08:00:53:088 - [HTTP] <-- POST /session/6df9aeb9-8bc1-4c9e-b30d-7873316ecf63/url - - ms - - 
```