### PR TITLE
feat: export atom names and make execute/executeAtom results generic

### DIFF
--- a/lib/atoms.ts
+++ b/lib/atoms.ts
@@ -8,6 +8,61 @@ import {getModuleRoot} from './utils/index.js';
 const ATOMS_CACHE: Record<string, Buffer> = {};
 
 /**
+ * Names of the Selenium-style atoms bundled under `atoms/` and loadable via `getAtom`/
+ * `executeAtom`/`executeAtomAsync`. Keep in sync with the `ATOMS` array in
+ * `scripts/build-atoms.mjs` (see `docs/update-atoms.md`) — `test/unit/atoms-loader.spec.ts`
+ * guards against drift by comparing this list against the committed `atoms/*.js` files.
+ */
+export const ATOM_NAMES = [
+  'active_element',
+  'clear_local_storage',
+  'clear_session_storage',
+  'clear',
+  'click',
+  'default_content',
+  'execute_async_script',
+  'execute_script',
+  'find_element_fragment',
+  'find_element',
+  'find_elements',
+  'frame_by_id_or_name',
+  'frame_by_index',
+  'get_attribute_value',
+  'get_attribute',
+  'get_effective_style',
+  'get_element_from_cache',
+  'get_frame_window',
+  'get_local_storage_item',
+  'get_local_storage_key',
+  'get_local_storage_keys',
+  'get_local_storage_size',
+  'get_location',
+  'get_session_storage_item',
+  'get_session_storage_key',
+  'get_session_storage_keys',
+  'get_session_storage_size',
+  'get_size',
+  'get_text',
+  'get_top_left_coordinates',
+  'get_value_of_css_property',
+  'is_displayed',
+  'is_editable',
+  'is_enabled',
+  'is_focusable',
+  'is_interactable',
+  'is_selected',
+  'remove_local_storage_item',
+  'remove_session_storage_item',
+  'set_local_storage_item',
+  'set_session_storage_item',
+  'submit',
+  'type',
+] as const;
+
+/** Name of a Selenium-style atom bundled under `atoms/`. */
+export type AtomName = (typeof ATOM_NAMES)[number];
+
+/**
  * Loads an atom script from the atoms directory and caches it.
  * If the atom has been loaded before, returns the cached version.
  *

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,5 @@
+import {ATOM_NAMES} from './atoms.js';
+import type {AtomName} from './atoms.js';
 import {RemoteDebuggerRealDevice} from './remote-debugger-real-device.js';
 import {RemoteDebugger, REMOTE_DEBUGGER_PORT} from './remote-debugger.js';
 import type {RemoteDebuggerRealDeviceOptions, RemoteDebuggerOptions} from './types.js';
@@ -20,5 +22,5 @@ export function createRemoteDebugger(
     : new RemoteDebugger(opts as RemoteDebuggerOptions);
 }
 
-export {RemoteDebugger, RemoteDebuggerRealDevice, REMOTE_DEBUGGER_PORT};
-export type {RemoteDebuggerRealDeviceOptions, RemoteDebuggerOptions};
+export {RemoteDebugger, RemoteDebuggerRealDevice, REMOTE_DEBUGGER_PORT, ATOM_NAMES};
+export type {RemoteDebuggerRealDeviceOptions, RemoteDebuggerOptions, AtomName};

--- a/lib/mixins/execute.ts
+++ b/lib/mixins/execute.ts
@@ -3,6 +3,7 @@ import {util, timing} from '@appium/support';
 import {retryInterval} from 'asyncbox';
 
 import {getScriptForAtom} from '../atoms.js';
+import type {AtomName} from '../atoms.js';
 import type {RemoteDebugger} from '../remote-debugger.js';
 import type {AppIdKey, PageIdKey} from '../types.js';
 import {checkParams, simpleStringify, convertJavascriptEvaluationResult, RESPONSE_LOG_LENGTH} from '../utils/index.js';
@@ -20,15 +21,15 @@ const RPC_RESPONSE_TIMEOUT_MS = 5000;
  * @param frames - Frame context array for frame-specific execution. Defaults to empty array.
  * @returns A promise that resolves to the result received from the atom execution.
  */
