### PR TITLE
chore(remote-debugger): fix compatability with iOS 26

### DIFF
--- a/lib/rpc/remote-messages.ts
+++ b/lib/rpc/remote-messages.ts
@@ -97,8 +97,8 @@ export class RemoteMessages {
         WIRApplicationIdentifierKey: appIdKey,
         WIRConnectionIdentifierKey: connId,
         WIRSenderKey: senderId,
-        WIRPageIdentifierKey: pageIdKey,
-        WIRAutomaticallyPause: false,
+        WIRPageIdentifierKey: pageIdKey != null ? Number(pageIdKey) : pageIdKey,
+        WIRMessageDataTypeChunkSupportedKey: 0,
       },
       __selector: '_rpc_forwardSocketSetup:',
     };
@@ -124,7 +124,7 @@ export class RemoteMessages {
         WIRApplicationIdentifierKey: appIdKey,
         WIRIndicateEnabledKey: enabled == null ? true : enabled,
         WIRConnectionIdentifierKey: connId,
-        WIRPageIdentifierKey: pageIdKey,
+        WIRPageIdentifierKey: pageIdKey != null ? Number(pageIdKey) : pageIdKey,
       },
       __selector: '_rpc_forwardIndicateWebView:',
     };
@@ -192,7 +192,7 @@ export class RemoteMessages {
         WIRConnectionIdentifierKey: connId,
         WIRSenderKey: senderId,
         WIRApplicationIdentifierKey: appIdKey,
-        WIRPageIdentifierKey: pageIdKey,
+        WIRPageIdentifierKey: pageIdKey != null ? Number(pageIdKey) : pageIdKey,
       },
       __selector: '_rpc_forwardSocketData:',
     };
@@ -228,7 +228,7 @@ export class RemoteMessages {
         WIRConnectionIdentifierKey: connId,
         WIRSenderKey: senderId,
         WIRApplicationIdentifierKey: appIdKey,
-        WIRPageIdentifierKey: pageIdKey,
+        WIRPageIdentifierKey: pageIdKey != null ? Number(pageIdKey) : pageIdKey,
       },
       __selector: '_rpc_forwardSocketData:',
     };
@@ -255,7 +255,7 @@ export class RemoteMessages {
         WIRConnectionIdentifierKey: connId,
         WIRSenderKey: senderId,
         WIRApplicationIdentifierKey: appIdKey,
-        WIRPageIdentifierKey: pageIdKey,
+        WIRPageIdentifierKey: pageIdKey != null ? Number(pageIdKey) : pageIdKey,
       },
       __selector: '_rpc_forwardSocketData:',
     };

--- a/lib/rpc/remote-messages.ts
+++ b/lib/rpc/remote-messages.ts
@@ -20,6 +20,13 @@ function omitNilValues<T extends Record<string, any>>(obj: T): Partial<T> {
   ) as Partial<T>;
 }
 
+function toPageIdKey(pageIdKey?: PageIdKey): {WIRPageIdentifierKey: number} | Record<never, never> {
+  if (pageIdKey == null || pageIdKey === '' || Number.isNaN(+pageIdKey)) {
+    return {};
+  }
+  return {WIRPageIdentifierKey: +pageIdKey};
+}
+
 // mapping of commands to the function for getting the command
 // defaults to `getMinimalCommand`, so no need to have those listed here
 const COMMANDS = {
@@ -97,7 +104,7 @@ export class RemoteMessages {
         WIRApplicationIdentifierKey: appIdKey,
         WIRConnectionIdentifierKey: connId,
         WIRSenderKey: senderId,
-        WIRPageIdentifierKey: pageIdKey != null ? Number(pageIdKey) : pageIdKey,
+        ...toPageIdKey(pageIdKey),
         WIRMessageDataTypeChunkSupportedKey: 0,
       },
       __selector: '_rpc_forwardSocketSetup:',
@@ -124,7 +131,7 @@ export class RemoteMessages {
         WIRApplicationIdentifierKey: appIdKey,
         WIRIndicateEnabledKey: enabled == null ? true : enabled,
         WIRConnectionIdentifierKey: connId,
-        WIRPageIdentifierKey: pageIdKey != null ? Number(pageIdKey) : pageIdKey,
+        ...toPageIdKey(pageIdKey),
       },
       __selector: '_rpc_forwardIndicateWebView:',
     };
