### PR TITLE
feat: add ignoredBundleIds option to skip system processes in webview detection

### DIFF
--- a/lib/mixins/connect.ts
+++ b/lib/mixins/connect.ts
@@ -402,11 +402,6 @@ function searchForPage(
 }
 
 /**
- * Logs the current application dictionary to the debug log.
- * Displays all applications, their properties, and their associated pages
- * in a formatted structure.
- */
-/**
  * Checks whether all apps in the app dictionary have bundle IDs that are in the
  * configured ignore list and logs the result accordingly.
  *
@@ -424,6 +419,9 @@ function isAppIgnored(instance: RemoteDebugger): boolean {
   }
   const ignoredSet = new Set(ignoredBundleIds);
   const appBundleIds = new Set(_.values(getAppDict(instance)).map((app) => app.bundleId));
+  if (appBundleIds.size === 0) {
+    return false;
+  }
   const nonIgnoredBundleIds = [...appBundleIds].filter((id) => !ignoredSet.has(id));
   const actuallyIgnoredIds = [...appBundleIds].filter((id) => ignoredSet.has(id));
   if (nonIgnoredBundleIds.length === 0) {
@@ -433,13 +431,20 @@ function isAppIgnored(instance: RemoteDebugger): boolean {
     );
     return true;
   }
-  instance.log.debug(
-    `Ignoring apps with bundle IDs: ${actuallyIgnoredIds.join(', ')}. ` +
-      `${util.pluralize('app', nonIgnoredBundleIds.length, true)} remain for webview search.`,
-  );
+  if (actuallyIgnoredIds.length > 0) {
+    instance.log.debug(
+      `Ignoring apps with bundle IDs: ${actuallyIgnoredIds.join(', ')}. ` +
+        `${util.pluralize('app', nonIgnoredBundleIds.length, true)} remain for webview search.`,
+    );
+  }
   return false;
 }
 
+/**
+ * Logs the current application dictionary to the debug log.
+ * Displays all applications, their properties, and their associated pages
+ * in a formatted structure.
+ */
 function logApplicationDictionary(this: RemoteDebugger): void {
   this.log.debug('Current applications available:');
   for (const [app, info] of _.toPairs(getAppDict(this))) {

--- a/lib/mixins/property-accessors.ts
+++ b/lib/mixins/property-accessors.ts
@@ -48,10 +48,10 @@ export function getAdditionalBundleIds(
   return instance['_additionalBundleIds'];
 }
 
-export function getIgnoreBundleIds(
+export function getIgnoredBundleIds(
   instance: RemoteDebugger,
-): (typeof instance)['_ignoreBundleIds'] {
-  return instance['_ignoreBundleIds'];
+): (typeof instance)['_ignoredBundleIds'] {
+  return instance['_ignoredBundleIds'];
 }
 
 export function getSkippedApps(instance: RemoteDebugger): (typeof instance)['_skippedApps'] {

--- a/lib/mixins/property-accessors.ts
+++ b/lib/mixins/property-accessors.ts
@@ -48,6 +48,12 @@ export function getAdditionalBundleIds(
   return instance['_additionalBundleIds'];
 }
 
+export function getIgnoreBundleIds(
+  instance: RemoteDebugger,
+): (typeof instance)['_ignoreBundleIds'] {
+  return instance['_ignoreBundleIds'];
+}
+
 export function getSkippedApps(instance: RemoteDebugger): (typeof instance)['_skippedApps'] {
   return instance['_skippedApps'];
 }

--- a/lib/remote-debugger.ts
+++ b/lib/remote-debugger.ts
@@ -38,7 +38,7 @@ export class RemoteDebugger extends EventEmitter {
   protected readonly _log: AppiumLogger;
   protected readonly _bundleId?: string;
   protected readonly _additionalBundleIds?: string[];
-  protected readonly _ignoreBundleIds?: string[];
+  protected readonly _ignoredBundleIds?: string[];
   protected readonly _platformVersion?: string;
   protected readonly _isSafari: boolean;
   protected readonly _includeSafari: boolean;
@@ -131,7 +131,7 @@ export class RemoteDebugger extends EventEmitter {
 
     this._bundleId = bundleId;
     this._additionalBundleIds = additionalBundleIds;
-    this._ignoreBundleIds = ignoreBundleIds;
+    this._ignoredBundleIds = ignoreBundleIds;
     this._platformVersion = platformVersion;
     this._isSafari = isSafari;
     this._includeSafari = includeSafari;

--- a/lib/remote-debugger.ts
+++ b/lib/remote-debugger.ts
@@ -38,6 +38,7 @@ export class RemoteDebugger extends EventEmitter {
   protected readonly _log: AppiumLogger;
   protected readonly _bundleId?: string;
   protected readonly _additionalBundleIds?: string[];
+  protected readonly _ignoreBundleIds?: string[];
   protected readonly _platformVersion?: string;
   protected readonly _isSafari: boolean;
   protected readonly _includeSafari: boolean;
@@ -108,6 +109,7 @@ export class RemoteDebugger extends EventEmitter {
     const {
       bundleId,
       additionalBundleIds = [],
+      ignoreBundleIds = [],
       platformVersion,
       isSafari = true,
       includeSafari = false,
@@ -129,6 +131,7 @@ export class RemoteDebugger extends EventEmitter {
 
     this._bundleId = bundleId;
     this._additionalBundleIds = additionalBundleIds;
+    this._ignoreBundleIds = ignoreBundleIds;
     this._platformVersion = platformVersion;
     this._isSafari = isSafari;
     this._includeSafari = includeSafari;

--- a/lib/remote-debugger.ts
+++ b/lib/remote-debugger.ts
@@ -109,7 +109,7 @@ export class RemoteDebugger extends EventEmitter {
     const {
       bundleId,
       additionalBundleIds = [],
-      ignoreBundleIds = [],
+      ignoredBundleIds = [],
       platformVersion,
       isSafari = true,
       includeSafari = false,
@@ -131,7 +131,7 @@ export class RemoteDebugger extends EventEmitter {
 
     this._bundleId = bundleId;
     this._additionalBundleIds = additionalBundleIds;
-    this._ignoredBundleIds = ignoreBundleIds;
+    this._ignoredBundleIds = ignoredBundleIds;
     this._platformVersion = platformVersion;
     this._isSafari = isSafari;
     this._includeSafari = includeSafari;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -38,6 +38,8 @@ export interface RemoteDebuggerOptions {
   bundleId?: string;
   /** array of possible bundle ids that the inspector could return */
   additionalBundleIds?: string[];
+  /** array of bundle ids to exclude from webview context detection */
+  ignoreBundleIds?: string[];
   /** version of iOS */
   platformVersion?: string;
   isSafari?: boolean;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -39,7 +39,7 @@ export interface RemoteDebuggerOptions {
   /** array of possible bundle ids that the inspector could return */
   additionalBundleIds?: string[];
   /** array of bundle ids to exclude from webview context detection */
-  ignoreBundleIds?: string[];
+  ignoredBundleIds?: string[];
   /** version of iOS */
   platformVersion?: string;
   isSafari?: boolean;

--- a/test/unit/mixins/connect-specs.ts
+++ b/test/unit/mixins/connect-specs.ts
@@ -135,7 +135,7 @@ describe('connect', function () {
     describe('ignoreBundleIds', function () {
       it('should return [] immediately when all apps match the ignore list', async function () {
         (rd as any)._appDict = {'PID:88535': systemProcessApp};
-        (rd as any)._ignoreBundleIds = ['com.apple.amsengagementd'];
+        (rd as any)._ignoredBundleIds = ['com.apple.amsengagementd'];
 
         const result = await rd.selectApp();
         expect(result).to.eql([]);
@@ -146,7 +146,7 @@ describe('connect', function () {
           'PID:88535': systemProcessApp,
           'PID:88536': {...systemProcessApp, id: 'PID:88536', bundleId: 'com.apple.otherprocess'},
         };
-        (rd as any)._ignoreBundleIds = ['com.apple.amsengagementd', 'com.apple.otherprocess'];
+        (rd as any)._ignoredBundleIds = ['com.apple.amsengagementd', 'com.apple.otherprocess'];
 
         const result = await rd.selectApp();
         expect(result).to.eql([]);
@@ -157,7 +157,7 @@ describe('connect', function () {
           'PID:88535': systemProcessApp,
           'PID:99999': realWebviewApp,
         };
-        (rd as any)._ignoreBundleIds = ['com.apple.amsengagementd'];
+        (rd as any)._ignoredBundleIds = ['com.apple.amsengagementd'];
 
         // No RPC client wired up — selectApp should NOT return [] (ignore guard bypassed)
         // and should throw the retry-exhaustion error from searchForApp.
@@ -172,7 +172,7 @@ describe('connect', function () {
 
       it('should proceed normally when ignoreBundleIds is empty', async function () {
         (rd as any)._appDict = {'PID:88535': systemProcessApp};
-        (rd as any)._ignoreBundleIds = [];
+        (rd as any)._ignoredBundleIds = [];
 
         // Empty ignore list → falls through to searchForApp and exhausts retries.
         // maxTries=1 to avoid 20x500ms retry delay.

--- a/test/unit/mixins/connect-specs.ts
+++ b/test/unit/mixins/connect-specs.ts
@@ -113,4 +113,76 @@ describe('connect', function () {
       expect(getPossibleDebuggerAppKeys.bind(rd)(['*'])).to.eql(['42', '43']);
     });
   });
+
+  describe('selectApp', function () {
+    const systemProcessApp: AppInfo = {
+      id: 'PID:88535',
+      bundleId: 'com.apple.amsengagementd',
+      isProxy: false,
+      name: 'amsengagementd',
+      isActive: false,
+      isAutomationEnabled: 'Unknown',
+    };
+    const realWebviewApp: AppInfo = {
+      id: 'PID:99999',
+      bundleId: 'com.example.myapp',
+      isProxy: false,
+      name: 'MyApp',
+      isActive: true,
+      isAutomationEnabled: true,
+    };
+
+    describe('ignoreBundleIds', function () {
+      it('should return [] immediately when all apps match the ignore list', async function () {
+        (rd as any)._appDict = {'PID:88535': systemProcessApp};
+        (rd as any)._ignoreBundleIds = ['com.apple.amsengagementd'];
+
+        const result = await rd.selectApp();
+        expect(result).to.eql([]);
+      });
+
+      it('should return [] when multiple system processes all match the ignore list', async function () {
+        (rd as any)._appDict = {
+          'PID:88535': systemProcessApp,
+          'PID:88536': {...systemProcessApp, id: 'PID:88536', bundleId: 'com.apple.otherprocess'},
+        };
+        (rd as any)._ignoreBundleIds = ['com.apple.amsengagementd', 'com.apple.otherprocess'];
+
+        const result = await rd.selectApp();
+        expect(result).to.eql([]);
+      });
+
+      it('should proceed past the ignore check when a non-ignored app exists', async function () {
+        (rd as any)._appDict = {
+          'PID:88535': systemProcessApp,
+          'PID:99999': realWebviewApp,
+        };
+        (rd as any)._ignoreBundleIds = ['com.apple.amsengagementd'];
+
+        // No RPC client wired up — selectApp should NOT return [] (ignore guard bypassed)
+        // and should throw the retry-exhaustion error from searchForApp.
+        // maxTries=1 to avoid 20x500ms retry delay.
+        try {
+          await rd.selectApp(null, 1);
+          expect.fail('Expected an error to be thrown');
+        } catch (err: any) {
+          expect(err.message).to.match(/Could not connect to a valid webapp/);
+        }
+      });
+
+      it('should proceed normally when ignoreBundleIds is empty', async function () {
+        (rd as any)._appDict = {'PID:88535': systemProcessApp};
+        (rd as any)._ignoreBundleIds = [];
+
+        // Empty ignore list → falls through to searchForApp and exhausts retries.
+        // maxTries=1 to avoid 20x500ms retry delay.
+        try {
+          await rd.selectApp(null, 1);
+          expect.fail('Expected an error to be thrown');
+        } catch (err: any) {
+          expect(err.message).to.match(/Could not connect to a valid webapp/);
+        }
+      });
+    });
+  });
 });

--- a/test/unit/mixins/connect-specs.ts
+++ b/test/unit/mixins/connect-specs.ts
@@ -132,7 +132,7 @@ describe('connect', function () {
       isAutomationEnabled: true,
     };
 
-    describe('ignoreBundleIds', function () {
+    describe('ignoredBundleIds', function () {
       it('should return [] immediately when all apps match the ignore list', async function () {
         (rd as any)._appDict = {'PID:88535': systemProcessApp};
         (rd as any)._ignoredBundleIds = ['com.apple.amsengagementd'];
@@ -170,7 +170,7 @@ describe('connect', function () {
         }
       });
 
-      it('should proceed normally when ignoreBundleIds is empty', async function () {
+      it('should proceed normally when ignoredBundleIds is empty', async function () {
         (rd as any)._appDict = {'PID:88535': systemProcessApp};
         (rd as any)._ignoredBundleIds = [];
 


### PR DESCRIPTION
## Problem

When `getContexts()` is called on a session where no webview is loaded, the Web Inspector sometimes reports iOS system processes (e.g. `com.apple.amsengagementd`) in the app dictionary. These are not real webviews, but because `appDict` is non-empty, the `selectApp()` early-exit guard is bypassed and the full retry loop runs — **20 retries × 500ms = ~10s** — before returning an empty result.

## Solution

Add a new `ignoreBundleIds` option to `RemoteDebuggerOptions`. When provided, `selectApp()` checks whether all apps in the `appDict` have bundle IDs in the ignore list before entering the retry loop:

- **All apps ignored** → logs and returns `[]` immediately (zero retries, zero delay).
- **Some apps ignored, others remain** → logs the skipped ones and proceeds into `searchForApp` normally, so real webviews are still discovered.

The `appDict` is never mutated — the check is purely a pre-flight guard.

## Changes

- **`lib/types.ts`** — Add `ignoreBundleIds?: string[]` to `RemoteDebuggerOptions`.
- **`lib/remote-debugger.ts`** — Add `_ignoreBundleIds` field; wire through constructor.
- **`lib/mixins/property-accessors.ts`** — Add `getIgnoreBundleIds` accessor.
- **`lib/mixins/connect.ts`** — Add early-exit guard in `selectApp()`; import accessor.

## Related

This option is surfaced to users via `appium:ignoreWebviewBundleIds` capability in [appium-xcuitest-driver](https://github.com/appium/appium-xcuitest-driver/pull/2734) (separate PR).
