### PR TITLE
feat: export AutomationSession and its types from the package root

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,8 @@ import {ATOM_NAMES} from './atoms.js';
 import type {AtomName} from './atoms.js';
 import {RemoteDebuggerRealDevice} from './remote-debugger-real-device.js';
 import {RemoteDebugger, REMOTE_DEBUGGER_PORT} from './remote-debugger.js';
+import {AutomationSession} from './rpc/index.js';
+import type {AutomationElement, AutomationRect, LocatorStrategy} from './rpc/index.js';
 import type {RemoteDebuggerRealDeviceOptions, RemoteDebuggerOptions} from './types.js';
 
 export function createRemoteDebugger(opts: RemoteDebuggerRealDeviceOptions, realDevice: true): RemoteDebuggerRealDevice;
@@ -22,5 +24,12 @@ export function createRemoteDebugger(
     : new RemoteDebugger(opts as RemoteDebuggerOptions);
 }
 
-export {RemoteDebugger, RemoteDebuggerRealDevice, REMOTE_DEBUGGER_PORT, ATOM_NAMES};
-export type {RemoteDebuggerRealDeviceOptions, RemoteDebuggerOptions, AtomName};
+export {RemoteDebugger, RemoteDebuggerRealDevice, REMOTE_DEBUGGER_PORT, ATOM_NAMES, AutomationSession};
+export type {
+  RemoteDebuggerRealDeviceOptions,
+  RemoteDebuggerOptions,
+  AtomName,
+  AutomationElement,
+  AutomationRect,
+  LocatorStrategy,
+};

--- a/lib/rpc/index.ts
+++ b/lib/rpc/index.ts
@@ -2,3 +2,4 @@ export {RpcClientSimulator} from './rpc-client-simulator.js';
 export {RpcClientRealDevice} from './rpc-client-real-device.js';
 export {RpcClientRealDeviceShim} from './rpc-client-real-device-shim.js';
 export {AutomationSession} from './automation/index.js';
+export type {AutomationElement, AutomationRect, LocatorStrategy} from './automation/index.js';

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import {
+  ATOM_NAMES,
+  AutomationSession,
+  createRemoteDebugger,
+  REMOTE_DEBUGGER_PORT,
+  RemoteDebugger,
+  RemoteDebuggerRealDevice,
+} from '../../lib/index.js';
+
+describe('package public exports', function () {
+  it('exports the debugger classes/values used by consumers', function () {
+    assert.strictEqual(typeof createRemoteDebugger, 'function');
+    assert.strictEqual(RemoteDebugger.name, 'RemoteDebugger');
+    assert.strictEqual(RemoteDebuggerRealDevice.name, 'RemoteDebuggerRealDevice');
+    assert.strictEqual(typeof REMOTE_DEBUGGER_PORT, 'number');
+    assert.ok(Array.isArray(ATOM_NAMES));
+  });
+
+  it('exports AutomationSession so consumers can name its type without a deep import', function () {
+    assert.strictEqual(AutomationSession.name, 'AutomationSession');
+  });
+
+  it('creates a RemoteDebugger whose automationSession is an AutomationSession once started', async function () {
+    const rd = createRemoteDebugger({} as any, false);
+    (rd as any)._automationSession = new AutomationSession(
+      {send: async () => undefined} as any,
+      {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      } as any,
+    );
+    assert.ok(rd.automationSession instanceof AutomationSession);
+  });
+});


### PR DESCRIPTION
xcuitest-driver needs to name AutomationSession (returned by RemoteDebugger.automationSession) to integrate against it, but only the internal lib/rpc/automation/index.ts exported it - lib/index.ts had no path to it without a deep import.