### PR TITLE
feat: Use cancellable delay built using native promises

### DIFF
--- a/lib/mixins/navigate.ts
+++ b/lib/mixins/navigate.ts
@@ -1,6 +1,6 @@
-import {checkParams, delay, TimeoutError, withTimeout} from '../utils';
+import {cancellableDelay, checkParams, delay, TimeoutError, withTimeout} from '../utils';
 import {events} from './events';
-import {timing, util} from '@appium/support';
+import {timing} from '@appium/support';
 import {
   getAppIdKey,
   setPageLoading,
@@ -86,7 +86,7 @@ export async function waitForDom(
 
   let isPageLoading = true;
   setPageLoading(this, true);
-  setPageLoadDelay(this, util.cancellableDelay(readinessTimeoutMs));
+  setPageLoadDelay(this, cancellableDelay(readinessTimeoutMs));
   const pageReadinessPromise = (async () => {
     let retry = 0;
     while (isPageLoading) {
@@ -199,7 +199,7 @@ export async function navToUrl(this: RemoteDebugger, url: string): Promise<void>
   const readinessTimeoutMs = this.pageLoadMs;
   let onPageLoaded: (() => void) | undefined;
   let onPageLoadedTimeout: NodeJS.Timeout | undefined | null;
-  setPageLoadDelay(this, util.cancellableDelay(readinessTimeoutMs));
+  setPageLoadDelay(this, cancellableDelay(readinessTimeoutMs));
   setPageLoading(this, true);
   let isPageLoading = true;
   const start = new timing.Timer().start();

--- a/lib/remote-debugger.ts
+++ b/lib/remote-debugger.ts
@@ -10,7 +10,7 @@ import * as cookieMixins from './mixins/cookies';
 import * as screenshotMixins from './mixins/screenshot';
 import * as eventMixins from './mixins/events';
 import * as miscellaneousMixins from './mixins/misc';
-import {util} from '@appium/support';
+import type {CancellableDelay} from './utils';
 import type {RemoteDebuggerOptions, AppDict, EventListener, PageIdKey, AppIdKey} from './types';
 import type {AppiumLogger, StringRecord} from '@appium/types';
 import type {RpcClient} from './rpc/rpc-client';
@@ -73,7 +73,7 @@ export class RemoteDebugger extends EventEmitter {
   protected _pageIdKey?: PageIdKey;
   protected _connectedDrivers?: StringRecord[];
   protected _currentState?: string;
-  protected _pageLoadDelay?: ReturnType<typeof util.cancellableDelay>;
+  protected _pageLoadDelay?: CancellableDelay;
   protected _rpcClient: RpcClient | null;
   protected _pageLoading: boolean;
   protected _navigatingToPage: boolean;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -17,6 +17,20 @@ const ACCEPTED_PAGE_TYPES = [
 ];
 export const RESPONSE_LOG_LENGTH = 100;
 
+export type CancellableDelay = Promise<void> & {
+  cancel: () => void;
+};
+
+/**
+ * Thrown when a cancellable delay is cancelled.
+ */
+export class DelayCancellation extends Error {
+  constructor(message: string = 'Delay cancelled') {
+    super(message);
+    this.name = 'DelayCancellation';
+  }
+}
+
 /**
  * Error thrown when an async operation exceeds the configured timeout.
  */
@@ -127,6 +141,33 @@ export function deepEqual(a: unknown, b: unknown): boolean {
  */
 export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Returns a delay promise with a `cancel` method that rejects the promise.
+ *
+ * @param ms - Delay in milliseconds.
+ * @returns A cancellable delay promise.
+ */
+export function cancellableDelay(ms: number): CancellableDelay {
+  let timeoutId: NodeJS.Timeout | undefined;
+  let rejectFn: ((error: Error) => void) | undefined;
+
+  const promise = new Promise<void>((resolve, reject) => {
+    rejectFn = reject;
+    timeoutId = setTimeout(resolve, ms);
+  }) as CancellableDelay;
+
+  promise.cancel = () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = undefined;
+    }
+    rejectFn?.(new DelayCancellation());
+    rejectFn = undefined;
+  };
+
+  return promise;
 }
 
 /**

--- a/test/unit/utils-specs.ts
+++ b/test/unit/utils-specs.ts
@@ -1,4 +1,6 @@
 import {
+  cancellableDelay,
+  DelayCancellation,
   pageArrayFromDict,
   checkParams,
   appInfoFromDict,
@@ -191,6 +193,25 @@ describe('utils', function () {
       expect(resolved).to.equal(false);
       await promise;
       expect(resolved).to.equal(true);
+    });
+  });
+
+  describe('cancellableDelay', function () {
+    it('resolves after the delay interval', async function () {
+      await cancellableDelay(0);
+    });
+
+    it('rejects when cancelled', async function () {
+      const delayed = cancellableDelay(50);
+      delayed.cancel();
+
+      try {
+        await delayed;
+        throw new Error('Expected cancellation rejection');
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(DelayCancellation);
+        expect(err.message).to.equal('Delay cancelled');
+      }
     });
   });
 


### PR DESCRIPTION
This will allow to ditch this utility completely from the support package as it's not used anywhere else