-export async function executeAtom(
+export async function executeAtom<R = any>(
   this: RemoteDebugger,
-  atom: string,
+  atom: AtomName,
   args: any[] = [],
   frames: string[] = [],
-): Promise<any> {
+): Promise<R> {
   this.log.debug(`Executing atom '${atom}' with 'args=${JSON.stringify(args)}; frames=${frames}'`);
   const script = await getScriptForAtom(atom, args, frames);
-  const value = await this.execute(script);
+  const value = await this.execute<R>(script);
   this.log.debug(
     `Received result for atom '${atom}' execution: ${util.truncateString(simpleStringify(value), RESPONSE_LOG_LENGTH)}`,
   );
@@ -46,12 +47,12 @@ export async function executeAtom(
  * @param frames - Frame context array for frame-specific execution. Defaults to empty array.
  * @returns A promise that resolves to the result received from the atom execution.
  */
-export async function executeAtomAsync(
+export async function executeAtomAsync<R = any>(
   this: RemoteDebugger,
-  atom: string,
+  atom: AtomName,
   args: any[] = [],
   frames: string[] = [],
-): Promise<any> {
+): Promise<R> {
   // helper to send directly to the web inspector
   const evaluate = async (method: string, opts: any) =>
     await this.requireRpcClient(true).send(
@@ -141,7 +142,7 @@ export async function executeAtomAsync(
       );
     } catch {}
   }
-  return convertJavascriptEvaluationResult(res);
+  return convertJavascriptEvaluationResult(res) as R;
 }
 
 /**
@@ -153,12 +154,12 @@ export async function executeAtomAsync(
  * @returns A promise that resolves to the result of the JavaScript evaluation,
  *          converted to a usable format.
  */
-export async function execute(
+export async function execute<R = any>(
   this: RemoteDebugger,
   command: string,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- kept for API compatibility
   override?: boolean,
-): Promise<any> {
+): Promise<R> {
   const {appIdKey, pageIdKey} = checkParams({
     appIdKey: getAppIdKey(this),
     pageIdKey: getPageIdKey(this),
@@ -177,7 +178,7 @@ export async function execute(
     appIdKey,
     pageIdKey,
   });
-  return convertJavascriptEvaluationResult(res);
+  return convertJavascriptEvaluationResult(res) as R;
 }
 
 /**
@@ -190,7 +191,12 @@ export async function execute(
  * @returns A promise that resolves to the result of the function call,
  *          converted to a usable format.
  */
-export async function callFunction(this: RemoteDebugger, objectId: string, fn: string, args?: any[]): Promise<any> {
+export async function callFunction<R = any>(
+  this: RemoteDebugger,
+  objectId: string,
+  fn: string,
+  args?: any[],
+): Promise<R> {
   const {appIdKey, pageIdKey} = checkParams({
     appIdKey: getAppIdKey(this),
     pageIdKey: getPageIdKey(this),
@@ -210,5 +216,5 @@ export async function callFunction(this: RemoteDebugger, objectId: string, fn: s
     pageIdKey,
   });
 
-  return convertJavascriptEvaluationResult(res);
+  return convertJavascriptEvaluationResult(res) as R;
 }

--- a/lib/mixins/screenshot.ts
+++ b/lib/mixins/screenshot.ts
@@ -30,10 +30,10 @@ export async function captureScreenshot(this: RemoteDebugger, opts: ScreenshotCa
 
   const arect =
     rect ??
-    ((await this.executeAtom('execute_script', [
+    (await this.executeAtom<Rect>('execute_script', [
       'return {x: 0, y: 0, width: window.innerWidth, height: window.innerHeight}',
       [],
-    ])) as Rect);
+    ]));
   const response = await this.requireRpcClient().send('Page.snapshotRect', {
     ...arect,
     appIdKey: getAppIdKey(this),

--- a/test/unit/atoms-loader.spec.ts
+++ b/test/unit/atoms-loader.spec.ts
@@ -1,13 +1,26 @@
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import {describe, it} from 'node:test';
 
-import {getAtom, getScriptForAtom} from '../../lib/atoms.js';
+import {fs} from '@appium/support';
+
+import {ATOM_NAMES, getAtom, getScriptForAtom} from '../../lib/atoms.js';
+import {getModuleRoot} from '../../lib/utils/index.js';
 
 // Unlike test/unit/atoms.spec.ts (which evals the compiled atoms in jsdom to exercise the atoms'
 // own behavior), this file unit-tests lib/atoms.ts's own helpers directly: loading/caching a
 // compiled atom file and building the injectable script string around it. Both are plain Node
 // functions with no DOM dependency, so no jsdom is needed here.
 describe('lib/atoms', function () {
+  describe('ATOM_NAMES', function () {
+    it('matches the committed atoms/*.js files exactly, so it cannot silently drift', async function () {
+      const atomFiles = (await fs.readdir(path.resolve(getModuleRoot(), 'atoms')))
+        .filter((name) => name.endsWith('.js'))
+        .map((name) => name.slice(0, -'.js'.length));
+      assert.deepStrictEqual([...ATOM_NAMES].sort(), atomFiles.sort());
+    });
+  });
+
   describe('getAtom', function () {
     it('loads a real compiled atom as a non-empty Buffer', async function () {
       const atom = await getAtom('click');


### PR DESCRIPTION
Adds `ATOM_NAMES`/`AtomName` (exported from the package root) so consumers like xcuitest-driver get a typed list of available atoms instead of raw strings, and makes `execute`, `executeAtom`, `executeAtomAsync`, and `callFunction` generic over their return type so callers can type the result instead of casting `any`.