@@ -192,7 +199,7 @@ export class RemoteMessages {
         WIRConnectionIdentifierKey: connId,
         WIRSenderKey: senderId,
         WIRApplicationIdentifierKey: appIdKey,
-        WIRPageIdentifierKey: pageIdKey != null ? Number(pageIdKey) : pageIdKey,
+        ...toPageIdKey(pageIdKey),
       },
       __selector: '_rpc_forwardSocketData:',
     };
@@ -228,7 +235,7 @@ export class RemoteMessages {
         WIRConnectionIdentifierKey: connId,
         WIRSenderKey: senderId,
         WIRApplicationIdentifierKey: appIdKey,
-        WIRPageIdentifierKey: pageIdKey != null ? Number(pageIdKey) : pageIdKey,
+        ...toPageIdKey(pageIdKey),
       },
       __selector: '_rpc_forwardSocketData:',
     };
@@ -255,7 +262,7 @@ export class RemoteMessages {
         WIRConnectionIdentifierKey: connId,
         WIRSenderKey: senderId,
         WIRApplicationIdentifierKey: appIdKey,
-        WIRPageIdentifierKey: pageIdKey != null ? Number(pageIdKey) : pageIdKey,
+        ...toPageIdKey(pageIdKey),
       },
       __selector: '_rpc_forwardSocketData:',
     };

--- a/lib/rpc/rpc-client.ts
+++ b/lib/rpc/rpc-client.ts
@@ -647,11 +647,15 @@ export class RpcClient {
     this.targets[appIdKey][pageIdKey] = targetInfo.targetId;
 
     try {
-      await this.send('Target.setPauseOnStart', {
-        pauseOnStart: true,
-        appIdKey,
-        pageIdKey,
-      });
+      await this.send(
+        'Target.setPauseOnStart',
+        {
+          pauseOnStart: true,
+          appIdKey,
+          pageIdKey,
+        },
+        false,
+      );
     } catch (e: any) {
       log.debug(
         `Cannot setup pause on start for app '${appIdKey}' and page '${pageIdKey}': ${e.message}`,

--- a/test/functional/real-device-safari-specs.ts
+++ b/test/functional/real-device-safari-specs.ts
@@ -1,0 +1,41 @@
+import {createRemoteDebugger} from '../../lib';
+import {expect} from 'chai';
+
+const UDID = process.env.DEVICE_UDID ?? '';
+const PLATFORM_VERSION = process.env.PLATFORM_VERSION ?? '26';
+
+describe('Real device Safari remote debugger', function () {
+  this.timeout('2m');
+
+  it('should connect to Safari and execute JavaScript', async function () {
+    const rd = createRemoteDebugger(
+      {
+        udid: UDID,
+        bundleId: 'com.apple.mobilesafari',
+        platformVersion: PLATFORM_VERSION,
+        isSafari: true,
+        includeSafari: false,
+        logAllCommunication: false,
+        logFullResponse: false,
+        targetCreationTimeoutMs: 5000,
+      },
+      true,
+    );
+
+    try {
+      await rd.connect(15000);
+
+      const pages = await rd.selectApp(null, undefined, true);
+      expect(pages).to.have.length.above(0, 'No Safari pages found');
+
+      const page = pages[0];
+      const [appIdKey, pageIdKey] = String(page.id).split('.');
+      await rd.selectPage(appIdKey, pageIdKey, true);
+
+      const title = await rd.execute('document.title');
+      expect(title).to.be.a('string').and.not.be.empty;
+    } finally {
+      await rd.disconnect();
+    }
+  });
+});

--- a/test/integrated/real-device-safari-specs.ts
+++ b/test/integrated/real-device-safari-specs.ts
@@ -7,6 +7,12 @@ const PLATFORM_VERSION = process.env.PLATFORM_VERSION ?? '26';
 describe('Real device Safari remote debugger', function () {
   this.timeout('2m');
 
+  before(function () {
+    if (!process.env.DEVICE_UDID) {
+      this.skip();
+    }
+  });
+
   it('should connect to Safari and execute JavaScript', async function () {
     const rd = createRemoteDebugger(
       {


### PR DESCRIPTION
Fixes https://github.com/appium/appium-remote-debugger/issues/497

iOS 26 introduced changes which caused the remote debugger to hang on forever.

The fix was to enforce integer conversions for `WIRPageIdentifierKey` and prevent the infinite hang by passing false to `Target.setPauseOnStart` as the behavior is changed for iOS 26.

I also added a test from the issue so that it can tested.
